### PR TITLE
Factor out Particle handling from world.js and change it to work with our core shim.

### DIFF
--- a/src/arr/compiler/initialize-trove.arr
+++ b/src/arr/compiler/initialize-trove.arr
@@ -33,3 +33,4 @@ import repl as _
 import "compiler/locators/file.arr" as _
 import plot as _
 import graph as _
+import particle as _

--- a/src/arr/trove/particle-shim-structs.arr
+++ b/src/arr/trove/particle-shim-structs.arr
@@ -1,0 +1,54 @@
+provide *
+provide-types *
+
+type Pin = String
+
+var A0 :: Pin = "A0"
+var A1 :: Pin = "A1"
+var A2 :: Pin = "A2"
+var A3 :: Pin = "A3"
+var A4 :: Pin = "A4"
+var A5 :: Pin = "A5"
+var A6 :: Pin = "A6"
+var A7 :: Pin = "A7"
+
+var D0 :: Pin = "D0"
+var D1 :: Pin = "D1"
+var D2 :: Pin = "D2"
+var D3 :: Pin = "D3"
+var D4 :: Pin = "D4"
+var D5 :: Pin = "D5"
+var D6 :: Pin = "D6"
+var D7 :: Pin = "D7"
+
+data AnalogInputTrigger:
+  | ait-enters(min :: Number, max :: Number) with:
+    _shim-convert(self):
+      tostring(self.min) + "-" + tostring(self.max)
+    end
+  | ait-exits(min :: Number, max :: Number) with:
+    _shim-convert(self):
+      tostring(self.max) + "-" + tostring(self.min)
+    end
+  | ait-crosses(mid :: Number) with:
+    _shim-convert(self):
+      tostring(self.mid) + "-" + tostring(self.mid)
+    end
+end
+
+data PinConfig:
+  | pc-write(pin :: Pin, event :: String) with:
+    _shim-convert(self):
+      self.pin + ":" + self.event + "\n"
+    end
+  | pc-digital-read(pin :: Pin, event :: String) with:
+    _shim-convert(self):
+      self.pin + ":" + self.event + "\n"
+    end
+  | pc-analog-read(pin :: Pin, event :: String, trigger :: AnalogInputTrigger) with:
+    _shim-convert(self):
+      self.pin + ":" + self.event + ":" + self.trigger._shim-convert() + "\n"
+    end
+end
+
+type CoreConfig = List<PinConfig>

--- a/src/arr/trove/particle-shim-structs.arr
+++ b/src/arr/trove/particle-shim-structs.arr
@@ -39,15 +39,15 @@ end
 data PinConfig:
   | pc-write(pin :: Pin, event :: String) with:
     _shim-convert(self):
-      self.pin + ":" + self.event + "\n"
+      self.event + ":" + self.pin + ":O" + "\n"
     end
   | pc-digital-read(pin :: Pin, event :: String) with:
     _shim-convert(self):
-      self.pin + ":" + self.event + "\n"
+      self.event + ":" + self.pin + ":I" + "\n"
     end
   | pc-analog-read(pin :: Pin, event :: String, trigger :: AnalogInputTrigger) with:
     _shim-convert(self):
-      self.pin + ":" + self.event + ":" + self.trigger._shim-convert() + "\n"
+      self.event + ":" + self.pin + ":I:" + self.trigger._shim-convert() + "\n"
     end
 end
 

