### PR TITLE
Export JS-compatible type checkers for immutable/mutable string-dicts.

### DIFF
--- a/src/js/trove/particle.js
+++ b/src/js/trove/particle.js
@@ -161,11 +161,7 @@ define(["js/runtime-util", "js/ffi-helpers", "trove/json", "trove/string-dict", 
             return ret;
           };
 
-          var is_string_dict = runtime.getField(
-            runtime.getField(sDict, "values"), "is-string-dict");
-          var checkStringDict = runtime.makeCheckType(function(val) {
-            return (is_string_dict.app(val) === runtime.pyretTrue) ? true : false;
-          }, "StringDict");
+          var checkStringDict = runtime.getField(sDict, "internal").checkISD;
 
           return makeObject({
             "provide": makeObject({

--- a/src/js/trove/string-dict.js
+++ b/src/js/trove/string-dict.js
@@ -497,9 +497,16 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
         return applyBrand(brandMutable, obj);
       }
 
+      function internal_isMSD(obj) {
+        return hasBrand(brandMutable, obj);
+      }
+
+      var jsCheckMSD =
+          runtime.makeCheckType(internal_isMSD, "MutableStringDict")
+
       function isMutableStringDict(obj) {
         arity(1, arguments, "is-mutable-string-dict")
-        return runtime.makeBoolean(hasBrand(brandMutable, obj))
+        return runtime.makeBoolean(internal_isMSD(obj))
       }
 
       function createMutableStringDict() {
@@ -525,9 +532,16 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
         return makeMutableStringDict(dict);
       }
 
+      function internal_isISD(obj) {
+        return hasBrand(brandImmutable, obj);
+      }
+
+      var jsCheckISD =
+          runtime.makeCheckType(internal_isISD, "StringDict")
+
       function isImmutableStringDict(obj) {
         arity(1, arguments, "is-immutable-string-dict")
-        return runtime.makeBoolean(hasBrand(brandImmutable, obj))
+        return runtime.makeBoolean(internal_isISD(obj))
       }
 
       function createImmutableStringDict() {
@@ -590,7 +604,11 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
             }),
             "string-dict-of": F(createConstImmutableStringDict),
             "is-string-dict": F(isImmutableStringDict)
-          })
+          }),
+          internal: {
+            checkISD: jsCheckISD,
+            checkMSD: jsCheckMSD
+          }
         }),
         "answer": runtime.nothing
       });


### PR DESCRIPTION
Instead of using the Pyret-facing versions of `is-string-dict` and `is-mutable-string-dict` in JS code, this commit instead exports type checking functions that are more appropriate for JS use.

Pretty simple, but still want a quick pass over it by either @jpolitz or @ds26gte just to be sure.