### PR TITLE
add safe-for-space tail calls with a flag to disable/enable

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -380,10 +380,11 @@ fun compile-fun-body(l :: Loc, step :: String, fun-name :: String, compiler, arg
         end
     end
   end
-  stack-attach-guard = if compiler.options.proper-tail-calls:
+  stack-attach-guard =
+    if compiler.options.proper-tail-calls:
       j-binop(rt-method("isCont", [list: j-id(e)]),
-                            j-and,
-                            j-parens(j-binop(j-id(step), j-neq, ret-label)))
+        j-and,
+        j-parens(j-binop(j-id(step), j-neq, ret-label)))
     else:
       rt-method("isCont", [list: j-id(e)])
     end

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -57,6 +57,7 @@ j-try-catch = J.j-try-catch
 j-throw = J.j-throw
 j-expr = J.j-expr
 j-binop = J.j-binop
+j-and = J.j-and
 j-eq = J.j-eq
 j-neq = J.j-neq
 j-geq = J.j-geq
@@ -379,6 +380,15 @@ fun compile-fun-body(l :: Loc, step :: String, fun-name :: String, compiler, arg
         end
     end
   end
+  stack-attach-guard = if compiler.options.proper-tail-calls:
+      j-binop(rt-method("isCont", [list: j-id(e)]),
+                            j-and,
+                            j-parens(j-binop(j-id(step), j-neq, ret-label)))
+    else:
+      rt-method("isCont", [list: j-id(e)])
+    end
+
+    
   j-block([list:
       j-var(step, j-num(0)),
       j-var(local-compiler.cur-ans, undefined),
@@ -398,7 +408,7 @@ fun compile-fun-body(l :: Loc, step :: String, fun-name :: String, compiler, arg
         e,
         j-block(
           [list:
-            j-if1(rt-method("isCont", [list: j-id(e)]),
+            j-if1(stack-attach-guard,
               j-block([list: 
                   j-expr(j-bracket-assign(j-dot(j-id(e), "stack"),
                       j-unop(rt-field("EXN_STACKHEIGHT"), J.j-postincr), act-record))
@@ -545,7 +555,7 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body):
     j-block([list:
         check-fun(compiler.get-loc(l), compiled-f),
         # Update step before the call, so that if it runs out of gas, the resumer goes to the right step
-        j-expr(j-assign(step,  after-app-label)),
+        j-expr(j-assign(step, after-app-label)),
         j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l))),
         j-expr(j-assign(ans, app(compiler.get-loc(l), compiled-f, compiled-args))),
         j-break]),
@@ -1317,8 +1327,9 @@ fun compile-program(self, l, imports, prog, freevars, env):
                         [list: wrap-modules(module-specs, toplevel-name, toplevel-fun)]))])))]))])
 end
 