--- a/src/js/trove/particle.js
+++ b/src/js/trove/particle.js
@@ -1,0 +1,154 @@
+define(["js/runtime-util", "js/ffi-helpers", "trove/world", "trove/world-lib", "trove/particle-shim-structs"], function(util, ffiLib, world, worldLib, pShimStruct) {
+
+  return util.definePyretModule(
+    "particle",
+    [],
+    {
+      values: {
+      },
+      aliases: {
+      },
+      datatypes: {
+      }
+    },
+    function(runtime, namespace) {
+      return runtime.loadJSModules(namespace, [worldLib, ffiLib], function(rawJsworld, ffi) {
+        return runtime.loadModulesNew(namespace, [world, pShimStruct], function(pWorld, pStruct) {
+          var WorldConfigOption = runtime.getField(pWorld, "internal").WorldConfigOption;
+          var adaptWorldFunction = runtime.getField(pWorld, "internal").adaptWorldFunction;
+
+          var sd_to_js = function(sd) {
+            var ret = {};
+            var arr = ffi.toArray(runtime.getField(sd, "keys-list").app());
+            for(var i in arr) {
+              var k = arr[i];
+              var v = runtime.getField(sd, "get-value").app(k);
+              if(typeof(v) === "string") {
+                ret[k] = v;
+              } else {
+                throw new Error('unimplemented value conversion for StringDict');
+              }
+            }
+            return ret;
+          };
+
+          var OnParticle = function(handler, name, sdict) {
+            WorldConfigOption.call(this, 'on-particle');
+            this.handler = handler;
+            this.event = name;
+            this.options = sd_to_js(sdict);
+          };
+
+          OnParticle.prototype = Object.create(WorldConfigOption.prototype);
+
+          OnParticle.prototype.toRawHandler = function(toplevelNode) {
+            var that = this;
+            var worldFunction = adaptWorldFunction(that.handler);
+            return rawJsworld.on_particle(worldFunction, that.event, that.options);
+          };
+
+
+          //////////////////////////////////////////////////////////////////////
+          
+          var ToParticle = function(handler, ename, sdict) {
+            WorldConfigOption.call(this, 'to-particle');
+            this.handler = handler;
+            this.event = ename;
+            this.options = sd_to_js(sdict);
+          };
+          
+          ToParticle.prototype = Object.create(WorldConfigOption.prototype);
+          
+          ToParticle.prototype.toRawHandler = function(toplevelNode) {
+            var that = this;
+            var worldFunction = adaptWorldFunction(that.handler);
+            var eventGen = function(w, k) {
+              worldFunction(w, function(v) {
+                if(ffi.isSome(v)) {
+                  var xhr = new XMLHttpRequest();
+                  xhr.open("POST","https://api.particle.io/v1/devices/events");
+                  xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
+                  xhr.send("access_token=" + that.options.acc +
+                           "&name=_event&data=" + that.event + ":" +
+                           runtime.getField(v, "value") + "&private=true&ttl=60");
+                }
+                k(w);
+              });
+            };
+            return rawJsworld.on_world_change(eventGen);
+          };
+          
+
+          //////////////////////////////////////////////////////////////////////
+          
+          var configCore = function(coreid, acc, configs) {
+            var config_str = configs.map(function(c){
+              return runtime.getField(c, "_shim-convert").app();}).join("");
+            var xhr = new XMLHttpRequest();
+            xhr.open("POST","https://api.particle.io/v1/devices/events");
+            xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
+            xhr.send("access_token=" + acc + "&name=_config&data=" + config_str + "&private=true&ttl=60");
+          }
+          
+          var pStruct_vals = runtime.getField(pStruct, "values");
+          
+          //////////////////////////////////////////////////////////////////////
+          var makeObject = runtime.makeObject;
+          var makeFunction = runtime.makeFunction;
+          
+          return makeObject({
+            "provide": makeObject({
+              "on-particle": makeFunction(function(onEvent,eName,sd) {
+                ffi.checkArity(3, arguments, "on-particle");
+                runtime.checkFunction(onEvent);
+                runtime.checkString(eName);
+                return runtime.makeOpaque(new OnParticle(onEvent,eName,sd));
+              }),
+              "to-particle": makeFunction(function(toEvent,eName,sd) {
+                ffi.checkArity(3, arguments, "to-particle");
+                runtime.checkFunction(toEvent);
+                runtime.checkString(eName);
+                return runtime.makeOpaque(new ToParticle(toEvent,eName,sd));
+              }),
+              // core configuration
+              "configure-core": makeFunction(function(coreid, acc, config) {
+                ffi.checkArity(3, arguments, "configure-core");
+                runtime.checkString(coreid);
+                runtime.checkString(acc);
+                runtime.checkList(config);
+                configCore(coreid, acc, ffi.toArray(config));
+              }),
+              "ait-enters": runtime.getField(pStruct_vals, "ait-enters"),
+              "ait-exits": runtime.getField(pStruct_vals, "ait-exits"),
+              "ait-crosses": runtime.getField(pStruct_vals, "ait-crosses"),
+              "is-ait-enters": runtime.getField(pStruct_vals, "is-ait-enters"),
+              "is-ait-exits": runtime.getField(pStruct_vals, "is-ait-exits"),
+              "is-ait-crosses": runtime.getField(pStruct_vals, "is-ait-crosses"),
+              "pc-write": runtime.getField(pStruct_vals, "pc-write"),
+              "pc-digital-read": runtime.getField(pStruct_vals, "pc-digital-read"),
+              "pc-analog-read": runtime.getField(pStruct_vals, "pc-analog-read"),
+              "is-pc-write": runtime.getField(pStruct_vals, "is-pc-write"),
+              "is-pc-digital-read": runtime.getField(pStruct_vals, "is-pc-digital-read"),
+              "is-pc-analog-read": runtime.getField(pStruct_vals, "is-pc-analog-read"),
+              "A0": runtime.getField(pStruct_vals, "A0"),
+              "A1": runtime.getField(pStruct_vals, "A1"),
+              "A2": runtime.getField(pStruct_vals, "A2"),
+              "A3": runtime.getField(pStruct_vals, "A3"),
+              "A4": runtime.getField(pStruct_vals, "A4"),
+              "A5": runtime.getField(pStruct_vals, "A5"),
+              "A6": runtime.getField(pStruct_vals, "A6"),
+              "A7": runtime.getField(pStruct_vals, "A7"),
+              "D0": runtime.getField(pStruct_vals, "D0"),
+              "D1": runtime.getField(pStruct_vals, "D1"),
+              "D2": runtime.getField(pStruct_vals, "D2"),
+              "D3": runtime.getField(pStruct_vals, "D3"),
+              "D4": runtime.getField(pStruct_vals, "D4"),
+              "D5": runtime.getField(pStruct_vals, "D5"),
+              "D6": runtime.getField(pStruct_vals, "D6"),
+              "D7": runtime.getField(pStruct_vals, "D7")
+            })
+          });
+        });
+      });
+    });
+});

