### PR TITLE
Use mutable string dicts for efficiency.

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -1441,6 +1441,7 @@ end
 fun import-key(i): AU.import-to-dep-anf(i).key() end
 
 fun compile-program(self, l, imports-in, prog, freevars, env):
+  shadow freevars = freevars.unfreeze()
   fun inst(id): j-app(j-id(id), [clist: RUNTIME, NAMESPACE]);
   imports = imports-in.sort-by(
       lam(i1, i2): import-key(i1.import-type) < import-key(i2.import-type)  end,

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -14,6 +14,7 @@ import srcloc as SL
 import sets as S
 
 string-dict = D.string-dict
+mutable-string-dict = D.mutable-string-dict
 
 type Loc = SL.Srcloc
 type CList = CL.ConcatList
@@ -1445,20 +1446,24 @@ fun compile-program(self, l, imports-in, prog, freevars, env):
       lam(i1, i2): import-key(i1.import-type) < import-key(i2.import-type)  end,
       lam(i1, i2): import-key(i1.import-type) == import-key(i2.import-type) end
     )
-  shadow freevars =
-    for fold(fv from freevars, i from imports):
-      fv.remove(i.vals-name.key()).remove(i.types-name.key())
-    end
-  import-keys = for fold(vt from {vs: [string-dict:], ts: [string-dict:]}, i from imports):
-    new-vals = for fold(vs from vt.vs, v from i.values):
-      vs.set(v.key(), v)
-    end
-    new-types = for fold(ts from vt.ts, t from i.types):
-      ts.set(t.key(), t)
-    end
-    { vs: new-vals, ts: new-types }
+
+  for each(i from imports):
+    freevars.remove-now(i.vals-name.key())
+    freevars.remove-now(i.types-name.key())
   end
-  free-ids = freevars.keys-list().map(freevars.get-value(_))
+
+  import-keys = {vs: [mutable-string-dict:], ts: [mutable-string-dict:]}
+
+  for each(i from imports):
+    for each(v from i.values):
+      import-keys.vs.set-now(v.key(), v)
+    end
+    for each(t from i.types):
+      import-keys.ts.set-now(t.key(), t)
+    end
+  end
+
+  free-ids = freevars.keys-list-now().map(freevars.get-value-now(_))
   module-and-global-binds = lists.partition(A.is-s-atom, free-ids)
   global-binds = for CL.map_list(n from module-and-global-binds.is-false):
     bind-name = cases(A.Name) n:
@@ -1470,9 +1475,9 @@ fun compile-program(self, l, imports-in, prog, freevars, env):
   module-binds = for CL.map_list(n from module-and-global-binds.is-true):
     bind-name = cases(A.Name) n:
       | s-atom(_, _) =>
-        if import-keys.vs.has-key(n.key()):
+        if import-keys.vs.has-key-now(n.key()):
           n.toname()
-        else if import-keys.ts.has-key(n.key()):
+        else if import-keys.ts.has-key-now(n.key()):
           type-name(n.toname())
         else:
           raise("Unaware of imported name: " + n.key())

--- a/src/arr/compiler/ast-anf.arr
+++ b/src/arr/compiler/ast-anf.arr
@@ -8,6 +8,7 @@ import srcloc as SL
 import string-dict as SD
 
 type NameDict = SD.MutableStringDict
+type FrozenNameDict = SD.StringDict
 
 empty-dict = SD.make-mutable-string-dict
 
@@ -756,8 +757,8 @@ fun freevars-e-acc(expr :: AExpr, seen-so-far :: NameDict<A.Name>) -> NameDict<A
   end
 end
 
-fun freevars-e(expr :: AExpr) -> NameDict<A.Name>:
-  freevars-e-acc(expr, empty-dict())
+fun freevars-e(expr :: AExpr) -> FrozenNameDict<A.Name>:
+  freevars-e-acc(expr, empty-dict()).freeze()
 where:
   d = dummy-loc
   n = A.global-names.make-atom
@@ -892,8 +893,8 @@ fun freevars-l-acc(e :: ALettable, seen-so-far :: NameDict<A.Name>) -> NameDict<
   end
 end
 
