### PR TITLE
no more gitmodules, do codemirror via package.json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "examples/pyret-lang-private"]
-	path = examples/pyret-lang-private
-	url = git@github.com:brownplt/pyret-lang-private
-[submodule "lib/CodeMirror"]
-	path = lib/CodeMirror
-	url = https://github.com/jpolitz/CodeMirror

--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,6 @@ $(PHASE3)/trove/%.js: src/$(TROVE)/%.arr $(PHASE2_ALL_DEPS)
 install:
 	@$(call MKDIR,node_modules)
 	npm install
-	git submodule init
-	git submodule update lib/CodeMirror
 
 
 .PHONY : test

--- a/docs/written/Makefile
+++ b/docs/written/Makefile
@@ -1,12 +1,12 @@
 all:
 	scribble \
     ++style styles.css \
-    ++style ../../lib/CodeMirror/lib/codemirror.css \
+    ++style ../../node_modules/codemirror/lib/codemirror.css \
     ++style editor.css \
     --prefix myprefix.html \
-    ++extra ../../lib/CodeMirror/mode/pyret/pyret.js \
-    ++extra ../../lib/CodeMirror/lib/codemirror.js \
-    ++extra ../../lib/CodeMirror/addon/runmode/runmode.js \
+    ++extra ../../node_modules/codemirror/mode/pyret/pyret.js \
+    ++extra ../../node_modules/codemirror/lib/codemirror.js \
+    ++extra ../../node_modules/codemirror/addon/runmode/runmode.js \
     ++extra hilite.js \
     --dest ../../build/ \
     --dest-name docs \

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "q": "~1.0.1",
     "lodash": "~2.4.1",
     "s-expression": "~2.2.0",
-    "seedrandom": "~2.3.10"
+    "seedrandom": "~2.3.10",
+    "CodeMirror": "git://github.com/jpolitz/CodeMirror"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Git submodules can be replaced by npm dependencies, to reduce the repo's reliance on git and confusing submodule errors.