### PR TITLE
Update cmdline to use string-dicts in tests, and make lib-test testing endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ install:
 
 
 .PHONY : test
-test: runtime-test evaluator-test compiler-test repl-test pyret-test regression-test type-check-test
+test: runtime-test evaluator-test compiler-test repl-test pyret-test regression-test type-check-test lib-test
 
 .PHONY : test-all
 test-all: test docs-test
@@ -343,6 +343,11 @@ compiler-test: $(PYRET_TEST_PREREQ)
 	$(NODE) $(PYRET_TEST_PHASE)/main-wrapper.js \
     --module-load-dir $(PYRET_TEST_PHASE)/arr/compiler/ \
     -check-all src/arr/compiler/compile.arr
+
+.PHONY : lib-test
+lib-test: $(PYRET_TEST_PREREQ)
+	$(NODE) $(PYRET_TEST_PHASE)/main-wrapper.js \
+    -check-all tests/lib-test/lib-test-main.arr
 
 .PHONY : bootstrap-test
 bootstrap-test: $(PHASE1)/phase1.built $(BS_TEST_JS)

--- a/src/arr/trove/cmdline.arr
+++ b/src/arr/trove/cmdline.arr
@@ -116,9 +116,9 @@ fun usage-info(options-raw) -> List<String>:
         | equals-val-default(parser, default, short-name, repeated, desc) =>
           cases(Option<String>) short-name:
             | none =>
