### PR TITLE
Set improvements: move less-than check, symmetric difference, don't forc...

### DIFF
--- a/src/tests/compile-tests.rkt
+++ b/src/tests/compile-tests.rkt
@@ -689,7 +689,7 @@ Looks shipshape, all 2 tests passed, mate!
 
   (check-pyret-match/check "pyret/libs/math-libs.arr" _ 7)
 
-  (check-pyret-match/check "pyret/libs/sets.arr" _ 177)
+  (check-pyret-match/check "pyret/libs/sets.arr" _ 186)
   (check-pyret-match/check "pyret/libs/array.arr" _ 68)
 
   (check-pyret-match/check "pyret/libs/strings.arr" _ 35)

--- a/src/tests/pyret/libs/sets.arr
+++ b/src/tests/pyret/libs/sets.arr
@@ -7,7 +7,7 @@ fun check-random-adds(n :: Number, set-constructor) -> Bool:
   expect = for fold(s from [], elt from nums):
     if s.member(elt): s else: link(elt, s) end
   end.sort()
-  set-constructor(nums).to-list() == expect
+  set-constructor(nums).to-list().sort() == expect
 end
 
 fun check-random-removes(n :: Number, set-constructor) -> Bool:
@@ -20,7 +20,7 @@ fun check-random-removes(n :: Number, set-constructor) -> Bool:
   end
   for fold(s from set-constructor(orig), rem-elt from nums):
     s.remove(rem-elt)
-  end.to-list() == expect
+  end.to-list().sort() == expect
 end
 
 check:
@@ -38,13 +38,16 @@ check:
     s([1, 2, 3]).add(1.5) is s([1, 2, 3, 1.5])
     s([1, 2]).remove(18) is s([1, 2])
     s([1, 2]).remove(2) is s([1])
-    s([3, 1, 2]).to-list() is [1, 2, 3]
+    s([3, 1, 2]).to-list().sort() is [1, 2, 3]
     s([1, 2]).union(s([2, 3])) is s([1, 2, 3])
     s([1, 2]).union(s([4])) is s([1, 2, 4])
     s([1, 2]).intersect(s([2, 3])) is s([2])
     s([1, 2]).intersect(s([4])) is s([])
     s([1, 2]).difference(s([2, 3])) is s([1])
     s([1, 2]).difference(s([4])) is s([1, 2])
+    s([1, 2]).symmetric_difference(s([1, 2])) is s([])
+    s([1, 2]).symmetric_difference(s([2, 3])) is s([1, 3])
+    s([1, 2]).symmetric_difference(s([3, 4])) is s([1, 2, 3, 4])
     (s([1, 2.1, 3]) <> s([1, 2.2, 3])) is true
     s([1, 2, 4]) is s([2, 1, 4])
 


### PR DESCRIPTION
...e sorting on to-list to allow arbitrary order

Put in a pull request mostly for the latter "improvement". Returning a sorted list seems not to be the duty of the set implementation, so we should allow for arbitrarily-ordered lists. The user can sort the list themselves if they want it to be sorted. (I made the tree-set implementation return a preorder-traversal list instead of an inorder-traversal list so that people couldn't count on the list to be sorted, either, as discussed with @justinpombrio earlier).

This represents a pretty decent API change for a standard library, though, so it's not going straight to master.