-fun non-splitting-compiler(env):
+fun non-splitting-compiler(env, options):
   compiler-visitor.{
+    options: options,
     a-program(self, l, imports, body):
       simplified = body.visit(remove-useless-if-visitor)
       freevars = N.freevars-e(simplified)

--- a/src/arr/compiler/anf.arr
+++ b/src/arr/compiler/anf.arr
@@ -25,9 +25,7 @@ data ANFCont:
     apply(self, l :: Loc, expr :: N.ALettable):
       cases(N.ALettable) expr:
         | a-val(l2, v) =>
-          name = mk-id(l2, "cont_tail_app")
-          N.a-let(l, name.id-b, N.a-app(l, N.a-id(l, self.name), [list: v]),
-            N.a-lettable(l2, N.a-val(l2, name.id-e)))
+          N.a-lettable(l, N.a-app(l, N.a-id(l, self.name), [list: v]))
         | else =>
           e-name = mk-id(l, "cont_tail_arg")
           name = mk-id(l, "cont_tail_app")

--- a/src/arr/compiler/compile.arr
+++ b/src/arr/compiler/compile.arr
@@ -69,11 +69,11 @@ fun compile-js-ast(phases, ast, name, libs, options) -> CompilationPhase:
           when options.collect-all: ret := phase("Inlined lambdas", inlined, ret) end
           any-errors = named-errors + U.check-unbound(libs, inlined) + U.bad-assignments(libs, inlined)
           if is-empty(any-errors):
-            if options.collect-all: P.trace-make-compiled-pyret(ret, phase, inlined, libs)
-            else: phase("Result", C.ok(P.make-compiled-pyret(inlined, libs)), ret)
+            if options.collect-all: P.trace-make-compiled-pyret(ret, phase, inlined, libs, options)
+            else: phase("Result", C.ok(P.make-compiled-pyret(inlined, libs, options)), ret)
             end
           else:
-            if options.collect-all and options.ignore-unbound: P.trace-make-compiled-pyret(ret, phase, inlined, libs)
+            if options.collect-all and options.ignore-unbound: P.trace-make-compiled-pyret(ret, phase, inlined, libs, options)
             else: phase("Result", C.err(any-errors), ret)
             end
           end

--- a/src/arr/compiler/js-of-pyret.arr
+++ b/src/arr/compiler/js-of-pyret.arr
@@ -27,15 +27,15 @@ data CompiledCodePrinter:
     end
 end
 
-fun make-compiled-pyret(program-ast, env) -> CompiledCodePrinter:
+fun make-compiled-pyret(program-ast, env, options) -> CompiledCodePrinter:
   anfed = N.anf-program(program-ast)
-  compiled = anfed.visit(AL.splitting-compiler(env))
+  compiled = anfed.visit(AL.splitting-compiler(env, options))
   ccp(compiled)
 end
 
-fun trace-make-compiled-pyret(trace, phase, program-ast, env):
+fun trace-make-compiled-pyret(trace, phase, program-ast, env, options):
   var ret = trace
   anfed = N.anf-program(program-ast)
   ret := phase("ANFed", anfed, ret)
-  phase("Generated JS", ccp(anfed.visit(AL.splitting-compiler(env))), ret)
+  phase("Generated JS", ccp(anfed.visit(AL.splitting-compiler(env, options))), ret)
 end

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -40,6 +40,8 @@ fun main(args):
       C.flag(C.once, "Skip checks"),
     "allow-shadow",
       C.flag(C.once, "Run without checking for shadowed variables"),
+    "improper-tail-calls",
+      C.flag(C.once, "Run without proper tail calls"),
     "type-check",
       C.flag(C.once, "Type-check the program during compilation"),
     "dialect",
@@ -67,6 +69,7 @@ fun main(args):
       module-dir = r.get-value("module-load-dir")
       check-all = r.has-key("check-all")
       type-check = r.has-key("type-check")
+      tail-calls = not(r.has-key("improper-tail-calls"))
       if not(is-empty(rest)):
         program-name = rest.first
         result = CM.compile-js(
@@ -80,7 +83,8 @@ fun main(args):
             allow-shadowed : allow-shadowed,
             collect-all: false,
             type-check: type-check,
-            ignore-unbound: false
+            ignore-unbound: false,
+            proper-tail-calls: tail-calls
           }
           ).result
         cases(CS.CompileResult) result:
@@ -129,7 +133,8 @@ fun main(args):
               type-check : type-check,
               allow-shadowed : allow-shadowed,
               collect-all: false,
-              ignore-unbound: false
+              ignore-unbound: false,
+              proper-tail-calls: tail-calls
             }
             ).result
         else:

