### PR TITLE
Update installing.scrbl

### DIFF
--- a/docs/installing.scrbl
+++ b/docs/installing.scrbl
@@ -14,6 +14,13 @@ There are several options for installing Pyret.
 You need to have installed at least Racket 5.3.4 (the current version, 5.3.6,
 works great).  You can get Racket at @url{http://download.racket-lang.org/}.
 
+@section[#:tag "s:url"]{Via Racket Automatic Download}
+
+Open a new definition in Racket, and using File -> Install .plt File, select
+the URL tab. Copy and paste the URL below into the space, and click "Okay"
+
+@url{http://cs.brown.edu/~joe/public/pyret/pyret-current.plt}
+
 @section[#:tag "s:plt-file"]{Via a .plt File}
 
 Download this .plt file:


### PR DESCRIPTION
Added method for automatic pyret download/installation. On mac, there are two things that differ from the instructions 1. the file window is not available unless a definitions window is open 2. when the link is clicked on in either safari or chrome(mac), it opens as a document in the browser instead of downloading.  There is no simple method to then download in chrome, and you have to right click on the link after opening it once to download the file on safari. 3. when the file is downloaded, it begins as a .txt file and has to be renamed in order to use in DrRacket.  This method streamlines the installation process slightly