--- a/src/js/trove/world-lib.js
+++ b/src/js/trove/world-lib.js
@@ -807,12 +807,12 @@ define(["js/runtime-util"], function(util) {
     Jsworld.on_mouse = on_mouse;
 
 
-    function on_particle(handler, acc, eName) {
+      function on_particle(handler, eName, options) {
         return function() {
             var evtSource;
             return {
                 onRegister: function(top) {
-                    evtSource = new EventSource("https://api.particle.io/v1/devices/events/?access_token=" + acc);
+                    evtSource = new EventSource("https://api.particle.io/v1/devices/events/?access_token=" + options.acc);
                     evtSource.addEventListener(eName,
                                                function(e) {
                                                    data = JSON.parse(e.data);

--- a/src/js/trove/world.js
+++ b/src/js/trove/world.js
@@ -1,4 +1,4 @@
-define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers", "js/type-util", "trove/string-dict", "trove/particle-shim-structs"], function(util, imageLib, worldLib, ffiLib, t, strDictLib, pShimStruct) {
+define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers", "js/type-util", "trove/string-dict"], function(util, imageLib, worldLib, ffiLib, t, strDictLib) {
 
   var wcOfA = t.tyapp(t.localType("WorldConfig"), [t.tyvar("a")]);
 
@@ -50,20 +50,6 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
                 t.arrow([t.tyvar("a"), t.number, t.number, t.string], t.tyvar("a")),
               ],
               wcOfA)),
-        "on-particle":
-          t.forall(["a"],
-            t.arrow([
-                t.arrow([t.tyvar("a"), t.string], t.tyvar("a")),
-                t.string,
-                t.libName("string-dict", "StringDict")],
-                    wcOfA)),
-        "to-particle":
-          t.forall(["a"],
-            t.arrow([
-                t.arrow([t.tyvar("a")], t.tyapp(t.libName("option", "Option"), [t.string])),
-                t.string,
-                t.libName("string-dict", "StringDict")],
-                    wcOfA)),
         "is-world-config": t.arrow([t.any], t.boolean),
         "is-key-equal": t.arrow([t.string, t.string], t.boolean)
       },
@@ -81,7 +67,6 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
     },
     function(runtime, namespace) {
         return runtime.loadJSModules(namespace, [imageLib, worldLib, ffiLib, strDictLib], function(imageLibrary, rawJsworld, ffi, strDict) {
-        return runtime.loadModulesNew(namespace, [pShimStruct], function(pStruct) {
         var isImage = imageLibrary.isImage;
 
         //////////////////////////////////////////////////////////////////////
@@ -522,7 +507,6 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
               adaptWorldFunction: adaptWorldFunction
             }
           })
-        });
       });
     });
   });