-fun freevars-l(e :: ALettable) -> NameDict<A.Name>:
-  freevars-l-acc(e, empty-dict())
+fun freevars-l(e :: ALettable) -> FrozenNameDict<A.Name>:
+  freevars-l-acc(e, empty-dict()).freeze()
 end
 
 fun freevars-v-acc(v :: AVal, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
@@ -916,20 +917,20 @@ fun freevars-v-acc(v :: AVal, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Nam
   end
 end
 
-fun freevars-v(v :: AVal) -> NameDict<A.Name>:
-  freevars-v-acc(v, empty-dict())
+fun freevars-v(v :: AVal) -> FrozenNameDict<A.Name>:
+  freevars-v-acc(v, empty-dict()).freeze()
 end
 
-fun freevars-prog(p :: AProg) -> NameDict<A.Name>:
+fun freevars-prog(p :: AProg) -> FrozenNameDict<A.Name>:
   cases(AProg) p:
     | a-program(l, _, imports, body) =>
-      body-vars = freevars-e(body)
+      body-vars = freevars-e-acc(body, empty-dict())
       for each(i from imports):
         for each(n from i.values + i.types):
           body-vars.remove-now(n.key())
         end
       end
-      body-vars
+      body-vars.freeze()
   end
 end
 

--- a/src/arr/compiler/ast-anf.arr
+++ b/src/arr/compiler/ast-anf.arr
@@ -746,7 +746,8 @@ fun freevars-e-acc(expr :: AExpr, seen-so-far :: NameDict<A.Name>) -> NameDict<A
       freevars-ann-acc(b.ann, freevars-l-acc(e, from-body))
     | a-var(_, b, e, body) =>
       from-body = freevars-e-acc(body, seen-so-far)
-      from-body.remove(b.id.key())
+      from-body.remove-now(b.id.key())
+      from-body
       freevars-ann-acc(b.ann, freevars-l-acc(e, from-body))
     | a-seq(_, e1, e2) =>
       from-e2 = freevars-e-acc(e2, seen-so-far)
@@ -788,8 +789,9 @@ fun freevars-branches-acc(branches :: List<ACasesBranch>, seen-so-far :: NameDic
       | a-cases-branch(_, _, _, args, body) =>
         from-body = freevars-e-acc(body, acc)
         shadow args = args.map(_.bind)
-        without-args = for fold(without from from-body, arg from args.map(get-id)):
-          without.remove(arg.key())
+        without-args = from-body 
+        for each(arg from args.map(get-id)):
+          without-args.remove-now(arg.key())
         end
         for fold(inner-acc from without-args, arg from args):
           freevars-ann-acc(arg.ann, inner-acc)

--- a/src/arr/compiler/ast-anf.arr
+++ b/src/arr/compiler/ast-anf.arr
@@ -7,7 +7,9 @@ import pprint as PP
 import srcloc as SL
 import string-dict as SD
 
-type StringDict = SD.StringDict
+type NameDict = SD.MutableStringDict
+
+empty-dict = SD.make-mutable-string-dict
 
 
 type Loc = SL.Srcloc
@@ -698,14 +700,18 @@ end
 
 rec get-ann = _.ann
 
-fun freevars-ann-acc(ann :: A.Ann, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-ann-acc(ann :: A.Ann, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   lst-a = freevars-list-acc(_, seen-so-far)
   cases(A.Ann) ann:
     | a-blank => seen-so-far
     | a-any => seen-so-far
-    | a-name(l, name) => seen-so-far.set(name.key(), name)
+    | a-name(l, name) => 
+      seen-so-far.set-now(name.key(), name)
+      seen-so-far
     | a-type-var(l, name) => seen-so-far
-    | a-dot(l, left, right) => seen-so-far.set(left.key(), left)
+    | a-dot(l, left, right) => 
+      seen-so-far.set-now(left.key(), left)
+      seen-so-far
     | a-arrow(l, args, ret, _) => lst-a(link(ret, args))
     | a-method(l, args, ret) => lst-a(link(ret, args))
     | a-record(l, fields) => lst-a(fields.map(get-ann))
@@ -716,26 +722,32 @@ fun freevars-ann-acc(ann :: A.Ann, seen-so-far :: StringDict<A.Name>) -> StringD
         | s-id(_, n) => n
         | s-id-letrec(_, n, _) => n
       end
-      freevars-ann-acc(a, seen-so-far.set(name.key(), name))
+      seen-so-far.set-now(name.key(), name)
+      freevars-ann-acc(a, seen-so-far)
   end
 end
 
-fun freevars-e-acc(expr :: AExpr, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-e-acc(expr :: AExpr, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   cases(AExpr) expr:
     | a-type-let(_, b, body) =>
       body-ids = freevars-e-acc(body, seen-so-far)
       cases(ATypeBind) b:
         | a-type-bind(_, name, ann) =>
-          freevars-ann-acc(ann, body-ids.remove(name.key()))
+          body-ids.remove-now(name.key())
+          freevars-ann-acc(ann, body-ids)
         | a-newtype-bind(_, name, nameb) =>
-          body-ids.remove(name.key()).remove(nameb.key())
+          body-ids.remove-now(name.key())
+          body-ids.remove-now(nameb.key())
+          body-ids
       end
     | a-let(_, b, e, body) =>
       from-body = freevars-e-acc(body, seen-so-far)
-      freevars-ann-acc(b.ann, freevars-l-acc(e, from-body.remove(b.id.key())))
+      from-body.remove-now(b.id.key())
+      freevars-ann-acc(b.ann, freevars-l-acc(e, from-body))
     | a-var(_, b, e, body) =>
       from-body = freevars-e-acc(body, seen-so-far)
-      freevars-ann-acc(b.ann, freevars-l-acc(e, from-body.remove(b.id.key())))
+      from-body.remove(b.id.key())
+      freevars-ann-acc(b.ann, freevars-l-acc(e, from-body))
     | a-seq(_, e1, e2) =>
       from-e2 = freevars-e-acc(e2, seen-so-far)
       freevars-l-acc(e1, from-e2)
@@ -743,8 +755,8 @@ fun freevars-e-acc(expr :: AExpr, seen-so-far :: StringDict<A.Name>) -> StringDi
   end
 end
 
-fun freevars-e(expr :: AExpr) -> StringDict<A.Name>:
-  freevars-e-acc(expr, empty-dict)
+fun freevars-e(expr :: AExpr) -> NameDict<A.Name>:
+  freevars-e-acc(expr, empty-dict())
 where:
   d = dummy-loc
   n = A.global-names.make-atom
@@ -755,7 +767,7 @@ where:
         a-lettable(d, a-val(d, a-id(d, y))))).keys().to-list() is [list: y.key()]
 end
 
-fun freevars-variant-acc(v :: AVariant, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-variant-acc(v :: AVariant, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   from-members = cases(AVariant) v:
     | a-variant(_, _, _, members, _) =>
       for fold(acc from seen-so-far, m from members):
@@ -770,7 +782,7 @@ end
 
 rec get-id = _.id
 
-fun freevars-branches-acc(branches :: List<ACasesBranch>, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-branches-acc(branches :: List<ACasesBranch>, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   for fold(acc from seen-so-far, b from branches):
     cases(ACasesBranch) b:
       | a-cases-branch(_, _, _, args, body) =>
@@ -787,7 +799,7 @@ fun freevars-branches-acc(branches :: List<ACasesBranch>, seen-so-far :: StringD
     end
   end
 end
-fun freevars-l-acc(e :: ALettable, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-l-acc(e :: ALettable, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   cases(ALettable) e:
     | a-module(_, ans, dv, dt, provs, types, checks) =>
       freevars-v-acc(ans,
@@ -805,7 +817,9 @@ fun freevars-l-acc(e :: ALettable, seen-so-far :: StringDict<A.Name>) -> StringD
       for fold(acc from seen-so-far, shadow v from vs):
         freevars-v-acc(v, acc)
       end
-    | a-assign(_, id, v) => freevars-v-acc(v, seen-so-far.set(id.key(), id))
+    | a-assign(_, id, v) => 
+      seen-so-far.set-now(id.key(), id)
+      freevars-v-acc(v, seen-so-far)
     | a-app(_, f, args) =>
       from-f = freevars-v-acc(f, seen-so-far)
       for fold(acc from from-f, arg from args):
@@ -822,18 +836,20 @@ fun freevars-l-acc(e :: ALettable, seen-so-far :: StringDict<A.Name>) -> StringD
       end
     | a-lam(_, args, ret, body) =>
       from-body = freevars-e-acc(body, seen-so-far)
-      without-args = for fold(without from from-body, arg from args.map(get-id)):
-          without.remove(arg.key())
-        end
+      without-args = from-body
+      for each(arg from args.map(get-id)):
+        without-args.remove-now(arg.key())
+      end
       from-args = for fold(acc from without-args, a from args):
         freevars-ann-acc(a.ann, acc)
       end
       freevars-ann-acc(ret, from-args)
     | a-method(_, args, ret, body) =>
       from-body = freevars-e-acc(body, seen-so-far)
-      without-args = for fold(without from from-body, arg from args.map(get-id)):
-          without.remove(arg.key())
-        end
+      without-args = from-body
+      for each(arg from args.map(get-id)):
+        without-args.remove-now(arg.key())
+      end
       from-args = for fold(acc from without-args, a from args):
         freevars-ann-acc(a.ann, acc)
       end
@@ -859,7 +875,8 @@ fun freevars-l-acc(e :: ALettable, seen-so-far :: StringDict<A.Name>) -> StringD
       from-shared = for fold(acc from from-variants, s from shared):
         freevars-v-acc(s.value, acc)
       end
-      from-shared.set(namet.key(), namet)
+      from-shared.set-now(namet.key(), namet)
+      from-shared
     | a-extend(_, supe, fields) =>
       from-supe = freevars-v-acc(supe, seen-so-far)
       for fold(acc from from-supe, f from fields):
@@ -873,15 +890,21 @@ fun freevars-l-acc(e :: ALettable, seen-so-far :: StringDict<A.Name>) -> StringD
   end
 end
 
-fun freevars-l(e :: ALettable) -> StringDict<A.Name>:
-  freevars-l-acc(e, empty-dict)
+fun freevars-l(e :: ALettable) -> NameDict<A.Name>:
+  freevars-l-acc(e, empty-dict())
 end
 
-fun freevars-v-acc(v :: AVal, seen-so-far :: StringDict<A.Name>) -> StringDict<A.Name>:
+fun freevars-v-acc(v :: AVal, seen-so-far :: NameDict<A.Name>) -> NameDict<A.Name>:
   cases(AVal) v:
-    | a-id(_, id) => seen-so-far.set(id.key(), id)
-    | a-id-var(_, id) => seen-so-far.set(id.key(), id)
-    | a-id-letrec(_, id, _) => seen-so-far.set(id.key(), id)
+    | a-id(_, id) => 
+      seen-so-far.set-now(id.key(), id)
+      seen-so-far
+    | a-id-var(_, id) => 
+      seen-so-far.set-now(id.key(), id)
+      seen-so-far
+    | a-id-letrec(_, id, _) => 
+      seen-so-far.set-now(id.key(), id)
+      seen-so-far
     | a-srcloc(_, _) => seen-so-far
     | a-num(_, _) => seen-so-far
     | a-str(_, _) => seen-so-far
@@ -891,21 +914,20 @@ fun freevars-v-acc(v :: AVal, seen-so-far :: StringDict<A.Name>) -> StringDict<A
   end
 end
 
-fun freevars-v(v :: AVal) -> StringDict<A.Name>:
-  freevars-v-acc(v, empty-dict)
+fun freevars-v(v :: AVal) -> NameDict<A.Name>:
+  freevars-v-acc(v, empty-dict())
 end
 
-fun freevars-prog(p :: AProg) -> StringDict<A.Name>:
+fun freevars-prog(p :: AProg) -> NameDict<A.Name>:
   cases(AProg) p:
     | a-program(l, _, imports, body) =>
       body-vars = freevars-e(body)
-      for fold(d from body-vars, i from imports):
-        for fold(shadow d from d, n from i.values + i.types):
-          d.remove(n.key())
+      for each(i from imports):
+        for each(n from i.values + i.types):
+          body-vars.remove-now(n.key())
         end
       end
+      body-vars
   end
 end
-
-rec empty-dict = [SD.string-dict:]
 

--- a/src/arr/compiler/ast-util.arr
+++ b/src/arr/compiler/ast-util.arr
@@ -854,7 +854,7 @@ fun get-named-provides(resolved :: CS.NameResolution, uri :: URI, compile-env ::
       cases(A.Provide) provide-complete:
         | s-provide-complete(_, values, aliases, datas) =>
           val-typs = SD.make-mutable-string-dict()
-          val-typs = for each(v from values):
+          for each(v from values):
             val-typs.set-now(v.v.toname(), ann-to-typ(v.ann))
           end
           alias-typs = SD.make-mutable-string-dict()

--- a/src/arr/compiler/js-dag-utils.arr
+++ b/src/arr/compiler/js-dag-utils.arr
@@ -259,12 +259,8 @@ fun used-vars-jfield(f :: J.JField) -> NameSet:
 end
 
 fun compute-live-vars(n :: GraphNode, dag :: D.StringDict<GraphNode>) -> NameSet:
-  #print('n!live-vars')
-  #print(n!live-vars)
   cases(Option) n!live-vars:
     | some(live) => 
-      #print('live: keys are...')
-      #print(live.keys-list())
       live
     | none =>
       live-after = copy-nameset(n!free-vars)
@@ -272,11 +268,7 @@ fun compute-live-vars(n :: GraphNode, dag :: D.StringDict<GraphNode>) -> NameSet
         next-opt = dag.get(tostring(follow.get()))
         when is-some(next-opt):
           next = next-opt.value
-          #print(gensym('***recur START_'))
           next-vars = compute-live-vars(next, dag)
-          #print(gensym('***recur  STOP_'))
-          #print('')
-
           live-after.merge-now(next-vars)
         end
       end
@@ -287,14 +279,6 @@ fun compute-live-vars(n :: GraphNode, dag :: D.StringDict<GraphNode>) -> NameSet
 
       n!{live-after-vars: some(live-after), live-vars: some(live),
         dead-after-vars: some(dead-after), dead-vars: some(dead)}
-
-      #print('!!!mutating the graph node')
-      #print('!!!new value of n!live-vars is...')
-      #print(some(live))
-      #print('!!!and if we unfreeze it right now, we get:')
-      #print(live.unfreeze().keys-list-now())
-      #print('***this call is returning an ISD with the following keys:')
-      #print(live.keys-list())
       live
   end
 end
@@ -417,7 +401,7 @@ end
 #   ranges
 # end
 fun simplify(body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAllocation:
-  # #print("Step 1: " + step + " num cases: " + tostring(body-cases.length()))
+  # print("Step 1: " + step + " num cases: " + tostring(body-cases.length()))
   acc-dag = D.make-mutable-string-dict()
   for CL.each(body-case from body-cases):
     when J.is-j-case(body-case):
@@ -427,7 +411,7 @@ fun simplify(body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAlloc
     end
   end
   dag = acc-dag.freeze()
-  # #print("Step 2")
+  # print("Step 2")
   labels = for CL.foldr(acc from empty, body-case from body-cases):
     if J.is-j-case(body-case): link(body-case.exp.label.get(), acc)
     else: acc
@@ -436,10 +420,10 @@ fun simplify(body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAlloc
   str-labels = dag.keys-list()
   # for each(lbl from labels):
   #   n = dag.get-value(lbl)
-  #   #print(tostring(n._from.get()) + " ==> " + tostring(n._to.to-list().map(_.get())))
-  #   #print("\n" + n.case-body.to-ugly-source())
+  #   print(tostring(n._from.get()) + " ==> " + tostring(n._to.to-list().map(_.get())))
+  #   print("\n" + n.case-body.to-ugly-source())
   # end
-  # #print("Step 3")
+  # print("Step 3")
   for each(lbl from str-labels):
     n = dag.get-value(lbl)
     n!{decl-vars: declared-vars-jcase(n.case-body)}
@@ -452,16 +436,16 @@ fun simplify(body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAlloc
   end
   # for each(lbl from str-labels):
   #   n = dag.get-value(lbl)
-  #   #print("Used vars for " + lbl + ": " + torepr(n!used-vars))
-  #   #print("Decl vars for " + lbl + ": " + torepr(n!decl-vars.to-list()))
-  #   #print("Free vars for " + lbl + ": " + torepr(n!free-vars))
-  #   #print("Live-after vars for " + lbl + ": " + torepr(n!live-after-vars.value.to-list()))
-  #   #print("Live vars for " + lbl + ": " + torepr(n!live-vars.value.to-list()))
-  #   #print("Dead vars for " + lbl + ": " + torepr(n!dead-vars.value.to-list()))
-  #   #print("Dead-after vars for " + lbl + ": " + torepr(n!dead-after-vars.value.to-list()))
-  #   #print("\n")
+  #   print("Used vars for " + lbl + ": " + torepr(n!used-vars))
+  #   print("Decl vars for " + lbl + ": " + torepr(n!decl-vars.to-list()))
+  #   print("Free vars for " + lbl + ": " + torepr(n!free-vars))
+  #   print("Live-after vars for " + lbl + ": " + torepr(n!live-after-vars.value.to-list()))
+  #   print("Live vars for " + lbl + ": " + torepr(n!live-vars.value.to-list()))
+  #   print("Dead vars for " + lbl + ": " + torepr(n!dead-vars.value.to-list()))
+  #   print("Dead-after vars for " + lbl + ": " + torepr(n!dead-after-vars.value.to-list()))
+  #   print("\n")
   # end
-  # #print("Step 4")
+  # print("Step 4")
   # live-ranges = D.make-mutable-string-dict()
   # for each(lbl from labels):
   #   n = dag.get-value(lbl)
@@ -487,6 +471,6 @@ fun simplify(body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAlloc
     end
   end
   
-  # #print("Done")
+  # print("Done")
   results(dead-assignment-eliminated, discardable-vars)
 end

--- a/src/js/trove/string-dict.js
+++ b/src/js/trove/string-dict.js
@@ -58,6 +58,7 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
             "get-now": t.arrow([t.string], t.tyapp(t.libName("option", "Option"), [t.tyvar("a")])),
             "get-value-now": t.arrow([t.string], t.tyvar("a")),
             "set-now": t.arrow([t.string, t.tyvar("a")], t.nothing),
+            "merge-now": t.arrow([msdOfA], t.nothing),
             "remove-now": t.arrow([t.string], t.nothing),
             "keys-now": t.arrow([], t.tyapp(t.libName("sets", "TreeSet"), [t.string])),
             "keys-list-now": t.arrow([], t.tyapp(t.libName("lists", "List"), [t.string])),
@@ -342,6 +343,19 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
           return runtime.nothing;
         });
 
+        var mergeMSD = runtime.makeMethod1(function(self, other) {
+          if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw runtime.ffi.throwArityErrorC(["merge-now"], 2, $a); }
+          checkMSD(other);
+          var otherKeys = runtime.getField(other, "keys-list-now").app();
+          var otherKeysArr = runtime.ffi.toArray(otherKeys);
+          for(var i = 0; i < otherKeysArr.length; i++) {
+            var key = otherKeysArr[i];
+            var val = runtime.getField(other, "get-value-now").app(key);
+            runtime.getField(self, "set-now").app(key, val);
+          }
+          return runtime.nothing;
+        });
+
         var removeMSD = runtime.makeMethod1(function(self, key) {
           if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw runtime.ffi.throwArityErrorC(["remove-now"], 2, $a); }
           if (sealed) {
@@ -486,6 +500,7 @@ define(["js/runtime-util", "js/type-util", "js/namespace", "js/ffi-helpers", "tr
           'get-now': getMSD,
           'get-value-now': getValueMSD,
           'set-now': setMSD,
+          'merge-now': mergeMSD,
           'remove-now': removeMSD,
           'keys-now': keysMSD,
           'keys-list-now': keysListMSD,

--- a/tests/pyret/tests/test-string-dict.arr
+++ b/tests/pyret/tests/test-string-dict.arr
@@ -204,3 +204,34 @@ check "predicates":
   SD.is-mutable-string-dict(1) is false
   SD.is-string-dict(1) is false
 end
+
+check "merge-now":
+  s1 = [SD.mutable-string-dict: "a", 5, "c", 4]
+  s2 = [SD.mutable-string-dict: "a", 10, "b", 6]
+
+  isd9 = s1.freeze()
+  isd10 = s2.freeze()
+
+  s1.merge-now(s2) is nothing
+  s1 is=~ [SD.mutable-string-dict: "a", 10, "b", 6, "c", 4]
+
+  orig-s1 = isd9.unfreeze()
+  s2.merge-now(orig-s1) is nothing
+  s2 is=~ [SD.mutable-string-dict: "a", 5, "b", 6, "c", 4]
+
+  isd9.keys-list()  is%(one-of) [list: [list: "a", "c"], [list: "c", "a"]]
+  isd10.keys-list() is%(one-of) [list: [list: "a", "b"], [list: "b", "a"]]
+
+  orig-s2 = isd10.unfreeze()
+  new-s1 = orig-s1
+  new-s1.merge-now(orig-s2) is nothing
+  new-s1 is=~ [SD.mutable-string-dict: "a", 10, "b", 6, "c", 4]
+
+  s4 = [SD.mutable-string-dict: "a", 5]
+  s5 = [SD.mutable-string-dict:]
+  s4.merge-now(s5) is nothing
+  s4 is=~ [SD.mutable-string-dict: "a", 5]
+  s5.merge-now(s4) is nothing
+  s5 is=~ [SD.mutable-string-dict: "a", 5]
+end
+


### PR DESCRIPTION
### What changes?
* A `.merge-now` method added to `string-dict.js`, which mutates the object, and returns `Nothing`.
* Tests of `merge-now` added to test-string-dict.arr
* Four (4) files in `src/arr/compiler/` overhauled to use mutable string dicts in contexts involving collecting sets of identifiers. In particular, many uses of the `.merge` method for immutable string-dicts are replaced by the new `.merge-now`.

### Why merge this PR?
Efficiency. In larger programs, time spent allocating all the new objects is a waste. To show the speedup, below present the results from `ast.arr` and `anf-loop-compiler.arr` (as currently on horizon), using [these profiling tools](https://github.com/awstlaur/pyret-lang/tree/horizon/tools/profiling). In summary, `ast.arr` saw a roughly 50 (fifty) percent speedup, `anf-loop-compiler` saw a roughly 30 (thirty) percent speedup at the calls to `runEvalPyret`. Smaller, more trivial programs saw no significant speedup.

### Data
These files are in [callgrind format](http://valgrind.org/docs/manual/cl-format.html), and can thus be (visually) inspected with a tool like [kcachegrind](http://kcachegrind.sourceforge.net/). For more details on how these data were obtained, see the README [in the profiling tools](https://github.com/awstlaur/pyret-lang/tree/horizon/tools/profiling)
* [ast.arr: before the changes](http://cs.brown.edu/~awstlaur/pub/ast.BEFORE.profile)
* [ast.arr: after the changes](http://cs.brown.edu/~awstlaur/pub/ast.AFTER.profile)
* [anf-loop-compiler: before](http://cs.brown.edu/~awstlaur/pub/anf-loop-compiler.BEFORE.profile)
* [anf-loop-compiler: after](http://cs.brown.edu/~awstlaur/pub/anf-loop-compiler.AFTER.profile)

### Sanity check
* `make test` passes
* `make no-diff-standalone` passes