### PR TITLE
New JSON library for Pyret

### DIFF
--- a/docs/written/trove/json.js.rkt
+++ b/docs/written/trove/json.js.rkt
@@ -1,0 +1,81 @@
+#lang scribble/base
+@(require "../../scribble-api.rkt" "../abbrevs.rkt")
+@(define (sref s)
+  (a-id s (xref "json-structs" s)))
+
+@(append-gen-docs
+'(module "json"
+  (path "build/phase1/trove/json.js")
+  (fun-spec (name "j-obj") (arity 0))
+  (fun-spec (name "j-arr") (arity 0))
+  (fun-spec (name "j-num") (arity 0))
+  (fun-spec (name "j-str") (arity 0))
+  (fun-spec (name "j-bool") (arity 0))
+  (fun-spec (name "j-null") (arity 0))
+  (fun-spec (name "is-j-obj") (arity 1))
+  (fun-spec (name "is-j-arr") (arity 1))
+  (fun-spec (name "is-j-num") (arity 1))
+  (fun-spec (name "is-j-str") (arity 1))
+  (fun-spec (name "is-j-bool") (arity 1))
+  (fun-spec (name "is-j-null") (arity 1))
+  (fun-spec (name "read-json") (arity 1))
+))
+
+@docmodule["json"]{
+@ignore[(list "j-obj" "j-arr" "j-num" "j-str" "j-bool" "j-null")]
+  @para{
+  This module re-exports the constructors from @sref["JSON"],
+  which defines the result of parsing a JSON expression.
+  }
+
+  @function["read-json" #:args '(("json-str" ""))
+    #:contract (a-arrow (a-id "String" (xref "<global>" "String"))
+                        (a-id "JSON" (xref "json-structs" "JSON")))]{
+    Reads a @emph{JSON expression} as a string, and returns it as a Pyret value.
+
+    A JSON expression is a string that satisfies the following grammar:
+
+    @verbatim{
+JSON = "{" <string> ":" JSON "," ... <string> ":" JSON "}"
+      | "[" JSON "," ... JSON "]"
+      | <number>
+      | <string>
+      | <boolean>
+      | null
+    }
+
+    The first form parses to a @sref["j-obj"] containing a
+    @(a-id StringDict (xref "string-dict" StringDict)) with the strings
+    before the colons as keys and the results of converting the JSON
+    expressions after the colons as values.
+    The second form parses to a @sref["j-arr"] containing the nested
+    sub-expression results as a list.
+    Numbers become @sref["j-num"]s, strings become
+    @sref["j-str"]s, the strings @pyret["true"] and @pyret["false"] become
+    @sref["j-bool"]s, and the string @pyret["null"] becomes @sref["j-null"].
+
+@examples{
+import json as J
+import string-dict as SD
+
+p = J.read-json
+
+check:
+  p("0") is J.j-num(0)
+  p('"a"') is J.j-str("a")
+  p("[]") is J.j-arr([list:])
+  p("{}") is J.j-obj([SD.string-dict:])
+  p("true") is J.j-bool(true)
+  p("false") is J.j-bool(false)
+  p("null") i J.j-null
+
+  p('{"foo": 1, "baz": true}') is
+    J.j-obj([SD.string-dict: "foo", J.j-num(1), "baz", J.j-bool(true)])
+  p('[1,2,3]') is J.j-arr([list: J.j-num(1), J.j-num(2), J.j-num(3)])
+  p('[[[]]]') is J.j-arr([list: J.j-arr([list: J.j-arr([list:])])])
+  p('[5, null, {"hello": "world"}]') is
+    J.j-arr([list: J.j-num(5), J.j-null,
+      J.j-obj([SD.string-dict: "hello", J.j-str("world")])])
+
+end
+}

--- a/src/arr/compiler/initialize-trove.arr
+++ b/src/arr/compiler/initialize-trove.arr
@@ -34,3 +34,4 @@ import "compiler/locators/file.arr" as _
 import plot as _
 import graph as _
 import particle as _
+import json as _

--- a/src/arr/trove/json-structs.arr
+++ b/src/arr/trove/json-structs.arr
@@ -20,7 +20,7 @@ data JSON:
       end
       "{" + l.join-str(", ") + "}"
     end
-  | j-arr(l :: List) with:
+  | j-arr(l :: List<JSON>) with:
     native(self):
       self.l.map(lam(x): x.native() end)
     end,

--- a/src/arr/trove/json-structs.arr
+++ b/src/arr/trove/json-structs.arr
@@ -1,0 +1,58 @@
+provide *
+provide-types *
+
+import string-dict as SD
+
+data JSON:
+  | j-obj(dict :: SD.StringDict<JSON>) with:
+    native(self):
+      d = self.dict
+      ret = [SD.mutable-string-dict:]
+      for map(s from d.keys().to-list()):
+        ret.set-now(s, d.get-value(s).native())
+      end
+      ret.freeze()
+    end,
+    serialize(self):
+      d = self.dict
+      l = for map(s from d.keys().to-list()):
+        '"' + s + '": ' + d.get-value(s).serialize()
+      end
+      "{" + l.join-str(", ") + "}"
+    end
+  | j-arr(l :: List) with:
+    native(self):
+      self.l.map(lam(x): x.native() end)
+    end,
+    serialize(self):
+      "[" + self.l.map(lam(x): x.serialize() end).join-str(", ") + "]"
+    end
+  | j-num(n :: Number) with:
+    native(self):
+      self.n
+    end,
+    serialize(self):
+      tostring(self.n)
+    end
+  | j-str(s :: String) with:
+    native(self):
+      self.s
+    end,
+    serialize(self):
+      '"' + self.s + '"'
+    end
+  | j-bool(b :: Boolean) with:
+    native(self):
+      self.b
+    end,
+    serialize(self):
+      if self.b: "true" else: "false" end
+    end
+  | j-null with:
+    native(self):
+      nothing
+    end,
+    serialize(self):
+      "null"
+    end
+end

--- a/src/arr/trove/json-structs.arr
+++ b/src/arr/trove/json-structs.arr
@@ -32,7 +32,15 @@ data JSON:
       self.n
     end,
     serialize(self):
-      tostring(self.n)
+      # This feels like a pretty big hack.  All I want is to convert a
+      # roughnum (or a rational) as a JavaScript number, which just
+      # means cutting off the initial "~".
+      if num-is-roughnum(self.n) or num-is-rational(self.n):
+        s = num-to-string(num-to-roughnum(self.n))
+        string-substring(s, 1, string-length(s))
+      else:
+        num-to-string(self.n)
+      end
     end
   | j-str(s :: String) with:
     native(self):
@@ -55,4 +63,40 @@ data JSON:
     serialize(self):
       "null"
     end
+end
+
+fun tojson(v :: Any) -> JSON:
+  if is-number(v):
+    if num-is-fixnum(v) or num-is-roughnum(v):
+      j-num(v)
+    else:
+      raise("Number " + v + " cannot be converted to a JavaScript number.")
+    end
+  else if is-string(v):
+    j-str(v)
+  else if is-boolean(v):
+    j-bool(v)
+  else if is-nothing(v):
+    j-null
+  else if is-link(v) or is-empty(v):
+    j-arr(v.map(lam(x): tojson(x) end))
+  else if is-array(v):
+    j-arr(v.to-list-now().map(lam(x): tojson(x) end))
+  else if is-raw-array(v):
+    j-arr(raw-array-to-list(v).map(lam(x): tojson(x) end))
+  else if SD.is-string-dict(v):
+    ret = [SD.mutable-string-dict:]
+    for map(s from v.keys().to-list()):
+      ret.set-now(s, tojson(v.get-value(s)))
+    end
+    j-obj(ret.freeze())
+  else if SD.is-mutable-string-dict(v):
+    ret = [SD.mutable-string-dict:]
+    for map(s from v.keys-now().to-list()):
+      ret.set-now(s, tojson(v.get-value-now(s)))
+    end
+    j-obj(ret.freeze())
+  else:
+    raise("Value " + torepr(v) + " cannot be converted to a JSON expression.")
+  end
 end

--- a/src/js/trove/json.js
+++ b/src/js/trove/json.js
@@ -66,7 +66,8 @@ define(["js/runtime-util", "trove/string-dict", "trove/json-structs"], function(
             "is-j-str": gf(vals, "is-j-str"),
             "is-j-bool": gf(vals, "is-j-bool"),
             "is-j-null": gf(vals, "is-j-null"),
-            "read-json": RUNTIME.makeFunction(readJSON)
+            "read-json": RUNTIME.makeFunction(readJSON),
+            "tojson": gf(vals, "tojson")
           }),
           "types": {
             "JSON": typs["JSON"]

--- a/src/js/trove/json.js
+++ b/src/js/trove/json.js
@@ -1,0 +1,78 @@
+define(["js/runtime-util", "trove/string-dict", "trove/json-structs"], function(util, sDict, jsonStruct) {
+  return util.memoModule("json", function(RUNTIME, NAMESPACE) {
+    var gf = RUNTIME.getField;
+    return RUNTIME.loadModulesNew(NAMESPACE, [sDict, jsonStruct], function(sdict, jstruct) {
+      var vals = gf(jstruct, "values");
+      var typs = gf(jstruct, "types");
+      var sdvals = gf(sdict, "values");
+      function readJSON(s) {
+        RUNTIME.checkString(s);
+        RUNTIME.checkArity(1, arguments);
+        var jsVal = JSON.parse(s);
+        var jObj = gf(vals, "j-obj");
+        var jArr = gf(vals, "j-arr");
+        var jStr = gf(vals, "j-str");
+        var jNum = gf(vals, "j-num");
+        var jBool = gf(vals, "j-bool");
+        var jNull = gf(vals, "j-null");
+        var sdMake = gf(gf(sdvals, "string-dict"), "make");
+        var str = function(s) { return jStr.app(RUNTIME.makeString(s)); }
+        var num = function(n) { return jNum.app(RUNTIME.makeNumber(n)); }
+        var bool = function(b) { return jBool.app(RUNTIME.makeBoolean(b ? RUNTIME.pyretTrue : RUNTIME.pyretFalse)); }
+        var arr = function(a) { return jArr.app(RUNTIME.ffi.makeList(a)) }
+        var nul = function(v) { return jNull; }
+        function convert(v) {
+          if(v === null) {
+            return nul(v);
+          } else if(typeof v === "string") {
+            return str(v);
+          } else if (typeof v === "number") {
+            return num(v);
+          } else if (typeof v === "boolean") {
+            return bool(v);
+          } else if(Array.isArray(v)) {
+            return arr(v.map(convert));
+          } else if(typeof v === "object") {
+            var a = [];
+            for (var key in v) {
+              // Just to make sure no new-fangled Symbols made it through.
+              if(typeof key === "string") {
+                a.push(key);
+                a.push(convert(v[key]));
+              } else {
+                RUNTIME.ffi.throwMessageException("Invalid key " + v + " in JSON: " + s);
+              }
+            }
+            return jObj.app(sdMake.app(a));
+          } else {
+            RUNTIME.ffi.throwMessageException("Invalid JSON: " + s);
+          }
+        }
+        return convert(jsVal);
+      }
+      return RUNTIME.makeObject({
+        answer: RUNTIME.nothing,
+        "provide-plus-types": RUNTIME.makeObject({
+          "values": RUNTIME.makeObject({
+            "j-obj": gf(vals, "j-obj"),
+            "j-arr": gf(vals, "j-arr"),  
+            "j-num": gf(vals, "j-num"),
+            "j-str": gf(vals, "j-str"),
+            "j-bool": gf(vals, "j-bool"),
+            "j-null" : gf(vals, "j-null"),
+            "is-j-obj": gf(vals, "is-j-obj"),
+            "is-j-arr": gf(vals, "is-j-arr"),
+            "is-j-num": gf(vals, "is-j-num"),
+            "is-j-str": gf(vals, "is-j-str"),
+            "is-j-bool": gf(vals, "is-j-bool"),
+            "is-j-null": gf(vals, "is-j-null"),
+            "read-json": RUNTIME.makeFunction(readJSON)
+          }),
+          "types": {
+            "JSON": typs["JSON"]
+          }
+        })
+      });
+    });
+  });
+});

--- a/tests/pyret/main.arr
+++ b/tests/pyret/main.arr
@@ -10,6 +10,7 @@ import "./tests/test-array.arr" as _
 import "./tests/test-constructors.arr" as _
 import "./tests/test-contracts.arr" as _
 import "./tests/test-s-exp.arr" as _
+import "./tests/test-json.arr" as _
 import "./tests/test-refs.arr" as _
 import "./tests/test-equality.arr" as _
 import "./tests/test-refined-refs.arr" as _

--- a/tests/pyret/main2.arr
+++ b/tests/pyret/main2.arr
@@ -10,6 +10,7 @@ import file("./tests/test-array.arr") as _
 import file("./tests/test-constructors.arr") as _
 import file("./tests/test-contracts.arr") as _
 import file("./tests/test-s-exp.arr") as _
+import file("./tests/test-json.arr") as _
 import file("./tests/test-refs.arr") as _
 import file("./tests/test-equality.arr") as _
 import file("./tests/test-refined-refs.arr") as _

--- a/tests/pyret/tests/test-json.arr
+++ b/tests/pyret/tests/test-json.arr
@@ -33,6 +33,7 @@ check "native":
   n("false") satisfies is-boolean
   n("null") satisfies is-nothing
 
+  n("5.1") is%(within-abs(0.000001)) ~5.1
   n('{"foo": 1, "baz": true}') is
     [SD.string-dict: "foo", 1, "baz", true]
   n('[1,2,3]') is [list: 1, 2, 3]
@@ -45,6 +46,7 @@ check "serialize":
   s = lam(x): J.read-json(x).serialize() end
 
   s("0") is "0"
+  s('5.1') is '5.1'
   s('"a"') is '"a"'
   s("[]") is "[]"
   s("{}") is "{}"
@@ -58,4 +60,30 @@ check "serialize":
   s('[[[]]]') is '[[[]]]'
   s('[5, null, {"hello": "world"}]') is
     '[5, null, {"hello": "world"}]'
+end
+
+check "tojson":
+  J.tojson(0) is J.j-num(0)
+  J.tojson("a") is J.j-str("a")
+  J.tojson([list:]) is J.j-arr([list:])
+  J.tojson([SD.string-dict:]) is J.j-obj([SD.string-dict:])
+  J.tojson(true) is J.j-bool(true)
+  J.tojson(false) is J.j-bool(false)
+  J.tojson(nothing) is J.j-null
+
+  J.tojson([SD.string-dict: "foo", 1, "baz", true]) is
+    J.j-obj([SD.string-dict: "foo", J.j-num(1), "baz", J.j-bool(true)])
+  J.tojson([SD.mutable-string-dict: "foo", 1, "baz", true]) is
+    J.j-obj([SD.string-dict: "foo", J.j-num(1), "baz", J.j-bool(true)])
+  J.tojson([list: 1, 2, 3]) is
+    J.j-arr([list: J.j-num(1), J.j-num(2), J.j-num(3)])
+  J.tojson([list: [list: [list: ]]]) is
+    J.j-arr([list: J.j-arr([list: J.j-arr([list:])])])
+  J.tojson([list: 5, nothing, [SD.string-dict: "hello", "world"]]) is
+    J.j-arr([list: J.j-num(5), J.j-null,
+      J.j-obj([SD.string-dict: "hello", J.j-str("world")])])
+  J.tojson([raw-array: 1, 2, 3]) is
+    J.j-arr([list: J.j-num(1), J.j-num(2), J.j-num(3)])
+  J.tojson([array: 1, 2, 3]) is
+    J.j-arr([list: J.j-num(1), J.j-num(2), J.j-num(3)])
 end

--- a/tests/pyret/tests/test-json.arr
+++ b/tests/pyret/tests/test-json.arr
@@ -1,0 +1,61 @@
+import json as J
+import string-dict as SD
+
+check "conversion":
+  p = J.read-json
+  
+  p("0") satisfies J.is-j-num
+  p('"a"') satisfies J.is-j-str
+  p("[]") satisfies J.is-j-arr
+  p("{}") satisfies J.is-j-obj
+  p("true") satisfies J.is-j-bool
+  p("false") satisfies J.is-j-bool
+  p("null") satisfies J.is-j-null
+
+  p('{"foo": 1, "baz": true}') is
+    J.j-obj([SD.string-dict: "foo", J.j-num(1), "baz", J.j-bool(true)])
+  p('[1,2,3]') is J.j-arr([list: J.j-num(1), J.j-num(2), J.j-num(3)])
+  p('[[[]]]') is J.j-arr([list: J.j-arr([list: J.j-arr([list:])])])
+  p('[5, null, {"hello": "world"}]') is
+    J.j-arr([list: J.j-num(5), J.j-null,
+      J.j-obj([SD.string-dict: "hello", J.j-str("world")])])
+end
+
+check "native":
+  n = lam(x): J.read-json(x).native() end
+
+  n("0") satisfies is-number
+  n('"a"') satisfies is-string
+  n("[]") satisfies is-empty
+  # n("{}") satisfies SD.is-string-dict # apparently there's no is-string-dict?
+  n("{}") is [SD.string-dict:]
+  n("true") satisfies is-boolean
+  n("false") satisfies is-boolean
+  n("null") satisfies is-nothing
+
+  n('{"foo": 1, "baz": true}') is
+    [SD.string-dict: "foo", 1, "baz", true]
+  n('[1,2,3]') is [list: 1, 2, 3]
+  n('[[[]]]') is [list: [list: [list:]]]
+  n('[5, null, {"hello": "world"}]') is
+    [list: 5, nothing, [SD.string-dict: "hello", "world"]]
+end
+
+check "serialize":
+  s = lam(x): J.read-json(x).serialize() end
+
+  s("0") is "0"
+  s('"a"') is '"a"'
+  s("[]") is "[]"
+  s("{}") is "{}"
+  s("true") is "true"
+  s("false") is "false"
+  s("null") is "null"
+
+  s('{"foo": 1, "baz": true}') is
+    '{"baz": true, "foo": 1}' # should write better comparison for this
+  s('[1,2,3]') is '[1, 2, 3]'
+  s('[[[]]]') is '[[[]]]'
+  s('[5, null, {"hello": "world"}]') is
+    '[5, null, {"hello": "world"}]'
+end


### PR DESCRIPTION
This adds a JSON manipulation library for Pyret. There is an initial attempt at docs based off the docs for the s-exp library, but the JSON structs also have two methods defined on them, native and serialize, that convert the JSON structs to "native" Pyret values and to a JSON string, respectively. I'll be glad to add docs for those as well before this is merged if I'm pointed to a good example of the right way to do them within the docs directory.

(For earlier discussions, see #582.)