--- a/src/js/trove/world.js
+++ b/src/js/trove/world.js
@@ -452,81 +452,6 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
         var checkHandler = runtime.makeCheckType(isOpaqueWorldConfigOption, "WorldConfigOption");
         //////////////////////////////////////////////////////////////////////
 
-        var sd_to_js = function(sd) {
-            var ret = {};
-            var arr = ffi.toArray(runtime.getField(sd, "keys-list").app());
-            for(var i in arr) {
-                var k = arr[i];
-                var v = runtime.getField(sd, "get-value").app(k);
-                if(typeof(v) === "string") {
-                    ret[k] = v;
-                } else {
-                    throw new Error('unimplemented value conversion for StringDict');
-                }
-            }
-            return ret;
-        };
-
-        var OnParticle = function(handler, name, sdict) {
-            WorldConfigOption.call(this, 'on-particle');
-            this.handler = handler;
-            this.event = name;
-            this.options = sd_to_js(sdict);
-        };
-
-        OnParticle.prototype = Object.create(WorldConfigOption.prototype);
-
-        OnParticle.prototype.toRawHandler = function(toplevelNode) {
-            var that = this;
-            var worldFunction = adaptWorldFunction(that.handler);
-            return rawJsworld.on_particle(worldFunction, that.event, that.options);
-        };
-
-
-        //////////////////////////////////////////////////////////////////////
-
-        var ToParticle = function(handler, ename, sdict) {
-            WorldConfigOption.call(this, 'to-particle');
-            this.handler = handler;
-            this.event = ename;
-            this.options = sd_to_js(sdict);
-        };
-
-        ToParticle.prototype = Object.create(WorldConfigOption.prototype);
-
-        ToParticle.prototype.toRawHandler = function(toplevelNode) {
-            var that = this;
-            var worldFunction = adaptWorldFunction(that.handler);
-            var eventGen = function(w, k) {
-                worldFunction(w, function(v) {
-                    if(ffi.isSome(v)) {
-                        var xhr = new XMLHttpRequest();
-                        xhr.open("POST","https://api.particle.io/v1/devices/events");
-                        xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-                        xhr.send("access_token=" + that.options.acc + "&name=_event&data=" + that.event + ":" + runtime.getField(v, "value") + "&private=true&ttl=60");
-                    }
-                    k(w);
-                });
-            };
-            return rawJsworld.on_world_change(eventGen);
-        };
-
-
-        //////////////////////////////////////////////////////////////////////
-
-        var configCore = function(coreid, acc, configs) {
-          var config_str = configs.map(function(c){
-              return runtime.getField(c, "_shim-convert").app();}).join("");
-          var xhr = new XMLHttpRequest();
-          xhr.open("POST","https://api.particle.io/v1/devices/events");
-          xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-          xhr.send("access_token=" + acc + "&name=_config&data=" + config_str + "&private=true&ttl=60");
-        }
-
-        var pStruct_vals = runtime.getField(pStruct, "values");
-
-        //////////////////////////////////////////////////////////////////////
-
 
         // The default tick delay is 28 times a second.
         var DEFAULT_TICK_DELAY = 1/28;
