### PR TITLE
changing desugaring of when so it always evaluates to nothing

### DIFF
--- a/src/lang/desugar.rkt
+++ b/src/lang/desugar.rkt
@@ -311,8 +311,11 @@
      (s-method s args ann doc (ds body) (ds check))]
 
     [(s-when s test body)
-     (s-if-else s (list (s-if-branch s (ds test) (ds body)))
-      (s-id s 'nothing))]
+     (s-if-else s
+                (list (s-if-branch s (ds test)
+                                   (s-block s (flatten-blocks
+                                               (list (ds body) (s-id s 'nothing))))))
+                (s-id s 'nothing))]
 
     [(s-if-else s cases else)
      (s-if-else s (map ds-if cases) (ds else))]

--- a/src/tests/compile-tests.rkt
+++ b/src/tests/compile-tests.rkt
@@ -128,8 +128,13 @@
   (check-pyret
     "b = brander()
      true-branded = b.brand(true)
+     if true-branded: 5 else: 6 end"
+    five)
+  (check-pyret
+    "b = brander()
+     true-branded = b.brand(true)
      when true-branded: 5 end"
-     five)
+    nothing)
 
   (check-pyret
     "b = brander()
@@ -172,11 +177,11 @@
 
   (check-pyret "
   when true: 5 end
-  " five)
+  " nothing)
 
   (check-pyret "
   when true: when true: 5 end end
-  " five)
+  " nothing)
 
   (check-pyret "
   when true: when false: 5 end end
@@ -343,9 +348,17 @@
    "data Foo:
      | single
     end
-    fun f(s :: is-single): when is-single(s): true end end
+    fun f(s :: is-single): if is-single(s): true else: false end end
     f(single)"
     (p:mk-bool #t))
+
+  (check-pyret
+   "data Foo:
+     | single
+    end
+    fun f(s :: is-single): when is-single(s): true end end
+    f(single)"
+    nothing)
 
   (check-pyret-exn
    "data Foo:


### PR DESCRIPTION
Closes #129 

Changes desugaring and fixes some tests that relied on the old behavior (when blocks would evaluate to their last expression if they ran, or nothing otherwise).
