### PR TITLE
Move on_particle from Jsworld to particle module, use JSON for event data.

### DIFF
--- a/src/js/trove/particle.js
+++ b/src/js/trove/particle.js
@@ -56,9 +56,9 @@ define(["js/runtime-util", "js/ffi-helpers", "trove/json", "trove/world", "trove
                   evtSource = new EventSource("https://api.particle.io/v1/devices/events/?access_token=" + options.acc);
                   evtSource.addEventListener(eName,
                                              function(e) {
-                                               data = JSON.parse(e.data)
+                                               data = read_json(JSON.parse(e.data).data)
                                                rawJsworld.change_world(function(w,k) {
-                                                 handler(w, read_json(data.data), k);
+                                                 handler(w, data, k);
                                                }, rawJsworld.doNothing)});
                 },
                 onUnregister: function(top) {

--- a/src/js/trove/world-lib.js
+++ b/src/js/trove/world-lib.js
@@ -22,6 +22,8 @@ define(["js/runtime-util"], function(util) {
     var currentFocusedNode = false;
 
     var doNothing = function() {};
+    // Just in case external users need this and doNothing might change.
+    Jsworld.doNothing = doNothing;
 
     // forEachK: CPS( array CPS(array -> void) (error -> void) -> void )
     // Iterates through an array and applies f to each element using CPS
@@ -806,27 +808,6 @@ define(["js/runtime-util"], function(util) {
     }
     Jsworld.on_mouse = on_mouse;
 
-
-      function on_particle(handler, eName, options) {
-        return function() {
-            var evtSource;
-            return {
-                onRegister: function(top) {
-                    evtSource = new EventSource("https://api.particle.io/v1/devices/events/?access_token=" + options.acc);
-                    evtSource.addEventListener(eName,
-                                               function(e) {
-                                                   data = JSON.parse(e.data);
-                                                   change_world(function(w,k) {
-                                                       handler(w, JSON.stringify(data.data), k);
-                                                   }, doNothing)});
-                },
-                onUnregister: function(top) {
-                    evtSource.close();
-                }
-            };
-        };
-    }
-    Jsworld.on_particle = on_particle;
 
 
 


### PR DESCRIPTION
This continues the cleanup that puts all Particle-specific things in the `particle` module.  While I'm at it, now that the `json` module has hit horizon, I can use it as the data structure for representing Particle event data.