### PR TITLE
Small improvements to SublimeText3 syntax highlighting

### DIFF
--- a/tools/sublime/pyret.YAML-tmLanguage
+++ b/tools/sublime/pyret.YAML-tmLanguage
@@ -27,13 +27,13 @@ patterns:
   name: variable.arr
   match: (^\s\|) ([a-zA-Z0-9\-]*) (=>)
 
-- comment: Now for basic keywords
+- comment: Basic keywords
   name: keyword.operators.arr
-  match: \s(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|var\b|fun:\s|with:\s|sharing:\s|as\b|try:\s|except\b|when\b|for\b|from\b|check:\s|where:\s|doc:\s|and\b|or\b| not |else:\s|\sif\s|is==\s|is=~\s|is<=>\s|is-not==\s|is-not=~\s|is-not<=>\s|is-not\b|is\s|raises\b|deriving\b|ref\b|graph:\s|m-graph:\s|block:\s|satisfies\b|shadow\b|\slam\b|type-let\b|provide-types\b|newtype\b)
+  match: \s(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|var\b|fun:\s|with:\s|sharing:\s|as\b|try:\s|except\b|when\b|for\b|from\b|check:\s|where:\s|doc:\s|and\b|or\b| not |else:\s|\sif\s|is==\s|is=~\s|is<=>\s|is-not==\s|is-not=~\s|is-not<=>\s|is-not\b|is\s|raises\b|deriving\b|ref\b|graph:\s|m-graph:\s|block:\s|satisfies\b|shadow\b|\slam\b|type-let\b|provide-types\b|newtype\b|cases)
 
 - comment: Keywords that start a line
   name: keyword.operators.arr
-  match: ^(fun\s|where:|end\s|type\s|data\b|import\b|provide\b)
+  match: ^(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|check\s|cases)
 
 - comment: cases
   name: variable.operators.arr
@@ -49,6 +49,11 @@ patterns:
 - comment: operators
   name: keyword.operator.arr
   match: ( \+ | - | \/ | \* | > | < | >= | <= | <> )