@@ -535,107 +460,67 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
         var makeFunction = runtime.makeFunction;
 
         return makeObject({
-          "provide": makeObject({
-            "big-bang": makeFunction(function(init, handlers) {
-              ffi.checkArity(2, arguments, "big-bang");
-              runtime.checkList(handlers);
-              var arr = ffi.toArray(handlers);
-              var initialWorldValue = init;
-              arr.map(function(h) { checkHandler(h); });
-              bigBang(initialWorldValue, arr);
-              ffi.throwMessageException("Internal error in bigBang: stack not properly paused and stored.");
+          "provide-plus-types": makeObject({
+            "values": makeObject({
+              "big-bang": makeFunction(function(init, handlers) {
+                ffi.checkArity(2, arguments, "big-bang");
+                runtime.checkList(handlers);
+                var arr = ffi.toArray(handlers);
+                var initialWorldValue = init;
+                arr.map(function(h) { checkHandler(h); });
+                bigBang(initialWorldValue, arr);
+                ffi.throwMessageException("Internal error in bigBang: stack not properly paused and stored.");
+              }),
+              "on-tick": makeFunction(function(handler) {
+                ffi.checkArity(1, arguments, "on-tick");
+                runtime.checkFunction(handler);
+                return runtime.makeOpaque(new OnTick(handler, Math.floor(DEFAULT_TICK_DELAY * 1000)));
+              }),
+              "on-tick-n": makeFunction(function(handler, n) {
+                ffi.checkArity(2, arguments, "on-tick-n");
+                runtime.checkFunction(handler);
+                runtime.checkNumber(n);
+                var fixN = typeof n === "number" ? fixN : n.toFixnum();
+                return runtime.makeOpaque(new OnTick(handler, fixN * 1000));
+              }),
+              "to-draw": makeFunction(function(drawer) {
+                ffi.checkArity(1, arguments, "to-draw");
+                runtime.checkFunction(drawer);
+                return runtime.makeOpaque(new ToDraw(drawer));
+              }),
+              "stop-when": makeFunction(function(stopper) {
+                ffi.checkArity(1, arguments, "stop-when");
+                runtime.checkFunction(stopper);
+                return runtime.makeOpaque(new StopWhen(stopper));
+              }),
+              "on-key": makeFunction(function(onKey) {
+                ffi.checkArity(1, arguments, "on-key");
+                runtime.checkFunction(onKey);
+                return runtime.makeOpaque(new OnKey(onKey));
+              }),
+              "on-mouse": makeFunction(function(onMouse) {
+                ffi.checkArity(1, arguments, "on-mouse");
+                runtime.checkFunction(onMouse);
+                return runtime.makeOpaque(new OnMouse(onMouse));
+              }),
+              "is-world-config": makeFunction(function(v) {
+                ffi.checkArity(1, arguments, "is-world-config");
+                if(!runtime.isOpaque(v)) { return runtime.pyretFalse; }
+                return runtime.makeBoolean(isWorldConfigOption(v.val));
+              }),
+              "is-key-equal": makeFunction(function(key1, key2) {
+                ffi.checkArity(2, arguments, "is-key-equal");
+                runtime.checkString(key1);
+                runtime.checkString(key2);
+                return key1.toString().toLowerCase() === key2.toString().toLowerCase();
+              })
             }),
-            "on-tick": makeFunction(function(handler) {
-              ffi.checkArity(1, arguments, "on-tick");
-              runtime.checkFunction(handler);
-              return runtime.makeOpaque(new OnTick(handler, Math.floor(DEFAULT_TICK_DELAY * 1000)));
+            "types": makeObject({
             }),
-            "on-tick-n": makeFunction(function(handler, n) {
-              ffi.checkArity(2, arguments, "on-tick-n");
-              runtime.checkFunction(handler);
-              runtime.checkNumber(n);
-              var fixN = typeof n === "number" ? fixN : n.toFixnum();
-              return runtime.makeOpaque(new OnTick(handler, fixN * 1000));
-            }),
-            "to-draw": makeFunction(function(drawer) {
-              ffi.checkArity(1, arguments, "to-draw");
-              runtime.checkFunction(drawer);
-              return runtime.makeOpaque(new ToDraw(drawer));
-            }),
-            "stop-when": makeFunction(function(stopper) {
-              ffi.checkArity(1, arguments, "stop-when");
-              runtime.checkFunction(stopper);
-              return runtime.makeOpaque(new StopWhen(stopper));
-            }),
-            "on-key": makeFunction(function(onKey) {
-              ffi.checkArity(1, arguments, "on-key");
-              runtime.checkFunction(onKey);
-              return runtime.makeOpaque(new OnKey(onKey));
-            }),
-            "on-mouse": makeFunction(function(onMouse) {
-              ffi.checkArity(1, arguments, "on-mouse");
-              runtime.checkFunction(onMouse);
-              return runtime.makeOpaque(new OnMouse(onMouse));
-            }),
-            "on-particle": makeFunction(function(onEvent,eName,sd) {
-              ffi.checkArity(3, arguments, "on-particle");
-              runtime.checkFunction(onEvent);
-              runtime.checkString(eName);
-              return runtime.makeOpaque(new OnParticle(onEvent,eName,sd));
-            }),
-            "to-particle": makeFunction(function(toEvent,eName,sd) {
-              ffi.checkArity(3, arguments, "to-particle");
-              runtime.checkFunction(toEvent);
-              runtime.checkString(eName);
-              return runtime.makeOpaque(new ToParticle(toEvent,eName,sd));
-            }),
-            "is-world-config": makeFunction(function(v) {
-              ffi.checkArity(1, arguments, "is-world-config");
-              if(!runtime.isOpaque(v)) { return runtime.pyretFalse; }
-              return runtime.makeBoolean(isWorldConfigOption(v.val));
-            }),
-            "is-key-equal": makeFunction(function(key1, key2) {
-              ffi.checkArity(2, arguments, "is-key-equal");
-              runtime.checkString(key1);
-              runtime.checkString(key2);
-              return key1.toString().toLowerCase() === key2.toString().toLowerCase();
-            }),
-            // core configuration
-            "configure-core": makeFunction(function(coreid, acc, config) {
-              ffi.checkArity(3, arguments, "configure-core");
-              runtime.checkString(coreid);
-              runtime.checkString(acc);
-              runtime.checkList(config);
-              configCore(coreid, acc, ffi.toArray(config));
-            }),
-            "ait-enters": runtime.getField(pStruct_vals, "ait-enters"),
-            "ait-exits": runtime.getField(pStruct_vals, "ait-exits"),
-            "ait-crosses": runtime.getField(pStruct_vals, "ait-crosses"),
-            "is-ait-enters": runtime.getField(pStruct_vals, "is-ait-enters"),
-            "is-ait-exits": runtime.getField(pStruct_vals, "is-ait-exits"),
-            "is-ait-crosses": runtime.getField(pStruct_vals, "is-ait-crosses"),
-            "pc-write": runtime.getField(pStruct_vals, "pc-write"),
-            "pc-digital-read": runtime.getField(pStruct_vals, "pc-digital-read"),
-            "pc-analog-read": runtime.getField(pStruct_vals, "pc-analog-read"),
-            "is-pc-write": runtime.getField(pStruct_vals, "is-pc-write"),
-            "is-pc-digital-read": runtime.getField(pStruct_vals, "is-pc-digital-read"),
-            "is-pc-analog-read": runtime.getField(pStruct_vals, "is-pc-analog-read"),
-            "A0": runtime.getField(pStruct_vals, "A0"),
-            "A1": runtime.getField(pStruct_vals, "A1"),
-            "A2": runtime.getField(pStruct_vals, "A2"),
-            "A3": runtime.getField(pStruct_vals, "A3"),
-            "A4": runtime.getField(pStruct_vals, "A4"),
-            "A5": runtime.getField(pStruct_vals, "A5"),
-            "A6": runtime.getField(pStruct_vals, "A6"),
-            "A7": runtime.getField(pStruct_vals, "A7"),
-            "D0": runtime.getField(pStruct_vals, "D0"),
-            "D1": runtime.getField(pStruct_vals, "D1"),
-            "D2": runtime.getField(pStruct_vals, "D2"),
-            "D3": runtime.getField(pStruct_vals, "D3"),
-            "D4": runtime.getField(pStruct_vals, "D4"),
-            "D5": runtime.getField(pStruct_vals, "D5"),
-            "D6": runtime.getField(pStruct_vals, "D6"),
-            "D7": runtime.getField(pStruct_vals, "D7")
+            "internal": {
+              WorldConfigOption: WorldConfigOption,
+              adaptWorldFunction: adaptWorldFunction
+            }
           })
         });
       });

--- a/src/js/trove/world.js
+++ b/src/js/trove/world.js
@@ -502,7 +502,7 @@ define(["js/runtime-util", "trove/image-lib", "trove/world-lib", "js/ffi-helpers
                         var xhr = new XMLHttpRequest();
                         xhr.open("POST","https://api.particle.io/v1/devices/events");
                         xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-                        xhr.send("access_token=" + that.options.acc + "&name=" + that.event + "&data=" + runtime.getField(v, "value") + "&private=true&ttl=60");
+                        xhr.send("access_token=" + that.options.acc + "&name=_event&data=" + that.event + ":" + runtime.getField(v, "value") + "&private=true&ttl=60");
                     }
                     k(w);
                 });


### PR DESCRIPTION
In order to simplify the student experience, we plan to have a configurable (through events) shim that can be flashed once to a Particle core, and then configuration of reading/writing pins and the like are done via Pyret.  These commits change the Particle handlers to talk with our shim, and also refactors the Particle-specific code out of world.js (since we end up adding a lot more Particle-specific exports to Pyret).