### PR TITLE
Add function for directly sending events to the Particle stream from Pyret.

### DIFF
--- a/src/js/trove/particle.js
+++ b/src/js/trove/particle.js
@@ -181,6 +181,16 @@ define(["js/runtime-util", "js/ffi-helpers", "trove/json", "trove/string-dict", 
                 var options = sd_to_js(sd);
                 return runtime.makeOpaque(new ToParticle(toEvent,eName,options));
               }),
+              // direct Particle stream access
+              "send-event": makeFunction(function(eName, eData, sd) {
+                ffi.checkArity(3, arguments, "send-event");
+                runtime.checkString(eName);
+                runtime.checkString(eData);
+                checkStringDict(sd);
+                var options = sd_to_js(sd);
+                sendEvent(eName, eData, options);
+                return ffi.makeNone();
+              }
               // core configuration
               "configure-core": makeFunction(function(config, sd) {
                 ffi.checkArity(2, arguments, "configure-core");


### PR DESCRIPTION
Not a big change, just exposing a Pyret function for calling the already factored-out function that handles sending events to the Pyret stream.  That is, a direct way, instead of having to go through the World teachpack to send events.