### PR TITLE
Fix typo in CLI arg retrieval; forward tail-call arg to compiler

### DIFF
--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -107,13 +107,14 @@ fun main(args):
         end
       else:
         if r.has-key("build"):
-          result = CLI.compile(r.get-value("compile"),
+          result = CLI.compile(r.get-value("build"),
             {
               check-mode : check-mode,
               type-check : type-check,
               allow-shadowed : allow-shadowed,
               collect-all: false,
-              ignore-unbound: false
+              ignore-unbound: false,
+              proper-tail-calls: tail-calls
             })
           failures = filter(CS.is-err, result)
           when is-link(failures):


### PR DESCRIPTION
I'm not sure if the --build option is even used much (compared to --compile-module-js), but it gave me trouble without these changes.

Also, it looks like pyret.arr and a few other places should be using `default-compile-options` from compiler-structs -- if that's the case, and if it'd be helpful, I can re-submit or make a new PR.