### PR TITLE
Fix typo in Tour docs

### DIFF
--- a/docs/written/tour.scrbl
+++ b/docs/written/tour.scrbl
@@ -144,8 +144,8 @@ end
 
 @section{Strings}
 
-Strings can be written single- or double- quoted. Character escapes like \\n
-work, and the enclosing quote character can be included if escaped like \\".
+Strings can be written single- or double- quoted. Character escapes like @pyret{\n}
+work, and the enclosing quote character can be included if escaped like @pyret{\"}.
 
 @pyret-block{
 "hello world"


### PR DESCRIPTION
I'm not sure if it is `@pyret{\n}` or `@pyret{\\n}`