--- a/src/js/base/eval-lib.js
+++ b/src/js/base/eval-lib.js
@@ -51,6 +51,7 @@ function(q, loader, rtLib, dialectsLib, ffiHelpersLib, csLib, compLib, replLib, 
                   runtime.makeObject({
                     "check-mode": runtime.pyretTrue,
                     "allow-shadowed": runtime.pyretFalse,
+                    "proper-tail-calls": options.properTailCalls || true,
                     "collect-all": runtime.pyretFalse,
                     "type-check": runtime.makeBoolean(options.typeCheck || false),
                     "ignore-unbound": runtime.pyretFalse

--- a/tests/pyret/test-compile-helper.arr
+++ b/tests/pyret/test-compile-helper.arr
@@ -14,7 +14,8 @@ compile-str = lam(str):
             allow-shadowed : false,
             collect-all: false,
             type-check: false,
-            ignore-unbound: false
+            ignore-unbound: false,
+            proper-tail-calls: true,
           }
           ).result
 end

--- a/tests/pyret/tests/test-compile-errors.arr
+++ b/tests/pyret/tests/test-compile-errors.arr
@@ -1,26 +1,9 @@
-import "compiler/compile.arr" as CM
 import "compiler/compile-structs.arr" as CS
-
-compile-str = lam(str):
-  CM.compile-js(
-          CM.start,
-          "Pyret",
-          str,
-          "test",
-          CS.standard-builtins,
-          {
-            check-mode : true,
-            allow-shadowed : false,
-            collect-all: false,
-            type-check: false,
-            ignore-unbound: false
-          }
-          ).result
-end
+import "../test-compile-helper.arr" as C
 
 check:
   fun c(str):
-    result = compile-str(str)
+    result = C.compile-str(str)
     result satisfies CS.is-err
     cases(CS.CompileResult) result:
       | ok(_) => "No error for " + str

--- a/tests/pyret/tests/test-contracts.arr
+++ b/tests/pyret/tests/test-contracts.arr
@@ -1,31 +1,17 @@
 #lang pyret
 
 import exec as X
-import "compiler/compile.arr" as CM
 import "compiler/compile-structs.arr" as CS
+import "../test-compile-helper.arr" as C
+
+compile-str = C.compile-str
 
 exec-result = lam(result):
   str = result.code.pyret-to-js-runnable()
   X.exec(str, "test", ".", true, "Pyret", [list:])
 end
-compile-str = lam(str):
-  CM.compile-js(
-          CM.start,
-          "Pyret",
-          str,
-          "test",
-          CS.standard-builtins,
-          {
-            check-mode : true,
-            allow-shadowed : false,
-            collect-all: false,
-            type-check: false,
-            ignore-unbound: false
-          }
-          ).result
-end
 run-str = lam(str):
-  compiled = compile-str(str)
+  compiled = C.compile-str(str)
   cases(CS.CompileResult) compiled:
     | ok(code) => exec-result(compiled)
     | err(errs) => raise("Compilation failure when a run was expected " + torepr(errs) + "\n Program was:\n " + str)

--- a/tests/pyret/tests/test-rec.arr
+++ b/tests/pyret/tests/test-rec.arr
@@ -1,24 +1,8 @@
 
-import "compiler/compile.arr" as CM
+import "../test-compile-helper.arr" as C
 import "compiler/compile-structs.arr" as CS
 
-compile-str = lam(str):
-  CM.compile-js(
-          CM.start,
-          "Pyret",
-          str,
-          "test",
-          CS.standard-builtins,
-          {
-            check-mode : true,
-            allow-shadowed : false,
-            collect-all: false,
-            type-check: false,
-            ignore-unbound: false
-          }
-          ).result
-end
-
+compile-str = C.compile-str
 is-unbound-failure = lam(e): CS.is-err(e) and CS.is-unbound-id(e.problems.first) end
 is-pointless-rec = lam(e): CS.is-err(e) and CS.is-pointless-rec(e.problems.first) end
 is-ok = CS.is-ok

--- a/tests/type-check/main.arr
+++ b/tests/type-check/main.arr
@@ -23,7 +23,8 @@ compile-str = lam(filename, str):
             allow-shadowed : false,
             collect-all: false,
             type-check: true,
-            ignore-unbound: false
+            ignore-unbound: false,
+            proper-tail-calls: true
           }
           ).result
 end


### PR DESCRIPTION
 (includes options now attached to the last step of the compiler)

The old version of the compiler had this, and I've confirmed that this all works, but it doesn't actually live on master.  This PR makes safe-for-space tail calls the default, and adds a flag that can be used to turn them off.