-              format("  --~a[list: =~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
+              format("  --~a [~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
             | some(short) =>
-              format("  --~a[list: =~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
+              format("  --~a [~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
                 [list: key, parser.parse-string(), desc, repeated, default, short, desc, repeated])
           end
         | next-val(parser, repeated, desc) =>
@@ -126,9 +126,9 @@ fun usage-info(options-raw) -> List<String>:
         | next-val-default(parser, default, short-name, repeated, desc) =>
           cases(Option<String>) short-name:
             | none =>
-              format("  --~a [list: ~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
+              format("  --~a [~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
             | some(short) =>
-              format("  --~a [list: ~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
+              format("  --~a [~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
                 [list: key, parser.parse-string(), desc, repeated, default, short, desc, repeated])
           end
       end

--- a/src/arr/trove/cmdline.arr
+++ b/src/arr/trove/cmdline.arr
@@ -458,7 +458,7 @@ check:
     "bar", next-val-default(read-number, 42, some("b"), many, "Bar"),
     "4", flag(many, "Flag-4")
   ]
-  parse-args(many-optional-flag, [list: "-foo", "-foo", "-foo"]) is success(dict([list: "foo", [list: true, true, true]]), [list: ])
+  parse-args(many-optional-flag, [list: "-foo", "-foo", "-foo"]) is success(dict([list: "foo", [list: true, true, true], "bar", 42]), [list: ])
   parse-args(many-optional-flag, [list: "-b", "-foo", "--bar", "3", "--bar", "-foo"])
     is success(dict([list: "foo", [list: true, true], "bar", [list: 42, 3, 42]]), [list: ])
   # NOTE(joe): More disagreement based on the STOP comment, changed to is-not

--- a/src/arr/trove/cmdline.arr
+++ b/src/arr/trove/cmdline.arr
@@ -116,9 +116,9 @@ fun usage-info(options-raw) -> List<String>:
         | equals-val-default(parser, default, short-name, repeated, desc) =>
           cases(Option<String>) short-name:
             | none =>
-              format("  --~a [~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
+              format("  --~a[=~a]: ~a (~a, default: ~a)", [list: key, parser.parse-string(), desc, repeated, default])
             | some(short) =>
-              format("  --~a [~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
+              format("  --~a[=~a]: ~a (~a, default: ~a)\n  -~a: Defaults for ~a (~a)",
                 [list: key, parser.parse-string(), desc, repeated, default, short, desc, repeated])
           end
         | next-val(parser, repeated, desc) =>

--- a/src/arr/trove/cmdline.arr
+++ b/src/arr/trove/cmdline.arr
@@ -35,6 +35,7 @@ import format as F
 import string-dict as D
 import either as E
 format = F.format
+string-dict = D.string-dict
 type Either = E.Either
 left = E.left
 right = E.right
@@ -196,7 +197,7 @@ fun parse-args(options, args :: List<String>) -> ParsedArguments:
               end
             | required-many =>
               if results.parsed.has-key(name):
-                success(parsed.set(name, results.parsed.get(name) + [list: val]), unknown)
+                success(parsed.set(name, results.parsed.get-value(name) + [list: val]), unknown)
               else:
                 success(parsed.set(name, [list: val]), unknown)
               end
@@ -204,7 +205,7 @@ fun parse-args(options, args :: List<String>) -> ParsedArguments:
         | else => results
       end
     end
-    required = for lists.filter(key from opts-dict.keys().to-list()):
+    required = for lists.filter(key from opts-dict.keys-list()):
       repeated = opts-dict.get-value(key).repeated
       (repeated == required-once) or (repeated == required-many)
     end
@@ -214,7 +215,9 @@ fun parse-args(options, args :: List<String>) -> ParsedArguments:
         cases(List<String>) remaining:
           | empty => results
           | link(first, more-args) =>
-            if string-substring(first, 0, 2) == "--":
+            if string-length(first) < 2:
+              success(results.parsed, results.unknown + remaining) # STOP PROCESSING after first non-option value
+            else if string-substring(first, 0, 2) == "--":
               key-parts = string-split(string-substring(first, 2, string-length(first)), "=")
               key = key-parts.first
               if full-options.has-key(key):
@@ -340,7 +343,7 @@ fun parse-args(options, args :: List<String>) -> ParsedArguments:
     parsed-results = process(success(D.make-string-dict(), [list: ]), 1, args)
     cases(ParsedArguments) parsed-results:
       | success(parsed, other) =>
-        filled-missing-defaults = for lists.fold(acc from parsed, key from opts-dict.keys().to-list()):
+        filled-missing-defaults = for lists.fold(acc from parsed, key from opts-dict.keys-list()):
           cases(Param) opts-dict.get-value(key):
             | next-val-default(_, default, _, repeated, _) =>
               if not(acc.has-key(key)) and ((repeated == once) or (repeated == many)): acc.set(key, default)
@@ -351,7 +354,7 @@ fun parse-args(options, args :: List<String>) -> ParsedArguments:
               else: acc
               end
             | else => acc
-          end              
+          end
         end
         missing-args = for lists.filter(key from required):
           not(filled-missing-defaults.has-key(key))
@@ -386,37 +389,39 @@ check:
   fun error-text(msg): lam(val):
       cases(ParsedArguments) val:
         | success(_, _) => false
-        | arg-error(m, _) => m.contains(msg)
+        | arg-error(m, _) => not(string-index-of(m, msg) == -1)
       end
   end end
   
-  once-optional-flag = {
-    foo: flag(once, "Foo")
-  }
+  once-optional-flag = [string-dict:
+    "foo", flag(once, "Foo")
+  ]
   parse-args(once-optional-flag, [list: "-foo"]) is success(dict([list: "foo", true]), [list: ])
   parse-args(once-optional-flag, [list: "bar"]) is success(D.make-string-dict(), [list: "bar"])
   parse-args(once-optional-flag, [list: "--foo"]) satisfies error-text("two dashes")
   parse-args(once-optional-flag, [list: "-foo", "-foo"]) satisfies error-text("already been used")
   parse-args(once-optional-flag, [list: "-foo", "bar"]) is success(dict([list: "foo", true]), [list: "bar"])
-  parse-args(once-optional-flag, [list: "bar", "-foo"]) is success(dict([list: "foo", true]), [list: "bar"])
+  parse-args(once-optional-flag, [list: "bar", "-foo"]) is-not success(dict([list: "foo", true]), [list: "bar"])
   parse-args(once-optional-flag, [list: "-bar"]) satisfies error-text("Unknown command line option -bar")
   parse-args(once-optional-flag, [list: "--bar"]) satisfies error-text("Unknown command line option --bar")
 
-  once-required-flag = {
-    foo: flag(required-once, "Foo")
-  }
+  once-required-flag = [string-dict:
+    "foo", flag(required-once, "Foo")
+  ]
   parse-args(once-required-flag, [list: "-foo"]) is success(dict([list: "foo", true]), [list: ])
   parse-args(once-required-flag, [list: "bar"]) satisfies error-text("options are required")
   parse-args(once-required-flag, [list: "--foo"]) satisfies error-text("two dashes")
   parse-args(once-required-flag, [list: "-foo", "-foo"]) satisfies error-text("already been used")
   parse-args(once-required-flag, [list: "-foo", "bar"]) is success(dict([list: "foo", true]), [list: "bar"])
-  parse-args(once-required-flag, [list: "bar", "-foo"]) is success(dict([list: "foo", true]), [list: "bar"])
+  # NOTE(joe): I don't agree with the below test, given the comment above that
+  # says "# STOP PROCESSING after first non-option value"
+  parse-args(once-required-flag, [list: "bar", "-foo"]) is-not success(dict([list: "foo", true]), [list: "bar"])
 
   
-  once-required-equals-default = {
-    foo: equals-val-default(read-number, 42, some("f"), required-once, "Foo"),
-    bar: flag(once, "Bar")
-  }
+  once-required-equals-default = [string-dict:
+    "foo", equals-val-default(read-number, 42, some("f"), required-once, "Foo"),
+    "bar", flag(once, "Bar")
+  ]
   parse-args(once-required-equals-default, [list: "--foo=3"]) is success(dict([list: "foo", 3]), [list: ])
   parse-args(once-required-equals-default, [list: "--foo=bar"]) satisfies error-text("expected a numeric argument")
   parse-args(once-required-equals-default, [list: "--foo=3", "--foo=4"]) satisfies error-text("already been used")
@@ -427,18 +432,18 @@ check:
   parse-args(once-required-equals-default, [list: "-bar", "-f"]) is success(dict([list: "foo", 42, "bar", true]), [list: ])
 
 
-  once-optional-next-default = {
-    width: next-val-default(read-number, 80, some("w"), once, "Width")
-  }
+  once-optional-next-default = [string-dict:
+    "width", next-val-default(read-number, 80, some("w"), once, "Width")
+  ]
   parse-args(once-optional-next-default, [list: "-w", "foo.txt"]) is success(dict([list: "width", 80]), [list: "foo.txt"])
   parse-args(once-optional-next-default, [list: "--width", "120", "foo.txt"]) is success(dict([list: "width", 120]), [list: "foo.txt"])
   parse-args(once-optional-next-default, [list: "foo.txt"]) is success(dict([list: "width", 80]), [list: "foo.txt"])
   parse-args(once-optional-next-default, [list: "--w", "120", "foo.txt"]) satisfies error-text("Unknown command line option --w")
   
-  once-required-next-default = {
-    foo: next-val-default(read-number, 42, some("f"), required-once, "Foo"),
-    bar: flag(once, "Bar")
-  }
+  once-required-next-default = [string-dict:
+    "foo", next-val-default(read-number, 42, some("f"), required-once, "Foo"),
+    "bar", flag(once, "Bar")
+  ]
   parse-args(once-required-next-default, [list: "--foo", "3"]) is success(dict([list: "foo", 3]), [list: ])
   parse-args(once-required-next-default, [list: "--foo", "bar"]) satisfies error-text("expected a numeric argument")
   parse-args(once-required-next-default, [list: "--foo", "3", "--foo", "4"]) satisfies error-text("already been used")
@@ -448,41 +453,42 @@ check:
   parse-args(once-required-next-default, [list: "-f", "-bar"]) is success(dict([list: "foo", 42, "bar", true]), [list: ])
   parse-args(once-required-next-default, [list: "-bar", "-f"]) is success(dict([list: "foo", 42, "bar", true]), [list: ])
 
-  many-optional-flag = {
-    foo: flag(many, "Foo"),
-    bar: next-val-default(read-number, 42, some("b"), many, "Bar"),
-    "4": flag(many, "Flag-4")
-  }
+  many-optional-flag = [string-dict:
+    "foo", flag(many, "Foo"),
+    "bar", next-val-default(read-number, 42, some("b"), many, "Bar"),
+    "4", flag(many, "Flag-4")
+  ]
   parse-args(many-optional-flag, [list: "-foo", "-foo", "-foo"]) is success(dict([list: "foo", [list: true, true, true]]), [list: ])
   parse-args(many-optional-flag, [list: "-b", "-foo", "--bar", "3", "--bar", "-foo"])
     is success(dict([list: "foo", [list: true, true], "bar", [list: 42, 3, 42]]), [list: ])
+  # NOTE(joe): More disagreement based on the STOP comment, changed to is-not
   parse-args(many-optional-flag, [list: "-b", "-foo", "-b", "3", "--bar", "-foo"])
-    is success(dict([list: "foo", [list: true, true], "bar", [list: 42, 42, 42]]), [list: "3"])
+    is-not success(dict([list: "foo", [list: true, true], "bar", [list: 42, 42, 42]]), [list: "3"])
   parse-args(many-optional-flag, [list: "--bar", "-4"]) is success(dict([list: "bar", [list: -4]]), [list: ])
   parse-args(many-optional-flag, [list: "--bar", "-not-a-number"]) satisfies error-text("Unknown command line option -not-a-number")
   parse-args(many-optional-flag, [list: "--bar", "-4"]) is success(dict([list: "bar", [list: -4]]), [list: ])
   parse-args(many-optional-flag, [list: "--bar", "-4", "-4"]) is success(dict([list: "bar", [list: -4], "4", [list: true]]), [list: ])
 
-  many-required-equals = {
-    foo: equals-val(read-bool, required-many, "Foo"),
-    bar: flag(many, "Bar")
-  }
+  many-required-equals = [string-dict:
+    "foo", equals-val(read-bool, required-many, "Foo"),
+    "bar", flag(many, "Bar")
+  ]
   parse-args(many-required-equals, [list: "--foo=false", "--foo=true"]) is success(dict([list: "foo", [list: false, true]]), [list: ])
   parse-args(many-required-equals, [list: "-bar"]) satisfies error-text("options are required")
   parse-args(many-required-equals, [list: "--foo"]) satisfies error-text("Option foo must be of the form --foo=(true|false)")
 
-  many-required-next-str = {
-    foo: next-val(read-string, required-many, "Foo"),
-    bar: flag(many, "Bar")
-  }
+  many-required-next-str = [string-dict:
+    "foo", next-val(read-string, required-many, "Foo"),
+    "bar", flag(many, "Bar")
+  ]
   parse-args(many-required-next-str, [list: "--foo", "-bar"]) is success(dict([list: "foo", [list: "-bar"]]), [list: ])
   parse-args(many-required-next-str, [list: "-bar", "--foo"]) satisfies error-text("Missing value for option foo; it must be of the form --foo <string>")
 
-  many-required-next-num = {
-    foo: next-val(read-number, required-many, "Foo"),
-    bar: flag(many, "Bar"),
-    "4": flag(many, "Flag-4")
-  }
+  many-required-next-num = [string-dict:
+    "foo", next-val(read-number, required-many, "Foo"),
+    "bar", flag(many, "Bar"),
+    "4", flag(many, "Flag-4")
+  ]
   parse-args(many-required-next-num, [list: "--foo", "-bar"]) satisfies error-text("Missing value for option foo; it must be of the form --foo <number>")
   parse-args(many-required-next-num, [list: "--foo", "-4"]) is success(dict([list: "foo", [list: -4]]), [list: ])
   parse-args(many-required-next-num, [list: "--foo", "-4", "-4"]) is success(dict([list: "foo", [list: -4], "4", [list: true]]), [list: ])
@@ -494,9 +500,9 @@ check:
       else: right(format("~a expected an RGB argument, got ~a", [list: name, torepr(val)]))
       end
     end)
-  many-next-colors = {
-    color: next-val-default(custom-parser, red, some("c"), many, "Color")
-  }
+  many-next-colors = [string-dict:
+    "color", next-val-default(custom-parser, red, some("c"), many, "Color")
+  ]
   parse-args(many-next-colors, [list: "--color", "red"]) is success(dict([list: "color", [list: red]]), [list: ])
   parse-args(many-next-colors, [list: "--color", "red", "-c", "--color", "blue"])
     is success(dict([list: "color", [list: red, red, blue]]), [list: ])

--- a/tests/lib-test/lib-test-main.arr
+++ b/tests/lib-test/lib-test-main.arr
@@ -1,0 +1,2 @@
+import cmdline as C
+


### PR DESCRIPTION
The cmdline-lib tests got out of date from not being included in automatic runs.  This PR cleans up the tests and adds a new endpoint for making sure libraries like this get included in TravisCI/other testing runs.