+  
+- comment: multi-line comments
+  name: string.arr
+  begin: (#\|)
+  end: (\|#)
 
 - comment: comments
   name: comment.line.number-sign.arr

--- a/tools/sublime/pyret.tmLanguage
+++ b/tools/sublime/pyret.tmLanguage
@@ -44,9 +44,9 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Now for basic keywords</string>
+			<string>Basic keywords</string>
 			<key>match</key>
-			<string>\s(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|var\b|fun:\s|with:\s|sharing:\s|as\b|try:\s|except\b|when\b|for\b|from\b|check:\s|where:\s|doc:\s|and\b|or\b| not |else:\s|\sif\s|is==\s|is=~\s|is&lt;=&gt;\s|is-not==\s|is-not=~\s|is-not&lt;=&gt;\s|is-not\b|is\s|raises\b|deriving\b|ref\b|graph:\s|m-graph:\s|block:\s|satisfies\b|shadow\b|\slam\b|type-let\b|provide-types\b|newtype\b)</string>
+			<string>\s(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|var\b|fun:\s|with:\s|sharing:\s|as\b|try:\s|except\b|when\b|for\b|from\b|check:\s|where:\s|doc:\s|and\b|or\b| not |else:\s|\sif\s|is==\s|is=~\s|is&lt;=&gt;\s|is-not==\s|is-not=~\s|is-not&lt;=&gt;\s|is-not\b|is\s|raises\b|deriving\b|ref\b|graph:\s|m-graph:\s|block:\s|satisfies\b|shadow\b|\slam\b|type-let\b|provide-types\b|newtype\b|cases)</string>
 			<key>name</key>
 			<string>keyword.operators.arr</string>
 		</dict>
@@ -54,7 +54,7 @@
 			<key>comment</key>
 			<string>Keywords that start a line</string>
 			<key>match</key>
-			<string>^(fun\s|where:|end\s|type\s|data\b|import\b|provide\b)</string>
+			<string>^(fun\s|where:|end\s|type\s|data\b|import\b|provide\b|check\s|cases)</string>
 			<key>name</key>
 			<string>keyword.operators.arr</string>
 		</dict>
@@ -91,6 +91,16 @@
 			<string>( \+ | - | \/ | \* | &gt; | &lt; | &gt;= | &lt;= | &lt;&gt; )</string>
 			<key>name</key>
 			<string>keyword.operator.arr</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(#\|)</string>
+			<key>comment</key>
+			<string>multi-line comments</string>
+			<key>end</key>
+			<string>(\|#)</string>
+			<key>name</key>
+			<string>string.arr</string>
 		</dict>
 		<dict>
 			<key>comment</key>

--- a/tools/sublime/readme.md
+++ b/tools/sublime/readme.md
@@ -3,10 +3,12 @@ This folder contains an easily-editable syntax definition (pyret.YAML-tmLanguage
 **For users looking to get Pyret syntax highlighting in Sublime3:** simply make a copy of the tmLanguage file, and move it to the appropriate directory.
 
 Linux:
-	cp pyret.tmLanguage "/Users/USER/Library/Application Support/Sublime Text 3/Packages/User/"
+
+    cp pyret.tmLanguage "/Users/USER/Library/Application Support/Sublime Text 3/Packages/User/"
 	
 Windows: copy the file to your equivalent of
-  C:\Users\USER\AppData\Roaming\Sublime Text 3\Packages\User
+
+    C:\Users\USER\AppData\Roaming\Sublime Text 3\Packages\User
   
 Once the file is in this directory, Pyret should be a selectable option in the syntax chooser.
 

--- a/tools/sublime/readme.md
+++ b/tools/sublime/readme.md
@@ -1,10 +1,19 @@
 This folder contains an easily-editable syntax definition (pyret.YAML-tmLanguage) and its Sublime-readable converted output (pyret.tmLanguage). 
 
-For Sublime(3) to recognize your pyret.tmLanguage file, you will need to run 
+**For users looking to get Pyret syntax highlighting in Sublime3:** simply make a copy of the tmLanguage file, and move it to the appropriate directory.
 
+Linux:
 	cp pyret.tmLanguage "/Users/USER/Library/Application Support/Sublime Text 3/Packages/User/"
+	
+Windows: copy the file to your equivalent of
+  C:\Users\USER\AppData\Roaming\Sublime Text 3\Packages\User
+  
+Once the file is in this directory, Pyret should be a selectable option in the syntax chooser.
 
-To build the .YAML-tmLanguage file into the .tmLanguage file Sublime will recognize, you will want to use [the AAAPackageDev plugin](https://github.com/SublimeText/AAAPackageDev).
+
+**For users looking to edit the syntax definition:** you will want to edit the YAML-tmLanguage file, then build it into the .tmLanguage file that Sublime will use to perform the syntax highlighting. 
+
+To build the .YAML-tmLanguage file into the .tmLanguage file, install [the AAAPackageDev plugin](https://github.com/SublimeText/AAAPackageDev) using the package manager. Open the .YAML-tmLanguage file in Sublime, set the syntax to `Sublime Text Syntax Def (YAML)`, and do `Tools > Build`.
 
 Use [PackageResourceViewer](https://github.com/skuroda/PackageResourceViewer) to modify your theme files for compatability with the Pyret style file. For help, see [this StackOverflow answer](http://stackoverflow.com/a/25691811/4283301). Right now the names defined in the syntax file are fairly arbitrary, to fit the default Monokai color scheme. If you want to standardize the naming, check out TextMate's [naming conventions](http://manual.macromates.com/en/language_grammars#naming_conventions). 
 


### PR DESCRIPTION
Added highlighting for "cases" and multi-line comments.

Clarified readme, added instructions for Windows users.

This is a tiny tiny increment on the work that @rrshaban did. 