### PR TITLE
Add Pair to base, map methods to Pair and Either

### DIFF
--- a/src/arr/base/either.arr
+++ b/src/arr/base/either.arr
@@ -3,7 +3,23 @@
 provide *
 provide-types *
 
-data Either<a,b>:
-  | left(v :: a)
-  | right(v :: b)
+fun<I> identity(i :: I) -> I: i end
+
+data Either<L, R>:
+  | left(v :: L) with:
+    bi-map(self, f :: (L -> Any), _ :: (R -> Any)) -> Either<Any, Any>:
+      left(f(self.v))
+    end,
+  | right(v :: R) with:
+    bi-map(self, _ :: (L -> Any), g :: (R -> Any)) -> Either<Any, Any>:
+      right(g(self.v))
+    end,
+end
+
+fun<A, B, R> map-left(f :: (A -> B), e :: Either<A, R>) -> Either<B, R>:
+   e.bi-map(f, identity)
+end
+
+fun<A, B, L> map-right(f :: (A -> B), e :: Either<L, A>) -> Either<L, B>:
+   e.bi-map(identity, f)
 end

--- a/src/arr/base/pair.arr
+++ b/src/arr/base/pair.arr
@@ -1,0 +1,22 @@
+#lang pyret
+
+provide *
+provide-types *
+
+fun <I> identity(i :: I) -> I: i end
+
+data Pair<L,R>:
+  | pair(left :: L, right :: R)
+sharing:
+  bi-map(self, f :: (L -> Any), g :: (R -> Any)) -> Pair<Any, Any>:
+    pair(f(self.left), g(self.right))
+  end,
+end
+
+fun<A, B, R> map-left(f :: (A -> B), p :: Pair<A, R>) -> Pair<B, R>:
+   p.bi-map(f, identity)
+end
+
+fun<A, B, L> map-right(f :: (A -> B), p :: Pair<L, A>) -> Pair<L, B>:
+   p.bi-map(identity, f)
+end


### PR DESCRIPTION
A pair data type is defined in Desugar and Type-Checker, thus beginning to be factoring out somewhere.

Given the simplicity generality of Pair, it seemed potentially worthy to go in the std library, rounding out Either and Option.

I figure the most controversial part of this will be the identifier choices. `Pair` was the name chosen by whoever defined it in `desugar.arr`, and is more friendly than `Product` for students with less math background. I like `map-*` as the operation is clearly a mapping, and the use `map` in the name should set students on the right track in identifying list-map-like combinatorial and seeing the commonalities.

I don't like `bi-map` very much however. I might have picked `map2` but that would recall the `map2` in `List`, which get's the "2" in it's name for very different reasons. Misleading students into thinking that there was deeper connection between the two `map2`s would certainly be counterproductive.

Eventually it would be nice to define `map-*` to by polymorphic on all types with a proper `bi-map` method, but as I am not sure how the type system will eventually work with such definitions, and loath to make a 2nd new file, I figure such changes better wait for a bigger overhaul of the standard library.

If this is OK'd, I'll clean up the exports to not export identity (or move it it somewhere else), and add documentation, and rig up the build system to actually include this.
