### PR TITLE
Added Matrix Library

### DIFF
--- a/docs/written/libraries.scrbl
+++ b/docs/written/libraries.scrbl
@@ -20,6 +20,7 @@ This section contains information on libraries that come with Pyret.
 @include-section["trove/world.js.rkt"]
 @;@include-section["trove/plot.js.rkt"]
 @;@include-section["trove/graph.js.rkt"]
+@include-section["trove/matrices.scrbl"]
 
 @include-section["trove/srcloc.js.rkt"]
 @include-section["trove/pprint.js.rkt"]

--- a/docs/written/trove/matrices.scrbl
+++ b/docs/written/trove/matrices.scrbl
@@ -1,0 +1,1183 @@
+#lang scribble/base
+@(require "../../scribble-api.rkt"
+          (except-in "../abbrevs.rkt" L-of))
+@(require (only-in scribble/core delayed-block)
+          (only-in scribble/manual math))
+
+@; Adapted from http://con.racket-lang.org/2011/pr-slides.pdf
+@; by Prabhakar Ragde
+@(require scribble/html-properties
+         scribble/base
+         scribble/core
+         (prefix-in net: net/url))
+ 
+@(provide mathjax-style math-in math-disp $ $$)
+ 
+@(define mathjax-source
+@(net:string->url "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"))
+
+@(define mathjax-style
+    (style #f (list (js-addition mathjax-source))))
+@(define (mymath start end . strs)
+@(make-element (make-style "relax" '(exact-chars)) `(,start ,@strs ,end)))
+ 
+@(define (math-in . strs)
+@(apply mymath "\\(" "\\)" strs))
+ 
+@(define (math-disp . strs)
+@(apply mymath "\\[" "\\]" strs))
+
+@; Creates a LaTeX inline environment
+@(define (math-in-env name . strs)
+@(apply mymath (string-append "\\(\\begin{" name "}") (string-append "\\end{" name "}\\)") strs))
+
+@; Creates a LaTeX environment
+@(define (math-disp-env name . strs)
+@(apply mymath (string-append "\\[\\begin{" name "}") (string-append "\\end{" name "}\\]") strs))
+
+@; Creates a Displayed Matrix
+@(define (math-mtx . strs)
+@(apply math-disp-env (cons "bmatrix" strs)))
+
+@; Creates an Inlined Matrix
+@(define (math-imtx . strs)
+@(apply mymath "\\(\\left[\\begin{smallmatrix}" "\\end{smallmatrix}\\right]\\)" strs))
+ 
+@(define $ math-in)
+@(define $$ math-disp) 
+
+
+
+
+@(define (matrix-method name #:args (args #f) #:return (return #f) #:contract (contract #f))
+  (method-doc "Matrix" "matrix" name #:alt-docstrings "" #:args args #:return return #:contract contract))
+
+@(define mtx-type (a-id "Matrix" (xref "matrices" "Matrix")))
+@(define vec-type (a-id "Vector" (xref "matrices" "Vector")))
+@(define (L-of typ) `(a-app (a-id "List" (xref "lists" "List")) ,typ))
+
+@(append-gen-docs
+  `(module "matrices"
+    (path "src/js/base/runtime-anf.js")
+    (fun-spec
+      (name "is-matrix")
+      (args ("val"))
+      (arity 1)
+      (return ,B)
+      (contract (a-arrow ,A ,B)))
+    (fun-spec
+      (name "vector")
+      (arity 1)
+      (args ("elts"))
+      (return ,vec-type)
+      (contract (a-arrow (a-id "Number..." (xref "<globals>" "Number")) ,vec-type)))
+    (fun-spec
+      (name "dot")
+      (arity 2)
+      (args ("left" "right"))
+      (return ,N)
+      (contract (a-arrow ,vec-type ,vec-type ,N)))
+    (fun-spec
+      (name "cross")
+      (arity 2)
+      (args ("v" "w"))
+      (return ,vec-type)
+      (contract (a-arrow ,vec-type ,vec-type ,vec-type)))
+    (fun-spec
+      (name "vector-add")
+      (arity 2)
+      (args ("left" "right"))
+      (return ,vec-type)
+      (contract (a-arrow ,vec-type ,vec-type ,vec-type)))
+    (fun-spec
+      (name "vector-sub")
+      (arity 2)
+      (args ("left" "right"))
+      (return ,vec-type)
+      (contract (a-arrow ,vec-type ,vec-type ,vec-type)))
+    (fun-spec
+      (name "magnitude")
+      (arity 1)
+      (args ("vec"))
+      (return ,N)
+      (contract (a-arrow ,vec-type ,N)))
+    (fun-spec
+      (name "normalize")
+      (arity 1)
+      (args ("vec"))
+      (return ,vec-type)
+      (contract (a-arrow ,vec-type ,vec-type)))
+    (fun-spec
+      (name "scale")
+      (arity 2)
+      (args ("vec" "factor"))
+      (return ,vec-type)
+      (contract (a-arrow ,vec-type ,N ,vec-type)))
+    (fun-spec
+      (name "is-row-matrix")
+      (arity 1)
+      (args ("mtx"))
+      (return ,B)
+      (contract (a-arrow ,mtx-type ,B)))
+    (fun-spec
+      (name "is-col-matrix")
+      (arity 1)
+      (args ("mtx"))
+      (return ,B)
+      (contract (a-arrow ,mtx-type ,B)))
+    (fun-spec
+      (name "is-square-matrix")
+      (arity 1)
+      (args ("mtx"))
+      (return ,B)
+      (contract (a-arrow ,mtx-type ,B)))
+    (fun-spec
+      (name "identity-matrix")
+      (arity 1)
+      (args ("n"))
+      (return ,mtx-type)
+      (contract (a-arrow ,N ,mtx-type)))
+    (fun-spec
+      (name "make-matrix")
+      (arity 3)
+      (args ("rows" "cols" "elt"))
+      (return ,mtx-type)
+      (contract (a-arrow ,N ,N ,N ,mtx-type)))
+    (fun-spec
+      (name "build-matrix")
+      (arity 3)
+      (args ("rows" "cols" "proc"))
+      (return ,mtx-type)
+      (contract (a-arrow ,N ,N (a-arrow ,N ,N ,N) ,mtx-type)))
+    (fun-spec
+      (name "vector-to-matrix")
+      (arity 1)
+      (args ("v"))
+      (return ,mtx-type)
+      (contract (a-arrow ,vec-type ,mtx-type)))
+    (fun-spec
+      (name "list-to-matrix")
+      (arity 3)
+      (args ("rows" "cols" "lst"))
+      (return ,mtx-type)
+      (contract (a-arrow ,N ,N (a-app (a-id "List" (xref "lists" "List")) ,N) ,mtx-type)))
+    (fun-spec
+      (name "list-to-row-matrix")
+      (arity 1)
+      (args ("lst"))
+      (return ,mtx-type)
+      (contract (a-arrow (a-app (a-id "List" (xref "lists" "List")) ,N) ,mtx-type)))
+    (fun-spec
+      (name "list-to-col-matrix")
+      (arity 1)
+      (args ("lst"))
+      (return ,mtx-type)
+      (contract (a-arrow (a-app (a-id "List" (xref "lists" "List")) ,N) ,mtx-type)))
+    (fun-spec
+      (name "lists-to-matrix")
+      (arity 1)
+      (args ("lst"))
+      (return ,mtx-type)
+      (contract (a-arrow (a-app (a-id "List" (xref "lists" "List")) ,N) ,mtx-type)))
+    (fun-spec
+      (name "vectors-to-matrix")
+      (arity 1)
+      (args ("lst"))
+      (return ,mtx-type)
+      (contract (a-arrow (a-app (a-id "List" (xref "lists" "List")) ,vec-type) ,mtx-type)))
+    (fun-spec
+      (name "matrix-within")
+      (arity 1)
+      (args ("delta"))
+      (return (a-arrow ,mtx-type ,mtx-type ,B))
+      (contract (a-arrow ,N (a-arrow ,mtx-type ,mtx-type ,B))))
+    (data-spec
+      (name "Vector"))
+    (data-spec
+      (name "Matrix")
+      (variants ("matrix"))
+      (constr-spec
+        (name "matrix")
+        (members
+          (("rows" (type normal) (contract N))
+           ("cols" (type normal) (contract N))
+           ("elts" (type normal) (contract RA))))
+        (with-members (
+          (method-spec 
+            (name "rc-to-index")
+            (arity 3)
+            (args ("self" "i" "j"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N ,N ,N)))
+          (method-spec 
+            (name "get")
+            (arity 3)
+            (args ("self" "i" "j"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N ,N ,N)))
+          (method-spec 
+            (name "to-list")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of N))
+            (contract (a-arrow ,mtx-type ,(L-of N))))
+          (method-spec 
+            (name "to-vector")
+            (arity 1)
+            (args ("self"))
+            (return ,vec-type)
+            (contract (a-arrow ,mtx-type ,vec-type)))
+          (method-spec 
+            (name "to-lists")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of (L-of N)))
+            (contract (a-arrow ,mtx-type ,(L-of (L-of N)))))
+          (method-spec 
+            (name "to-vectors")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of vec-type))
+            (contract (a-arrow ,mtx-type ,(L-of vec-type))))
+          (method-spec 
+            (name "row")
+            (arity 2)
+            (args ("self" "i"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,N ,mtx-type)))
+          (method-spec 
+            (name "col")
+            (arity 2)
+            (args ("self" "j"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,N ,mtx-type)))
+          (method-spec 
+            (name "submatrix")
+            (arity 3)
+            (args ("self" "loi" "loj"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,(L-of N) ,(L-of N) ,mtx-type)))
+          (method-spec 
+            (name "transpose")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "diagonal")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "upper-triangle")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "lower-triangle")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "row-list")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of mtx-type))
+            (contract (a-arrow ,mtx-type ,(L-of mtx-type))))
+          (method-spec 
+            (name "col-list")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of mtx-type))
+            (contract (a-arrow ,mtx-type ,(L-of mtx-type))))
+          (method-spec 
+            (name "map")
+            (arity 2)
+            (args ("self" "func"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type (a-arrow ,N ,N) ,mtx-type)))
+          (method-spec 
+            (name "row-map")
+            (arity 2)
+            (args ("self" "func"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type (a-arrow ,mtx-type ,mtx-type) ,mtx-type)))
+          (method-spec 
+            (name "col-map")
+            (arity 2)
+            (args ("self" "func"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type (a-arrow ,mtx-type ,mtx-type) ,mtx-type)))
+          (method-spec 
+            (name "augment")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "stack")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "trace")
+            (arity 1)
+            (args ("self"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N)))
+          (method-spec 
+            (name "scale")
+            (arity 2)
+            (args ("self" "factor"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,N ,mtx-type)))
+          (method-spec 
+            (name "dot")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,mtx-type ,N)))
+          (method-spec 
+            (name "_plus")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "_minus")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "_times")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "expt")
+            (arity 2)
+            (args ("self" "power"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,N ,mtx-type)))
+          (method-spec 
+            (name "determinant")
+            (arity 1)
+            (args ("self"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N)))
+          (method-spec 
+            (name "is-invertible")
+            (arity 1)
+            (args ("self"))
+            (return ,B)
+            (contract (a-arrow ,mtx-type ,B)))
+          (method-spec 
+            (name "rref")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "inverse")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "solve")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "least-squares-solve")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "lp-norm")
+            (arity 2)
+            (args ("self" "power"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N ,mtx-type)))
+          (method-spec 
+            (name "l1-norm")
+            (arity 1)
+            (args ("self"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N)))
+          (method-spec 
+            (name "l2-norm")
+            (arity 1)
+            (args ("self"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N)))
+          (method-spec 
+            (name "l-inf-norm")
+            (arity 1)
+            (args ("self"))
+            (return ,N)
+            (contract (a-arrow ,mtx-type ,N)))
+          (method-spec 
+            (name "qr-decomposition")
+            (arity 1)
+            (args ("self"))
+            (return ,(L-of mtx-type))
+            (contract (a-arrow ,mtx-type ,(L-of mtx-type))))
+          (method-spec 
+            (name "gram-schmidt")
+            (arity 1)
+            (args ("self"))
+            (return ,mtx-type)
+            (contract (a-arrow ,mtx-type ,mtx-type)))
+          (method-spec 
+            (name "_torepr")
+            (arity 1)
+            (args ("self"))
+            (return ,S)
+            (contract (a-arrow ,mtx-type ,S)))
+          (method-spec 
+            (name "equalTo") ;TODO: Get rid of camelCase
+            (arity 2)
+            (args ("self" "other"))
+            (return ,B)
+            (contract (a-arrow ,mtx-type ,mtx-type ,B)))
+          (method-spec 
+            (name "_equals")
+            (arity 2)
+            (args ("self" "other"))
+            (return ,B)
+            (contract (a-arrow ,mtx-type ,mtx-type ,B)))
+          ))))))
+
+@docmodule["matrices"]{
+@section{The Vector Datatype}
+
+@type-spec["Vector" '()]
+
+The @pyret{Vector} type represents mathematical vectors. The datatype is equivalent to that of a @pyret{list} of numbers.
+
+@section{The @pyret{vector} Constructor}
+@collection-doc["vector" #:contract `(a-arrow ("elt" ,N) ,vec-type)]
+
+Vector constructor which works in an identical manner to the @pyret{list} constructor.
+@para{@bold{WARNING:} Matrix rows and columns are @bold{1-indexed}.}
+
+@section[#:style mathjax-style]{The Matrix Datatype}
+@data-spec["Matrix" (list
+  @constructor-spec["Matrix" "matrix" (list `("rows" ("type" "normal") ("contract" ,N))
+                                          `("cols" ("type" "normal") ("contract" ,N))
+                                          `("elts" ("type" "normal") ("contract" ,RA)))])]
+
+  The internal representation of matrices is not exposed, but, for reference, it is provided here.
+
+  @nested[#:style 'inset]{
+  @constructor-doc["Matrix" "matrix" (list `("rows" ("type" "normal") ("contract" ,N))
+                                           `("cols" ("type" "normal") ("contract" ,N))
+                                           `("elts" ("type" "normal") ("contract" ,RA)))
+                                     (a-id "Matrix" (xref "matrices" "Matrix"))]{
+  }
+
+  @function["is-matrix" #:alt-docstrings ""]
+
+  }
+
+@section{Matrix Constructors}
+
+@collection-doc["matrix(rows,cols)" #:contract `(a-arrow ("elt" ,N) ,mtx-type)]
+
+Publicly exposed constructor which constructs a matrix of size 
+@pyret{rows} by @pyret{cols} with the given elements, entered row by row.
+
+The following example represents the matrix @math-imtx{1 & 2 & 3 \\ 4 & 5 & 6}:
+
+@examples{
+[matrix(2,3): 1, 2, 3, 4, 5, 6]
+}
+
+@collection-doc["row-matrix" #:contract `(a-arrow ("elt" ,N) ,mtx-type)]
+
+Constructor which returns a one-row matrix containing the given entries.
+
+The following will construct the matrix @math-imtx{1 & 2 & 3}:
+
+@examples{
+check:
+  [row-matrix: 1, 2, 3] is [matrix(1,3): 1, 2, 3]
+end
+}
+
+@collection-doc["col-matrix" #:contract `(a-arrow ("elt" ,N) ,mtx-type)]
+
+Constructor which returns a one-column matrix containing the given entries.
+
+The following will construct the matrix @math-imtx{1 \\ 2 \\ 3}:
+
+@examples{
+check:
+  [col-matrix: 1, 2, 3] is [matrix(3,1): 1, 2, 3]
+end
+}
+
+@function["identity-matrix"]
+
+Constructs an @pyret{n}@math-in{\times}@pyret{n} identity matrix.
+
+@examples{
+check:
+  identity-matrix(2) is [matrix(2,2): 1, 0, 0, 1]
+  identity-matrix(3) is [matrix(3,3): 1, 0, 0, 0, 1, 0, 0, 0, 1]
+end
+}
+
+@function["make-matrix"]
+
+Constructs a matrix of the given size using only the given element.
+
+@examples{
+check:
+  make-matrix(2, 3, 1) is [matrix(2,3): 1, 1, 1, 1, 1, 1]
+  make-matrix(3, 2, 5) is [matrix(3,2): 5, 5, 5, 5, 5, 5]
+end
+}
+
+@function["build-matrix"]
+
+Constructs a matrix of the given size, where entry @math{(i,j)} is the result of @pyret{proc(i,j)}.
+
+@examples{
+check:
+  build-matrix(2, 3, lam(i,j): i + j end) is [matrix(3,2): 0, 1, 1, 2, 2, 3]
+end
+}
+
+@section{Matrix Methods}
+
+These methods are available on all matrices.
+
+@matrix-method["get"]
+
+Returns the matrix's entry in the @math{i^th} row and the @math{j^th} column.
+
+@examples{
+check:
+  [matrix(3,2): 1, 2, 3, 4, 5, 6].get(2,2) is 4
+  [matrix(3,2): 1, 2, 3, 4, 5, 6].get(3,1) is 5
+end
+}
+
+@matrix-method["to-list"]
+
+Returns the matrix as a list of numbers (this is just the internal
+@pyret{RawArray} representation written as a list).
+
+For example, given the matrix @math-imtx{2 & 4 & 6 \\ 8 & 10 & 12 \\ 14 & 16 & 18}:
+
+@examples{
+check:
+  [matrix(3,3): 2, 4, 6, 8, 10, 12, 14, 16, 18].to-list() is
+  [list: 2, 4, 6, 8, 10, 12, 14, 16, 18]
+end
+}
+
+@matrix-method["to-vector"]
+
+Returns a one-row/one-column matrix as a vector.
+
+@examples{
+check:
+  [matrix(2,1): 4, 5].to-vector() is [vector: 4, 5]
+  [matrix(1,2): 4, 5].to-vector() is [matrix(2,1): 4, 5].to-vector()
+end
+}
+
+@matrix-method["to-lists"]
+
+Returns the matrix as a list of lists of numbers, with each list
+corresponding to one row.
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].to-lists() is
+  [list: [list: 1, 2, 3],
+         [list: 4, 5, 6]]
+end
+}
+
+@matrix-method["to-vectors"]
+
+Returns the matrix as a list of lists of numbers (i.e. a list of @pyret{Vector}s), 
+with each list corresponding to one column.
+
+For example, the matrix @math-imtx{1 & 2 & 3 \\ 4 & 5 & 6} corresponds to the
+vectors @math-imtx{1 \\ 4}, @math-imtx{2 \\ 5}, and @math-imtx{3 \\ 6}: 
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].to-vectors() is
+  [list: [list: 1, 4],
+         [list: 2, 5],
+         [list: 3, 6]]
+end
+}
+
+@matrix-method["row"]
+
+Returns a one-row matrix with the matrix's given row.
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].row(2) is
+  [matrix(1,3): 4, 5, 6]
+
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].row(3) is
+  [matrix(1,3): 7, 8, 9]
+end
+}
+
+@matrix-method["col"]
+
+Returns a one-column matrix with the matrix's given column.
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].col(2) is
+  [matrix(2,1): 2, 5]
+
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].col(3) is
+  [matrix(3,1): 3, 6, 9]
+end
+}
+
+@matrix-method["submatrix"]
+
+Returns the submatrix of the matrix comprised of the intersection
+of the given list of rows and the given list of columns.
+
+For example, if our list of rows is @math-in{\{1, 2\}} and our
+list of columns is @math-in{\{2, 3\}}, then the positions in the
+resulting submatrix will be the elements with @math-in{(row,col)} positions
+@math-in{\{(1, 2), (1, 3), (2, 2), (2, 3)\}}.
+
+@math-in{
+\left[\begin{matrix} 
+            a_{11} & a_{12} & a_{13} \\
+            a_{21} & a_{22} & a_{23} \\
+            a_{31} & a_{32} & a_{33}
+            \end{matrix}\right]}@pyret{.submatrix([list: 1, 2], [list: 2, 3])}
+                                     @math-in{=
+\left[\begin{matrix}
+a_{12} & a_{13} \\
+a_{22} & a_{23}\end{matrix}\right]}
+
+This is shown in the below example:
+
+@examples{
+check:
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].submatrix([list: 1, 2], [list: 2, 3]) is
+  [matrix(2,2): 2, 3, 4, 5]
+end
+}
+
+@matrix-method["transpose"]
+
+Returns the transposition of the matrix. For example,
+@math-disp{\begin{bmatrix}1 & 2 & 3 \\ 4 & 5 & 6\end{bmatrix}
+                 \overrightarrow{Transpose}
+                 \begin{bmatrix}1 & 4 \\ 2 & 5 \\ 3 & 6\end{bmatrix}}
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].transpose() is
+  [matrix(3,2): 1, 4, 2, 5, 3, 6]
+end
+}
+
+@matrix-method["diagonal"]
+
+Returns a one-row matrix containing the matrix's diagonal entries.
+
+@examples{
+check:
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].diagonal() is
+  [matrix(1,3): 1, 5, 9]
+
+  [matrix(3,2): 1, 2, 3, 4, 5, 6].diagonal() is
+  [matrix(1,2): 1, 5]
+end
+}
+
+@matrix-method["upper-triangle"]
+
+Returns the upper triangle of the matrix, if the matrix is square.
+For example, the upper triangle of @math-imtx{1 & 2 & 3\\ 4 & 5 & 6\\ 7 & 8 & 9}
+would be @math-imtx{1 & 2 & 3\\ 0 & 5 & 6 \\ 0 & 0 & 9}.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4].upper-triangle() is [matrix(2,2): 1, 2, 0 ,4]
+
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].upper-triangle() is
+  [matrix(3,3): 1, 2, 3, 0, 5, 6, 0, 0, 9]
+end
+}
+
+@matrix-method["lower-triangle"]
+
+Returns the lower triangle of the matrix, if the matrix is square.
+For example, the upper triangle of @math-imtx{1 & 2 & 3\\ 4 & 5 & 6\\ 7 & 8 & 9}
+would be @math-imtx{1 & 0 & 0\\ 4 & 5 & 0\\ 7 & 8 & 9}.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4].lower-triangle() is [matrix(2,2): 1, 0, 3, 4]
+
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].lower-triangle() is
+  [matrix(3,3): 1, 0, 0, 4, 5, 0, 7, 8, 9]
+end
+}
+
+@matrix-method["row-list"]
+
+Returns the matrix as a list of one-row matrices.
+(Very similar to @pyret{to-lists()}, except this method
+returns a list of matrices instead.
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].row-list() is
+  [list: [matrix(1,3): 1, 2, 3],
+         [matrix(1,3): 4, 5, 6]]
+end
+}
+
+@matrix-method["col-list"]
+
+Returns the matrix as a list of one-column matrices.
+(Very similar to @pyret{to-vectors()}, except this method
+returns a list of matrices instead.
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].col-list() is
+  [list: [matrix(2,1): 1, 4],
+         [matrix(2,1): 2, 5],
+         [matrix(2,1): 3, 6]]
+end
+}
+
+@matrix-method["map"]
+
+Maps the given function entrywise over the matrix.
+
+@examples{
+check:
+  multTwo = lam(x): x * 2 end
+  [matrix(2,2): 1, 2, 3, 4].map(multTwo) is
+  [matrix(2,2): 2, 4, 6, 8]
+end
+}
+
+@matrix-method["row-map"]
+
+Maps the given function over each row in the matrix.
+
+@examples{
+check:
+  # sumRow :: 1*n matrix
+  # Computes the total sum of all entries in the given row
+  sumRow = lam(row): [matrix(1,1): row.to-vector().foldr(_ + _)] end
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].row-map(sumRow) is
+  [matrix(2,1): 6, 15]
+end
+}
+
+@matrix-method["col-map"]
+
+Maps the given function over each column in the matrix.
+
+@examples{
+check:
+  # sumCol :: m*1 matrix
+  # Computes the total sum of all entries in the given column
+  sumCol = lam(col): [matrix(1,1): col.to-vector().foldr(_ + _)] end
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].col-map(sumCol) is
+  [matrix(1,3): 5, 7, 9]
+end
+}
+
+@matrix-method["augment"]
+
+Returns the matrix augmented with the given matrix. For
+example, augmenting the matrix @math-imtx{1 & 2\\4 & 5} with
+the matrix @math-imtx{3\\ 6} yields the matrix
+@math-imtx{1 & 2 & 3\\ 4 & 5 & 6}.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 4, 5].augment([matrix(2,1): 3, 6]) is
+  [matrix(2,3): 1, 2, 3, 4, 5, 6]
+end
+}
+
+@matrix-method["stack"]
+
+Returns the matrix stacked on top of the given matrix. For
+example, stacking the matrix @math-imtx{1 & 2 & 3} on top of
+the matrix @math-imtx{4 & 5 & 6} gives the matrix
+@math-imtx{1 & 2 & 3\\ 4 & 5 & 6}.
+
+@examples{
+check:
+  [matrix(1,3): 1, 2, 3].stack([matrix(1,3): 4, 5, 6]) is
+  [matrix(2,3): 1, 2, 3, 4, 5, 6]
+end
+}
+
+@matrix-method["trace"]
+
+Returns the trace of the matrix (i.e. the sum of its diagonal values).
+
+@examples{
+check:
+  [matrix(3,3): 1, 2, 3, 4, 5, 6, 7, 8, 9].trace() is 15
+  [matrix(2,2): 2, 4, 6, 8].trace() is 10
+end
+}
+
+@matrix-method["scale"]
+
+Multiplies each entry in the matrix by the given value.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4].scale(2) is 
+  [matrix(2,2): 2, 4, 6, 8]
+
+  [matrix(2,2): 2, 4, 6, 8].scale(1/2) is
+  [matrix(2,2): 1, 2, 3, 4]
+end
+}
+
+@matrix-method["dot"]
+
+Returns the Frobenius Product of the matrix with the given matrix (for
+1-dimensional matrices, this is simply the dot product). This is done by
+multiplying the matrix with the transposition of @pyret{other} and taking
+the trace of the result. An example of this calculation (@math-in{\ast} 
+denotes matrix multiplication):
+
+@math-in{\left(\left[\begin{smallmatrix}1 & 2 & 3\end{smallmatrix}\right]
+\ast\left[\begin{smallmatrix}4\\ 2\\ ^4/_3 \end{smallmatrix}\right]\right)}@pyret{.trace()}
+@math-in{=
+\underbrace{\left[\begin{smallmatrix}(1\cdot 4)+(2\cdot 2)+(3\cdot \frac{4}{3})\end{smallmatrix}\right]}_{
+1\times 1 \text{ matrix}}}@pyret{.trace()}@math-in{=12}
+
+@examples{
+check:
+  [matrix(1,3): 1, 2, 3].dot([matrix(1,3): 4, 2, 4/3]) is 12
+  [matrix(1,3): 1, 2, 3].dot([matrix(1,3): 1, 1, 1]) is 6
+end
+}
+
+@matrix-method["expt"]
+
+Multiplies the matrix by itself the given number of times.
+
+@examples{
+check:
+  a = [matrix(2,2): 1, 2, 3, 4]
+  a.expt(1) is a
+  a.expt(2) is a * a
+  a.expt(3) is a * a * a
+end
+}
+
+@matrix-method["determinant"]
+
+Returns the determinant of the matrix, calculated via a recursive
+implementation of laplace expansion.
+
+@examples{
+check:
+  [matrix(5,5): 1, 2, 1, 2, 3,
+                2, 3, 1, 0, 1,
+                2, 2, 1, 0, 0,
+                1, 1, 1, 1, 1,
+                0,-2, 0,-2,-2].determinant() is -2
+end
+}
+
+@matrix-method["is-invertible"]
+
+Returns true if the matrix is invertible (i.e. it has a nonzero determinant).
+
+@matrix-method["rref"]
+
+Returns the Reduced Row Echelon Form of the matrix. For example:
+@math-disp{\begin{bmatrix}1 & 2 & 3 \\ 4 & 5 & 6\end{bmatrix}
+                 \overrightarrow{RREF}
+                 \begin{bmatrix}1 & 0 & -1\\ 0 & 1 & 2\end{bmatrix}}
+
+@examples{
+check:
+  [matrix(2,3): 1, 2, 3, 4, 5, 6].rref() is
+  [matrix(2,3): 1, 0,-1, 0, 1, 2]
+end
+}
+
+@matrix-method["inverse"]
+
+Returns the inverse of the matrix, if it is invertible (found
+by augmenting the matrix with itself and finding the reduced-row
+echelon form). For example:
+@math-disp{\begin{bmatrix}1 & 0 & 4\\ 1 & 1 & 6\\ -3 & 0 & -10\end{bmatrix}^{-1}
+                 = \begin{bmatrix}-5 & 0 & -2\\ -4 & 1 & -1\\ ^3/_2 & 0 & ^1/_2\end{bmatrix}}
+
+@examples{
+check:
+  [mk-mtx(3,3): 1, 0, 4, 1, 1, 6, -3, 0, -10].inverse() is 
+  [mk-mtx(3,3): -5, 0, -2, -4, 1, -1, 3/2, 0, 1/2]
+end
+}
+
+@matrix-method["solve"]
+
+Returns the matrix which, when multiplied on the right of this matrix, results in the given matrix.
+In other words, this returns the solution to the system of equations represented by this and the given matrix.
+This method only works on invertible matrices (Calculated by inverting itself and multiplying the given
+matrix on the right side of this inverse).
+
+@matrix-method["least-squares-solve"]
+
+Returns the least squares solution for this and the given matrix, calculated using QR decomposition.
+
+@matrix-method["lp-norm"]
+
+Computes the @math{L^p} norm of the matrix using the given number.
+
+@matrix-method["l1-norm"]
+@matrix-method["l2-norm"]
+@matrix-method["l-inf-norm"]
+
+Computes the @math{L^1}, @math{L^2}, and @math{L}@superscript{∞} norms of the matrix, respectively.
+
+@examples{
+check:
+  a = [matrix(3,1): 1, 2, 3]
+  b = [matrix(3,3): 1, 0, 0, 2, 0, 0, 3, 0, 0]
+
+  a.lp-norm(3) is-within(0.00001) num-expt(35, 1/3)
+  b.lp-norm(3) is-within(0.00001) (b * a).lp-norm(3)
+
+  a.l1-norm()  is-within(0.00001) 6
+  a.l2-norm()  is-within(0.00001) num-sqrt(14)
+  a.l-inf-norm() is 3
+end
+}
+
+@matrix-method["qr-decomposition"]
+
+Returns the QR Decomposition of the matrix as a list with two matricies, the first being
+the Q matrix and the second being the R matrix.
+
+@matrix-method["gram-schmidt"]
+
+Returns an orthogonal matrix whose image is the same as the span of the matrix's columns.
+(The same as the first result of @pyret{qr-decomposition})
+
+@section{@pyret{Matrix} Binary Operations}
+
+The following binary operations on matrices are defined:
+
+@matrix-method["_plus"]
+
+Adds the matrix to the given matrix.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4] + [matrix(2,2): 1, 2, 3, 4] is
+  [matrix(2,2): 2, 4, 6, 8]
+end
+}
+
+@matrix-method["_minus"]
+
+Subtracts the given matrix from the matrix.
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4] - [matrix(2,2): 0, 2, 3, 3] is
+  [matrix(2,2): 1, 0, 0, 1]
+end
+}
+
+@matrix-method["_times"]
+
+Multiplies the given matrix on the right of the matrix
+(Reminder: Matrix Multiplication is not commutative)
+
+@examples{
+check:
+  [matrix(2,2): 1, 2, 3, 4] * [matrix(2,2): 3, 0, 0, 3] is
+  [matrix(2,2): 3, 6, 9, 12]
+end
+}
+
+@section{Matrix and Vector Functions}
+
+The following functions are defined for matrices and vectors:
+
+@function[
+  "dot"
+  #:examples
+  '@{
+  check:
+    dot([vector: 1, 2, 3], [vector: 3, 2, 1]) is 10
+  end
+  }
+]{Returns the dot product of the two given vectors.}
+
+@function[
+  "magnitude"
+  #:examples
+  '@{
+  check:
+    magnitude([vector: 3, 4]) is 5
+    magnitude([vector: 4, 0]) is 4
+  end
+  }
+]{Returns the magnitude of the given vector.}
+
+@function[
+  "cross"
+  #:examples
+  '@{
+  check:
+    cross([vector: 2, -3, 1], [vector: -2, 1, 1]) is [vector: -4, -4, -4]
+  end
+  }
+]{Returns the cross product of the two given 3D vectors.}
+
+@function[
+  "normalize"
+  #:examples
+  '@{
+  check:
+    normalize([vector: 1, 2, 3]) is 
+    [vector: (1 / num-sqrt(14)), (2 / num-sqrt(14)), (3 / num-sqrt(14))]
+  end
+  }
+]{Normalizes the given vector into a unit vector.}
+
+@function[
+  "scale"
+  #:examples
+  '@{
+  check:
+    scale([vector: 1, 2, 3], 2) is [vector: 2, 4, 6]
+  end
+  }
+]{Scales the given vector by the given constant.}
+
+@function[
+  "vector-add"
+  #:examples
+  '@{
+  check:
+    vector-add([vector: 1, 2, 3], [vector: 4, 5, 6]) is [vector: 5, 7, 9]
+  end
+  }
+]{Adds the two given vectors.}
+
+@function[
+  "vector-sub"
+  #:examples
+  '@{
+  check:
+    vector-sub([vector: 1, 2, 3], [vector: 4, 5, 6]) is [vector: -3, -3, -3]
+  end
+  }
+]{Subtracts the two given vectors.}
+
+@function["is-row-matrix"]{Returns true if the given matrix has exactly one row.}
+@function["is-col-matrix"]{Returns true if the given matrix has exactly one column.}
+@function["is-square-matrix"]{Returns true if the given matrix has the same number of rows and columns.}
+@function[
+  "vector-to-matrix"
+  #:examples
+  '@{
+  check:
+    vector-to-matrix([vector: 1, 2, 3]) is [matrix(1,3): 1, 2, 3]
+  end
+  }
+]{Converts the given vector into a one-row matrix.}
+
+@function[
+  "list-to-matrix"
+  #:examples
+  '@{
+  check:
+    list-to-matrix(2, 2, [list: 1, 2, 3, 4]) is 
+    [matrix(2,2): 1, 2, 3, 4]
+    
+    list-to-matrix(2, 3, [list: 1, 2, 3, 4, 5, 6]) is 
+    [matrix(2,3): 1, 2, 3, 4, 5, 6]
+  end
+  }
+]{Converts the given list of numbers into a matrix of the given size.}
+
+@function[
+  "list-to-row-matrix"
+  #:examples
+  '@{
+  check:
+    list-to-row-matrix([list: 1, 2, 3, 4]) is [matrix(1,4): 1, 2, 3, 4]
+  end
+  }
+]{Converts the given list of numbers into a one-row matrix.}
+
+@function[
+  "list-to-col-matrix"
+  #:examples
+  '@{
+  check:
+    list-to-col-matrix([list: 1, 2, 3, 4]) is [matrix(4,1): 1, 2, 3, 4]
+  end
+  }
+]{Converts the given list of numbers into a one-column matrix.}
+
+@function[
+  "lists-to-matrix"
+  #:examples
+  '@{
+  check:
+    lists-to-matrix([list: [list: 1, 2, 3, 4]]) is [matrix(1,4): 1, 2, 3, 4]
+    lists-to-matrix([list: [list: 1, 2, 3],
+                           [list: 4, 5, 6]]) is [matrix(2,3): 1, 2, 3, 4, 5, 6]
+  end
+  }
+]{Converts the given list of lists into a matrix, with each list as a row.}
+
+@function[
+  "vectors-to-matrix"
+  #:examples
+  '@{
+  check:
+    vectors-to-matrix([list: [vector: 1, 2, 3]]) is [matrix(3,1): 1, 2, 3]
+    vectors-to-matrix([list: [vector: 1, 3, 5], [vector: 2, 4, 6]]) is
+    [matrix(3,2): 1, 2, 3, 4, 5, 6]
+  end
+  }
+]{Converts the given list of vectors into a matrix, with each vector as a column.}
+
+@function["matrix-within"]{Returns a comparison predicate which returns true if each entry in both matrices is within @pyret{delta} of each other.}
+  
+}

--- a/src/arr/compiler/initialize-trove.arr
+++ b/src/arr/compiler/initialize-trove.arr
@@ -35,3 +35,4 @@ import plot as _
 import graph as _
 import particle as _
 import json as _
+import matrices as _

--- a/src/arr/trove/matrices.arr
+++ b/src/arr/trove/matrices.arr
@@ -1,0 +1,995 @@
+### PYRET MATRIX LIBRARY
+### Maintained by (i.e.
+### Blame all issues on):
+### Philip Blair
+###   - Github: belph
+###   - Email : peblairman@gmail.com
+
+### Last Modified: 17 Jan 2015
+
+### The following is a matrix library which
+###   has been heavily influenced by the Racket
+###   Linear Algebra functionality (however, all
+###   code was done from scratch).
+
+### For individual function documentation, see
+###   the appropriate doc strings.
+
+### DATA REPRESENTATION
+### A Vector is simply a list of numbers,
+###   which correspond to the vector's components.
+### A Matrix is a custom data structure with
+###   three accessors:
+###   Matrix.rows = (Number)
+###                 The number of rows
+###                     in the matrix
+###   Matrix.cols = (Number)
+###                 The number of columns
+###                     in the matrix
+###   Matrix.elts = (RawArray)
+###                 The elements of the matrix
+
+### The rest should be relatively
+###   straightforward, given the doc strings
+###   and example checks.
+
+provide {
+  matrix: mk-mtx,
+  vector: vector,
+  is-matrix: is-matrix,
+  dot: dot,
+  cross: cross,
+  vector-add: vector-add,
+  vector-sub: vector-sub,
+  magnitude: magnitude,
+  normalize: normalize,
+  scale: scale,
+  is-row-matrix: is-row-matrix,
+  is-col-matrix: is-col-matrix,
+  is-square-matrix: is-square-matrix,
+  identity-matrix: identity-matrix,
+  make-matrix: make-matrix,
+  build-matrix: build-matrix,
+  vector-to-matrix: vector-to-matrix,
+  list-to-matrix: list-to-matrix,
+  list-to-row-matrix: list-to-row-matrix,
+  list-to-col-matrix: list-to-col-matrix,
+  lists-to-matrix: lists-to-matrix,
+  vectors-to-matrix: vectors-to-matrix,
+  matrix-within: matrix-within,
+  row-matrix: row-matrix,
+  col-matrix: col-matrix
+} end
+provide-types {
+  Vector :: Vector,
+  Matrix :: Matrix
+}
+
+import Equal,NotEqual from equality
+import lists as L
+
+fun nonzeronat(n :: Number): num-is-integer(n) and (n > 0) end
+fun nat(n :: Number): num-is-integer(n) and (n >= 0) end
+
+type Vector = List<Number>
+vector = list
+length3 = lam(v :: Vector): v.length() == 3 end
+type Vector3D = Vector%(length3)
+type NonZeroNat = Number%(nonzeronat)
+type Nat = Number%(nat)
+
+fun dot( v :: Vector, w :: Vector) -> Number:
+  for fold2(acc from 0,  v-elt from v, w-elt from w):
+    (v-elt * w-elt) + acc
+  end
+end
+
+fun magnitude(v :: Vector) -> Number:
+  doc: "Returns the magnitude of the given vector"
+  sqrsum = lam(acc,cur): acc + num-sqr(cur) end
+  num-sqrt(fold(sqrsum,0,v))
+where:
+  magnitude([vector: 1, 2, 3]) is%(within(0.001)) num-sqrt(14)
+end
+
+fun cross(v :: Vector3D, w :: Vector3D) -> Vector3D:
+  doc: "Returns the cross product of the two given 3D vectors"
+  [vector: ((v.get(1) * w.get(2)) - (v.get(2) * w.get(1))),
+    ((v.get(2) * w.get(0)) - (v.get(0) * w.get(2))),
+    ((v.get(0) * w.get(1)) - (v.get(1) * w.get(0)))]
+where:
+  cross([vector: 2, -3, 1], [vector: -2, 1, 1]) is [vector: -4, -4, -4]
+end
+
+fun normalize(v :: Vector) -> Vector:
+  doc: "Normalizes the given vector into a unit vector"
+  m = magnitude(v)
+  v.map(_ / m)
+where:
+  fun vec-within(v :: Vector, w :: Vector) -> Boolean:
+    L.all2(within(0.001), v, w)
+  end
+  normalize([vector: 1, 2, 3]) is%(vec-within) [vector: (1 / num-sqrt(14)), (2 / num-sqrt(14)), (3 / num-sqrt(14))]
+end
+
+fun scale(v :: Vector, k :: Number) -> Vector:
+  doc: "Scales the vector by the given constant"
+  v.map(_ * k)
+end
+
+fun vector-add(v :: Vector, w :: Vector) -> Vector:
+  doc: "Adds the two given vectors"
+  when not(v.length() == w.length()):
+    raise("Cannot add vectors of different lengths")
+  end
+  for map2(v-elt from v, w-elt from w):
+    v-elt + w-elt
+  end
+end
+
+fun vector-sub(v :: Vector, w :: Vector) -> Vector:
+  doc: "Subtracts the two given vectors"
+  when not(v.length() == w.length()):
+    raise("Cannot subtract vectors of different lengths")
+  end
+  for map2(v-elt from v, w-elt from w):
+    v-elt - w-elt
+  end
+end
+
+fun is-row-matrix(mtx :: Matrix):
+  doc: "Returns true if the given matrix has exactly one row"
+  mtx.rows == 1
+end
+
+fun is-col-matrix(mtx :: Matrix):
+  doc: "Returns true if the given matrix has exactly one column"
+  mtx.cols == 1
+end
+
+fun is-square-matrix(mtx :: Matrix):
+  doc: "Returns true if the given matrix has the same number of rows and columns"
+  mtx.rows == mtx.cols
+end
+
+fun make-raw-array-fold2(start1, start2, stride1, stride2, stop1, stop2):
+  doc: "RawArray fold2 Implementation with striding ability"
+  lam(f, base, arr1, arr2):
+    len1 = num-min(raw-array-length(arr1), stop1)
+    len2 = num-min(raw-array-length(arr2), stop2)
+    fun help(acc, idx1, idx2):
+      if (idx1 > len1) or (idx2 > len2): acc
+      else:
+        help(f(acc, raw-array-get(arr1, idx1), raw-array-get(arr2, idx2)), idx1 + stride1, idx2 + stride2)
+      end
+    end
+    help(base, start1, start2)
+  end
+end
+
+fun rc-to-index-with-col-size(row :: Nat, col :: Nat, m-cols :: Nat):
+  (row * m-cols) + col
+end
+
+fun raw-array-duplicate(arr :: RawArray) -> RawArray:
+  # Enables pass-by-value behavior
+  doc: "Returns a new copy of the given array"
+  ret = raw-array-of(0,raw-array-length(arr))
+  for each(i from range(0,raw-array-length(arr))):
+    raw-array-set(ret,i,raw-array-get(arr,i))
+  end
+  ret
+where:
+  a = [raw-array: 1, 2, 3]
+  # Assign by value
+  b = raw-array-duplicate(a)
+  # Assign by reference
+  c = a
+  a is=~ b
+  a is=~ c
+  raw-array-set(a,0,7)
+  # Values now differ
+  a is-not=~ b
+  # Reference has new value
+  a is=~ c
+end
+
+fun list-to-raw-array(lst :: List) -> RawArray:
+  doc: "Converts the given list into a RawArray"
+  raw-arr = raw-array-of(0, lst.length())
+  for each(i from range(0, lst.length())):
+    raw-array-set(raw-arr,i,lst.get(i))
+  end
+  raw-arr
+where:
+  list-to-raw-array([list: 1, 2, 3]) is=~ [raw-array: 1, 2, 3]
+end
+
+fun rc-to-index(mtx, row, col):
+  doc: "Returns the RawArray index corresponding to the given row and column"
+  (row * mtx.cols) + col
+end
+
+data Matrix:
+  | matrix(rows :: NonZeroNat, cols :: NonZeroNat, elts :: RawArray)
+    with:
+    get(self, i :: Number, j :: Number) -> Number:
+      doc: "Returns the matrix's entry in the i'th row and j'th column"
+      raw-array-get(self.elts,rc-to-index(self, i,j))
+    end,
+    
+    to-list(self) -> List<Number>:
+      doc: "Returns the matrix as a list of numbers"
+      raw-array-to-list(self.elts)
+    end,
+    
+    to-vector(self) -> Vector:
+      doc: "Returns the one-row/one-column matrix as a vector"
+      if (self.cols == 1):
+        self.transpose().to-list()
+      else if (self.rows == 1):
+        self.to-list()
+      else:
+        raise("Cannot convert non-vector matrix to vector")
+      end
+    end,
+    
+    to-lists(self) -> List<List<Number>>:
+      doc: "Returns the matrix as a list of lists of numbers, with each list corresponding to a row"
+      self.row-list().map(lam(r): r.to-vector() end)
+    end,
+    
+    to-vectors(self) -> List<Vector>:
+      doc: "Returns the matrix a a list of vectors, with each vector corresponding to a column"
+      self.col-list().map(lam(c): c.to-vector() end)
+    end,
+    
+    row(self, i :: Number) -> Matrix:
+      doc: "Returns a one-row matrix with the matrix's i'th row"
+      raw-arr = raw-array-of(0, self.cols)
+      for each(n from range(0, self.cols)):
+        raw-array-set(raw-arr, n, raw-array-get(self.elts, rc-to-index(self,i,n)))
+      end
+      matrix(1, self.cols, raw-arr)
+    end,
+    col(self, j :: Number) -> Matrix:
+      doc: "Returns a one-column matrix with the matrix's j'th column"
+      raw-arr = raw-array-of(0, self.rows)
+      for each(n from range(0, self.rows)):
+        raw-array-set(raw-arr, n, raw-array-get(self.elts, rc-to-index(self,n,j)))
+      end
+      matrix(self.rows, 1, raw-arr)
+    end,
+    
+    submatrix(self, loi :: List<Number>, loj :: List<Number>) -> Matrix:
+      doc: "Returns the matrix's submatrix, containing the rows in the first list and the columns in the second"
+      loil = loi.length()
+      lojl = loj.length()
+      raw-arr = raw-array-of(0, (loil * lojl))
+      # Loops manually unwrapped to avoid excessive allocations
+      fun fetch-row(r :: Number):
+        when r < loil:
+          n = loi.get(r)
+          fun fetch-cols(c :: Number):
+            when c < lojl:
+              colnum = loj.get(c)
+              raw-array-set(raw-arr, (r * lojl) + c, 
+                raw-array-get(self.elts, rc-to-index(self,n,colnum)))
+              fetch-cols(c + 1)
+            end
+          end
+          fetch-cols(0)
+          fetch-row(r + 1)
+        end
+      end
+      fetch-row(0)
+      matrix(loil, lojl, raw-arr)
+    end,
+    
+    transpose(self) -> Matrix:
+      doc: "Returns the matrix's transpose"
+      raw-arr = raw-array-of(0, (self.rows * self.cols))
+      fun set-row(r :: Number):
+        when r < self.cols:
+          fun set-col(c :: Number):
+            when c < self.rows:
+              raw-array-set(raw-arr, rc-to-index-with-col-size(r,c,self.rows), 
+                raw-array-get(self.elts, rc-to-index(self,c,r)))
+              set-col(c + 1)
+            end
+          end
+          set-col(0)
+          set-row(r + 1)
+        end
+      end
+      set-row(0)
+      matrix(self.cols, self.rows, raw-arr)
+    end,
+    
+    diagonal(self) -> Matrix:
+      doc: "Returns a one-row matrix with the matrix's diagonal entries"
+      num-diag = num-min(self.rows, self.cols)
+      raw-arr = raw-array-of(0, num-diag)
+      fun fetch-diag(n :: Number):
+        when n < num-diag:
+          raw-array-set(raw-arr, n,
+            raw-array-get(self.elts, rc-to-index(self,n,n)))
+          fetch-diag(n + 1)
+        end
+      end
+      fetch-diag(0)
+      matrix(1, num-diag, raw-arr)
+    end,
+    
+    upper-triangle(self) -> Matrix:
+      doc: "Returns the upper triangle of the matrix"
+      if not(is-square-matrix(self)):
+        raise("Cannot make a non-square upper-triangular matrix")
+      else:
+        raw-arr = raw-array-of(0,(self.rows * self.cols))
+        fun set-row(r :: Number):
+          when r < self.rows:
+            fun set-col(nonzeros :: Number, on-col :: Number):
+              when nonzeros > 0:
+                raw-array-set(raw-arr, rc-to-index(self,r,on-col),
+                  raw-array-get(self.elts, rc-to-index(self,r,on-col)))
+                set-col(nonzeros - 1, on-col - 1)
+              end
+            end
+            set-col((self.rows - r), self.cols - 1)
+            set-row(r + 1)
+          end
+        end
+        set-row(0)
+        matrix(self.rows, self.cols, raw-arr)
+      end
+    end,
+    
+    lower-triangle(self) -> Matrix:
+      doc: "Returns the lower triangle of the matrix"
+      if not(is-square-matrix(self)):
+        raise("Cannot make a non-square lower-triangular matrix")
+      else:
+        raw-arr = raw-array-of(0,(self.rows * self.cols))
+        fun set-row(r :: Number):
+          when r < self.rows:
+            fun set-col(nonzeros :: Number, on-col :: Number):
+              when nonzeros > 0:
+                raw-array-set(raw-arr, rc-to-index(self,r,on-col),
+                  raw-array-get(self.elts, rc-to-index(self,r,on-col)))
+                set-col(nonzeros - 1, on-col + 1)
+              end
+            end
+            set-col((r + 1), 0)
+            set-row(r + 1)
+          end
+        end
+        set-row(0)
+        matrix(self.rows, self.cols, raw-arr)
+      end
+    end,
+    
+    row-list(self) -> List<Matrix>:
+      doc: "Returns the matrix as a list of one-row matrices"
+      for map(i from range(0, self.rows)):
+        self.row(i)
+      end
+    end,
+    
+    col-list(self) -> List<Matrix>:
+      doc: "Returns the matrix as a list of one-column matrices"
+      for map(i from range(0, self.cols)):
+        self.col(i)
+      end
+    end,
+    
+    map(self, func):
+      doc: "Maps the given function over each entry in the matrix"
+      self-len = raw-array-length(self.elts)
+      raw-arr = raw-array-of(0, self-len)
+      for each(i from range(0,self-len)):
+        raw-array-set(raw-arr, i, func(raw-array-get(self.elts, i)))
+      end
+      matrix(self.rows, self.cols, raw-arr)
+    end,
+    
+    row-map(self, func :: (Matrix -> Matrix)):
+      doc: "Maps the given function over each row in the matrix"
+      to-stack = self.row-list().map(func)
+      for fold(acc from to-stack.get(0), cur from to-stack.rest):
+        acc.stack(cur)
+      end
+    end,
+    
+    col-map(self, func :: (Matrix -> Matrix)):
+      doc: "Maps the given function over each column in the matrix"
+      to-aug = self.col-list().map(func)
+      for fold(acc from to-aug.get(0), cur from to-aug.rest):
+        acc.augment(cur)
+      end
+    end,
+    
+    augment(self, other :: Matrix):
+      doc: "Augments the given matrix onto the matrix"
+      if not(self.rows == other.rows):
+        raise("Cannot augment matrices with different numbers of rows")
+      else:
+        new-size = ((self.cols + other.cols) * self.rows)
+        raw-arr = raw-array-of(0, new-size)
+        fun get-el(n :: Number):
+          col = num-modulo(n, (self.cols + other.cols))
+          row = num-floor(n / (self.cols + other.cols))
+          if col >= self.cols:
+            raw-array-get(other.elts, (other.cols * row) + num-modulo(col, self.cols))
+          else:
+            raw-array-get(self.elts, (self.cols * row) + col)
+          end
+        end
+        for each(i from range(0,new-size)):
+          raw-array-set(raw-arr, i, get-el(i))
+        end
+        matrix(self.rows, (self.cols + other.cols), raw-arr)
+      end
+    end,
+    
+    stack(self, other :: Matrix):
+      doc: "Returns the matrix stacked on top of the given matrix"
+      if not(self.cols == other.cols):
+        raise("Cannot stack matrices with different row lengths")
+      else:
+        new-size = ((self.rows + other.rows) * self.cols)
+        old-size = raw-array-length(self.elts)
+        raw-arr = raw-array-of(0,new-size)
+        fun get-el(n :: Number):
+          if n < old-size:
+            raw-array-get(self.elts, n)
+          else:
+            raw-array-get(other.elts, (n - old-size))
+          end
+        end
+        for each(i from range(0,new-size)):
+          raw-array-set(raw-arr, i, get-el(i))
+        end
+        matrix((self.rows + other.rows), self.cols, raw-arr)
+      end
+    end,
+    
+    trace(self) -> Number:
+      doc: "Returns the trace of the matrix (sum of the diagonal values)"
+      for raw-array-fold(acc from 0, n from self.diagonal().elts, i from 0):
+        acc + n
+      end
+    end,
+    
+    scale(self, k :: Number) -> Matrix:
+      doc: "Scales the matrix by the given value"
+      self.map(_ * k)
+    end,
+    
+    dot(self, b :: Matrix) -> Number:
+      doc: "Returns the Frobenius Product of the matrix with the given matrix"
+      when (not(self.rows == b.rows) or not(self.cols == b.cols)):
+        raise("Cannot return the inner product of two different-sized matrices")
+      end
+      (self * b.transpose()).trace()
+    end,
+    
+    
+    # Arithmetic Operators
+    _plus(self, b :: Matrix) -> Matrix:
+      doc: "Adds the given matrix to the matrix"
+      when (not(self.rows == b.rows)
+          or not(self.cols == b.cols)):
+        raise("Cannot add two different sized matricies")
+      end
+      size = raw-array-length(self.elts)
+      raw-arr = raw-array-of(0, size)
+      for each(i from range(0, size)):
+        raw-array-set(raw-arr, i,
+          (raw-array-get(self.elts, i) +
+            raw-array-get(b.elts, i)))
+      end
+      matrix(self.rows, self.cols, raw-arr)
+    end,
+    
+    _minus(self, b :: Matrix) -> Matrix:
+      doc: "Subtracts the given matrix from the matrix"
+      when (not(self.rows == b.rows)
+          or not(self.cols == b.cols)):
+        raise("Cannot add two different sized matricies")
+      end
+      size = raw-array-length(self.elts)
+      raw-arr = raw-array-of(0, size)
+      for each(i from range(0, size)):
+        raw-array-set(raw-arr, i,
+          (raw-array-get(self.elts, i) -
+            raw-array-get(b.elts, i)))
+      end
+      matrix(self.rows, self.cols, raw-arr)
+    end,
+    
+    _times(self, b :: Matrix) -> Matrix:
+      #C_ik = Sum(A_ij * B_jk)
+      doc: "Multiplies the matrix by the given matrix"
+      when not(self.cols == b.rows):
+        raise("Matrix multiplication is undefined for the given inputs")
+      end
+      new-size = (self.rows * b.cols)
+      raw-arr = raw-array-of(0,new-size)
+      for each(i from range(0, self.rows)):
+        for each(k from range(0, b.cols)):
+          strided-fold = make-raw-array-fold2(i * self.cols, k, 1, b.cols, ((i + 1) * self.cols) - 1,(b.rows * b.cols) + k)
+          raw-array-set(raw-arr, rc-to-index(b,i,k),
+            for strided-fold(base from 0, self_ij from self.elts, b_jk from b.elts):
+              base + (self_ij * b_jk)
+            end)
+        end
+      end
+      matrix(self.rows, b.cols, raw-arr)
+    end,
+    
+    expt(self, n :: Number) -> Matrix:
+      doc: "Multiplies the matrix by itself the given number of times"
+      if n == 0:
+        identity-matrix(self.rows)
+      else if (num-modulo(n,2) == 0):
+        to-sqr = self.expt(n / 2)
+        to-sqr * to-sqr
+      else:
+        to-sqr = self.expt((n - 1) / 2)
+        self * (to-sqr * to-sqr)
+      end
+    end,
+    
+    determinant(self) -> Number:
+      doc: "Returns the determinant of the matrix"
+      # Recursive implementation of Laplace Expansion
+      if not(is-square-matrix(self)):
+        raise("Cannot take the determinant of a non-square matrix")
+      else:
+        ask:
+          | self.rows == 2 then:
+            (self.get(0,0) * self.get(1,1)) -
+            (self.get(0,1) * self.get(1,0))
+          | otherwise:
+            for raw-array-fold(acc from 0, cur from self.row(0).elts, n from 0):
+              (num-expt(-1, n) * (cur * self.submatrix(
+                    range( 1, self.rows ), 
+                    range( 0, n) + range(n + 1, self.cols) ).determinant())) + acc
+            end
+        end
+      end
+    end,
+    
+    is-invertible(self) -> Boolean:
+      doc: "Returns true if the given matrix is invertible"
+      not(self.determinant() == 0)
+    end,
+    
+    rref(self) -> Matrix:
+      doc: "Returns the Reduced Row Echelon Form of the Matrix"
+      # Copy matrix into new one to avoid game of temporary
+      #      matrix hot potato between helper functions
+      to-ret = matrix(self.rows, self.cols, self.elts)
+      
+      fun row-range(row :: Nat):
+        doc: "Returns the index range for the given row"
+        range(rc-to-index(to-ret,row,0),
+          rc-to-index(to-ret,row,to-ret.cols))
+      end
+      
+      fun leading-col(row :: Nat):
+        doc: "Returns the leading nonzero column of the given row"
+        for fold(acc from (to-ret.cols - 1), cur from range(0,to-ret.cols).reverse()):
+          if not(to-ret.get(row,cur) == 0):
+            cur
+          else:
+            acc
+          end
+        end
+      end
+      
+      fun mult(row :: Nat, scalar :: Number):
+        doc: "Multiplies the given row by the given scalar"
+        for each(j from row-range(row)):
+          raw-array-set(to-ret.elts, j,
+            raw-array-get(to-ret.elts, j) * scalar)
+        end
+      end
+      
+      fun divide-to-one(row :: Nat):
+        doc: "Divides the given row such that the leading entry is a one"
+        mult(row, 1 / to-ret.get(row, leading-col(row)))
+      end
+      
+      fun sub-mult(sub-from :: Nat, subbing :: Nat, scalar :: Number):
+        doc: "Subtracts a multiple of the second row from the first"
+        for each2(i from row-range(sub-from), j from row-range(subbing)):
+          raw-array-set(to-ret.elts, i,
+            (raw-array-get(to-ret.elts, i) -
+              (raw-array-get(to-ret.elts, j) * scalar)))
+        end
+      end
+      
+      fun reduce-row(to-reduce :: Nat, based-on :: Nat):
+        doc: "Reduces the given row such that it has a 0 where the based-on row has its leading entry"
+        sub-mult(to-reduce, based-on, to-ret.get(to-reduce, leading-col(based-on)))
+      end
+      
+      for each(i from range(0,to-ret.rows)):
+        divide-to-one(i)
+        for each(k from (range(0,i) + range(i + 1,to-ret.rows))):
+          reduce-row(k,i)
+        end
+      end
+      
+      to-ret
+    end,
+    
+    inverse(self) -> Matrix:
+      when not(self.is-invertible()):
+        raise("Cannot find inverse of non-invertible matrix")
+      end
+      to-ret = matrix(self.rows,self.cols,raw-array-duplicate(self.elts))
+      to-aug = identity-matrix(self.rows)
+      to-chop = to-ret.augment(to-aug).rref().col-list().drop(self.cols)
+      for fold(acc from to-chop.first, cur from to-chop.rest):
+        acc.augment(cur)
+      end
+    end,
+    
+    solve(self, b :: Matrix) -> Matrix:
+      doc: "Returns the matrix needed to multiply with this matrix to receive the given matrix (i.e. the solution for a system of equations), if it exists"
+      when not(self.is-invertible()):
+        raise("Cannot find exact solution for non-invertible matrix")
+      end
+      self.inverse() * b
+    end,
+    
+    least-squares-solve(self, b :: Matrix) -> Matrix:
+      doc: "Returns the least-squares solution for this and the given matrix"
+      # Take the QR Decomposition and pull out results (and transpose Q)
+      qrres = self.qr-decomposition()
+      qt = qrres.first.transpose()
+      r = qrres.rest.first
+      # Solve for x: r * x = qt * b
+      r.inverse() * (qt * b)
+    end,
+    
+    # While perhaps not the most useful in practice,
+    #   multi-column matricies do have norms defined,
+    #   so they are defined here.    
+    lp-norm(self, p :: Number) -> Number:
+      doc: "Computes the Lp norm of the matrix"
+      summed = for raw-array-fold(acc from 0, cur from self.elts, i from 0):
+        acc + num-expt(cur, p)
+      end
+      num-expt(summed, (1 / p))
+      #max-mag = for raw-array-fold(acc from 0, cur from self.elts, i from 0):
+      #  num-max(acc,num-abs(cur))
+      #end
+      #sum-pow = for raw-array-fold(acc from 0, cur from self.elts, i from 0):
+      #  acc + num-expt((num-abs(cur) / max-mag), p)
+      #end
+      #max-mag * num-expt(sum-pow, (1 / p))
+    end,
+    
+    l1-norm(self) -> Number:
+      doc: "Computes the L1 norm (or Taxicab norm) of the matrix"
+      self.lp-norm(1)
+    end,
+    
+    l2-norm(self) -> Number:
+      doc: "Computes the L2 norm (or Euclidean norm) of the matrix"
+      self.lp-norm(2)
+    end,
+    
+    l-inf-norm(self) -> Number:
+      doc: "Computes the L-Infinity norm of the matrix"
+      raw-array-fold(lam(acc, cur, i): num-max(acc,num-abs(cur)) end, 0, self.elts, 0)
+    end,
+    
+    qr-decomposition(self) -> List<Matrix>:
+      doc: "Returns the QR Decomposition of the matrix"
+      # (Ample comments because debugging)
+      q-arr = self.elts # Copy Current List of elements for modification
+      r-arr = raw-array-of(0,raw-array-length(self.elts))
+      cols = self.col-list()
+      first-col = cols.get(0).to-vector() # Get the first column
+      raw-array-set(r-arr,0, magnitude(first-col)) # Store its magnitude in R Matrix
+      for each2(n from normalize(first-col), i from range(0,self.rows)):
+        raw-array-set(q-arr, rc-to-index(self,i,0),n) # Normalize and store in Q Matrix
+      end
+      fun get-q-col(j :: Nat) -> Vector:
+        doc: "Returns the given column in the Q matrix as a vector"
+        for map(n from range(0,self.rows)):
+          raw-array-get(q-arr, rc-to-index(self,n,j))
+        end
+      end
+      for each(i from range(1,self.cols)):
+        v-vec = cols.get(i).to-vector() # Convert the current column into a vector (needs to be able to dot)
+        first-dot = dot(v-vec, get-q-col(0)) # Dot the current vector with the first unit vector
+        raw-array-set(r-arr,rc-to-index(self,0,i),first-dot) # Store dot in R Matrix
+        sum-mults = for fold(acc from scale(get-q-col(0), first-dot), j from range(1,i)): # Loop over all 
+                                                                                          #   already-established
+                                                                                          #   unit vectors
+          dotted = dot(v-vec, get-q-col(j)) # Dot the current vector with the given unit vector
+          raw-array-set(r-arr,rc-to-index(self,j,i),dotted) # Store dot in R matrix
+          vector-add(acc, scale(get-q-col(j), dotted)) # Add the scaled unit vector to the accumulated result
+        end
+        v-perp = vector-sub(cols.get(i).to-vector(), sum-mults) # Subtract the accumulated result
+                                                                #   from the current vector to get
+                                                                #   its perpendicular component
+        raw-array-set(r-arr,rc-to-index(self,i,i),magnitude(v-perp)) # Store magnitude in R matrix
+        for each2(n from normalize(v-perp), k from range(0,self.rows)):
+          raw-array-set(q-arr,rc-to-index(self,k,i),n) # Store Normalized Perp. Component in Q Matrix
+        end
+      end
+      # Shrink R Matrix to a (self.cols * self.cols) square matrix
+      r-ret-arr = raw-array-of(0, (self.cols * self.cols))
+      for each(i from range(0, (self.cols * self.cols))):
+        raw-array-set(r-ret-arr,i,raw-array-get(r-arr,i))
+      end
+      [list: matrix(self.rows, self.cols, q-arr), matrix(self.cols, self.cols, r-ret-arr)]
+    end,
+          
+    
+    gram-schmidt(self) -> Matrix:
+      doc: "Returns an orthogonal matrix whose image is the same as the span of the Matrix's columns"
+      self.qr-decomposition().get(0)
+    end,
+    
+    _torepr(self, shadow torepr) -> String:
+      fun pad(str :: String, to-len :: Number):
+        if to-len <= string-length(str):
+          str
+        else:
+          string-append(
+            string-repeat(" ", (to-len - string-length(str))), str)
+        end
+      end
+      max-len = for raw-array-fold(acc from 0, n from self.elts, i from 0):
+        num-max(string-length(num-tostring(n)), acc)
+      end
+      fun elt-tostr(i :: Number):
+        if num-is-integer((i + 1) / self.cols):
+          pad(num-tostring(raw-array-get(self.elts, i)), max-len) + "\n"
+        else:
+          pad(num-tostring(raw-array-get(self.elts, i)), max-len) + "\t"
+        end
+      end
+      "\n" + for raw-array-fold(acc from "", n from self.elts, i from 0):
+        acc + elt-tostr(i)
+      end
+    end,
+    
+    equalTo(self, a :: Matrix, eq):
+      circa = lam(m,n): num-abs(m - n) < 0.00001 end #Because floating points
+      basically-equal = lam(l1, l2): fold2(lam(x,y,z): x and circa(y,z) end, true, l1, l2) end
+      if ((self.to-list() == a.to-list()) or basically-equal(self.to-list(), a.to-list())):
+        Equal
+      else:
+        NotEqual("Matrices are not equal")
+      end
+    end,
+    
+    _equals(self, a :: Matrix, eq):
+      self.equalTo(a,eq)
+    end
+end
+
+fun identity-matrix(n :: NonZeroNat):
+  doc: "Returns the identity matrix of the given size"
+  fun id(r :: Number, c :: Number) -> RawArray:
+    raw-arr = raw-array-of(0, (r * c))
+    for each(i from range(0,r)):
+      raw-array-set(raw-arr,(i * (c + 1)), 1)
+    end
+    raw-arr
+  end
+  matrix(n, n, id(n,n))
+end
+
+fun mk-mtx(rows :: NonZeroNat, cols :: NonZeroNat):
+  fun invalid-msg(num-given :: Number):
+    pre = "Invalid " + tostring(rows) + "x"
+      + tostring(cols) + " Matrix Input: Expected "
+      + tostring(cols * rows) + " elements; Received "
+    post = " elements."
+    pre + tostring(num-given) + post
+  end
+  fun make-unexpected(n :: Number):
+    lam(arr): raise(invalid-msg(raw-array-length(arr))) end
+  end
+  # Implement all constructors so we only allocate RawArrays if
+  # absolutely necessary
+  var make0 = lam(): raise(invalid-msg(0)) end
+  var make1 = lam(a): raise(invalid-msg(1)) end
+  var make2 = lam(a, b): raise(invalid-msg(2)) end
+  var make3 = lam(a, b, c): raise(invalid-msg(3)) end
+  var make4 = lam(a, b, c, d): raise(invalid-msg(4)) end
+  var make5 = lam(a, b, c, d, e): raise(invalid-msg(5)) end
+  var make  = lam(arr): raise(invalid-msg(raw-array-length(arr))) end
+  expected = rows * cols
+  ask:
+    | expected == 0 then: raise("Impossible") # NonZeroNat should handle this
+    | expected == 1 then: make1 := lam(a): matrix(rows, cols, [raw-array: a]) end
+    | expected == 2 then: make2 := lam(a, b): matrix(rows, cols, [raw-array: a, b]) end
+    | expected == 3 then: make3 := lam(a, b, c): matrix(rows, cols, [raw-array: a, b, c]) end
+    | expected == 4 then: make4 := lam(a, b, c, d): matrix(rows, cols, [raw-array: a, b, c, d]) end
+    | expected == 5 then: make5 := lam(a, b, c, d, e): matrix(rows, cols, [raw-array: a, b, c, d, e]) end
+    | otherwise: make := lam(arr):
+        if not(raw-array-length(arr) == (rows * cols)):
+          raise(invalid-msg(raw-array-length(arr)))
+        else:
+          matrix(rows, cols, arr)
+        end
+      end
+  end
+  {
+    make0: make0,
+    make1: make1,
+    make2: make2,
+    make3: make3,
+    make4: make4,
+    make5: make5,
+    make : make
+  }
+where:
+  [mk-mtx(1,1): 1] is matrix(1, 1, [raw-array: 1])
+  [mk-mtx(3,1): 1, 
+                2,
+                3] is matrix(3, 1, [raw-array: 1, 2, 3])
+  [mk-mtx(1,3): 3, 2, 1] is matrix(1, 3, [raw-array: 3, 2, 1])
+  [mk-mtx(2,2): 1, 2, 
+                3, 4] is matrix(2, 2, [raw-array: 1, 2, 3, 4])
+end
+
+row-matrix =
+  {
+    make: lam(arr :: RawArray):
+        matrix(1,raw-array-length(arr),arr)
+      end,
+    make0: lam(): raise("Invalid Matrix Input: Cannot construct a zero-length row matrix") end,
+    make1: lam(a): matrix(1, 1, [raw-array: a]) end,
+    make2: lam(a, b): matrix(1, 2, [raw-array: a, b]) end,
+    make3: lam(a, b, c): matrix(1, 3, [raw-array: a, b, c]) end,
+    make4: lam(a, b, c, d): matrix(1, 4, [raw-array: a, b, c, d]) end,
+    make5: lam(a, b, c, d, e): matrix(1, 5, [raw-array: a, b, c, d, e]) end
+  }
+
+col-matrix =
+  {
+    make: lam(arr :: RawArray):
+        matrix(raw-array-length(arr), 1, arr)
+      end,
+    make0: lam(): raise("Invalid Matrix Input: Cannot construct a zero-length column matrix") end,
+    make1: lam(a): matrix(1, 1, [raw-array: a]) end,
+    make2: lam(a, b): matrix(2, 1, [raw-array: a, b]) end,
+    make3: lam(a, b, c): matrix(3, 1, [raw-array: a, b, c]) end,
+    make4: lam(a, b, c, d): matrix(4, 1, [raw-array: a, b, c, d]) end,
+    make5: lam(a, b, c, d, e): matrix(5, 1, [raw-array: a, b, c, d, e]) end
+  }
+
+fun make-matrix(rows :: NonZeroNat, cols :: NonZeroNat, x :: Number):
+  doc: "Constructs a matrix of the given size with the given elements"
+  matrix(rows,cols,raw-array-of(x,(rows * cols)))
+where:
+  make-matrix(2, 3, 1) is [mk-mtx(2, 3): 1, 1, 1, 1, 1, 1]
+  make-matrix(3, 2, 5) is [mk-mtx(3, 2): 5, 5, 5, 5, 5, 5]
+end
+
+fun build-matrix(rows :: NonZeroNat, cols :: NonZeroNat, proc :: (Number, Number -> Number)):
+  doc: "Constructs a matrix of the given size, where entry (i,j) is the result of proc(i,j)"
+  raw-arr = raw-array-of(0,(rows * cols))
+  for each(i from range(0, rows)):
+    for each(j from range(0, cols)):
+      raw-array-set(raw-arr, rc-to-index-with-col-size(i,j,cols),proc(i,j))
+    end
+  end
+  matrix(rows,cols,raw-arr)
+where:
+  build-matrix(3,2,lam(i,j): i + j end) is
+  [mk-mtx(3,2): 0, 1, 1, 2, 2, 3]
+end
+
+fun vector-to-matrix(v :: Vector):
+  doc: "Converts the given vector into a one-row matrix"
+  raw-arr = raw-array-of(0, v.length())
+  for each(i from range(0,v.length())):
+    raw-array-set(raw-arr, i ,v.get(i))
+  end
+  matrix(1,v.length(),raw-arr)
+where:
+  vector-to-matrix([list: 1, 2, 3]) is
+  [mk-mtx(1,3): 1, 2, 3]
+end
+
+fun list-to-matrix(rows :: NonZeroNat, cols :: NonZeroNat, lst :: List<Number>):
+  doc: "Converts the given list of numbers into a matrix of the given size"
+  when not(lst.length() == (rows * cols)):
+    raise("Provided list does not have arguments corresponding to provided matrix size")
+  end
+  matrix(rows,cols,list-to-raw-array(lst))
+where:
+  list-to-matrix(2, 3, [list: 1, 2]) raises "Provided list does not have arguments corresponding to provided matrix size"
+  list-to-matrix(3, 2, [list: 1, 2, 3, 4, 5, 6]) is [mk-mtx(3,2): 1, 2, 3, 4, 5, 6]
+  list-to-matrix(1, 4, [list: 2, 4, 6, 8]) is [mk-mtx(1,4): 2, 4, 6, 8]
+end
+
+fun list-to-row-matrix(lst :: List<Number>):
+  doc: "Converts the given list into a row matrix"
+  list-to-matrix(1,lst.length(),lst)
+where:
+  list-to-row-matrix([list: 2, 3, 4, 5]) is [mk-mtx(1,4): 2, 3, 4, 5]
+end
+
+fun list-to-col-matrix(lst :: List<Number>):
+  doc: "Converts the given list into a column matrix"
+  list-to-matrix(lst.length(), 1, lst)
+where:
+  list-to-col-matrix([list: 1, 2, 3]) is [mk-mtx(3,1): 1, 2, 3]
+end
+
+fun lists-to-matrix(lst :: List<List<Number>>):
+  doc: "Converts the given list of lists into a matrix, with each contained list as a row"
+  rows = lst.length()
+  cols = lst.get(0).length()
+  # Check that all Lists are the same length
+  when fold(lam(r,f): not(f.length() == cols) or r end,false,lst):
+    raise("Invalid Matrix input")
+  end
+  matrix(rows,cols,list-to-raw-array(lst.foldr(_ + _, empty)))
+where:
+  lists-to-matrix([list: [list: 1, 2, 3], [list: 4, 5, 6]]) is
+  [mk-mtx(2,3): 1, 2, 3, 4, 5, 6]
+  
+  lists-to-matrix([list: [list: 1, 2, 3], [list: 1, 2]]) raises
+  "Invalid Matrix input"
+end
+
+# NOTE:
+# The Racket implementation of this function works
+#   the same way as lists-to-matrix does. The reasons
+#   I opted to make the vectors columns instead are twofold:
+#   1.) The way Vectors are defined (as of this implementation),
+#       they are functionally indistinguishable from 
+#       List<List<Number>>, so one may still convert a List<Vector>
+#       into a matrix with the vectors as rows using that function.
+#   2.) Mathematically, vectors (usually) have components in
+#       different dimensions. The matrix representation dimensions
+#       usually corresponds to the matrix's rows, so I felt it
+#       was perhaps more appropriate to line up the dimensional
+#       components of the vectors.
+# Am I wrong? Maybe.
+fun vectors-to-matrix(lst :: List<Vector>):
+  doc: "Converts the given list of vectors into a matrix, with each vector as a column"
+  rows = lst.get(0).length()
+  cols = lst.length()
+  # Check that all Vectors are the same length
+  when fold(lam(r,f): not(f.length() == rows) or r end,false,lst):
+    raise("Invalid Matrix input")
+  end
+  raw-arr = raw-array-of(0, (rows) * (cols))
+  for each(i from range(0, rows)):
+    for each(j from range(0, cols)):
+      raw-array-set(raw-arr, rc-to-index-with-col-size(i,j,cols),lst.get(j).get(i))
+    end
+  end
+  matrix(rows,cols,raw-arr)
+where:
+  vectors-to-matrix([list: [vector: 1, 2, 3], [vector: 4, 5, 6]]) is
+  [mk-mtx(3,2): 1, 4, 2, 5, 3, 6]
+end
+
+fun matrix-within(n :: Number) -> (Matrix, Matrix -> Boolean):
+  lam(a, b):
+    if (raw-array-length(a.elts) == raw-array-length(b.elts)):
+      f = make-raw-array-fold2(0,0,1,1,raw-array-length(a.elts) - 1,raw-array-length(b.elts) - 1)
+      wn = within(n)
+      f(lam(acc, a-elt, b-elt): wn(a-elt,b-elt) and acc end, true, a.elts, b.elts)
+    else:
+      false
+    end
+  end
+end

--- a/tests/pyret/tests/test-matrices.arr
+++ b/tests/pyret/tests/test-matrices.arr
@@ -1,0 +1,244 @@
+import matrices as M
+import all2 from lists
+
+matrix = M.matrix
+matrix-within = M.matrix-within
+row-matrix = M.row-matrix
+col-matrix = M.col-matrix
+
+fun list-matrix-within(n :: Number) -> (List<M.Matrix>, List<M.Matrix> -> Boolean):
+  lam(a, b):
+    wn = matrix-within(n)
+    all2(wn,a,b)
+  end
+end
+
+mtx1 = [matrix(2,3): 1, 2, 3, 
+                     4, 5, 6]
+mtx2 = [matrix(3,3): 1, 1, 1, 
+                     2, 2, 2, 
+                     3, 3, 3]
+mtx3 = [matrix(3,2): 1, 2,
+                     3, 4, 
+                     5, 6]
+
+mtx4 = [matrix(3,1): 1, 
+                     2, 
+                     3]
+mtx5 = [matrix(3,3): 1, 0, 0, 
+                     2, 0, 0,
+                     3, 0, 0]
+
+check "Constructor Errors":
+  [matrix(1,2):] raises "Invalid 1x2 Matrix Input: Expected 2 elements; Received 0 elements"
+  [row-matrix:] raises "Invalid Matrix Input: Cannot construct a zero-length row matrix"
+  [col-matrix:] raises "Invalid Matrix Input: Cannot construct a zero-length column matrix"
+  [matrix(1,0):] raises-other-than "Impossible" # Check that the type refinement is working
+end
+
+check "Basic Matrix Accessors":
+    
+  mtx1.get(1,1) is 5
+  mtx1.get(0,2) is 3
+  
+  mtx1.rows is 2
+  mtx1.cols is 3
+  
+  mtx1.to-list() is [list: 1, 2, 3, 4, 5, 6]
+  
+  mtx1.row(0) is [matrix(1,3): 1, 2, 3]
+  mtx1.row(1) is [matrix(1,3): 4, 5, 6]
+  mtx1.col(1) is [matrix(2,1): 2, 
+                               5]
+  mtx1.col(2) is [matrix(2,1): 3,
+                               6]
+  
+  mtx1.row(0).to-vector() is [list: 1, 2, 3]
+  mtx1.col(1).to-vector() is [list: 2, 5]
+
+end
+
+check "Submatrices":
+
+  mtx1.submatrix([list: 0, 1], [list: 0, 2]) is
+  [matrix(2,2): 1, 3, 
+                4, 6]
+  mtx1.submatrix([list: 1], [list: 0, 1, 2]) is
+  [matrix(1,3): 4, 5, 6]
+  mtx1.submatrix([list: 0], [list: 1, 2]) is
+  [matrix(1,2): 2, 3]
+end
+
+check "Matrix Transpose":
+  
+  mtx1.transpose() is 
+  [matrix(3,2): 1, 4, 
+                2, 5, 
+                3, 6]
+end
+check "Matrix Diagonal":
+  mtx1.diagonal() is
+  [matrix(1,2): 1, 5]
+  mtx2.diagonal() is
+  [matrix(1,3): 1, 2, 3]
+  mtx3.diagonal() is
+  [matrix(1,2): 1, 4]
+end
+
+check "Matrix Upper/Lower Triangles":
+
+  mtx1.upper-triangle() raises "Cannot make a non-square upper-triangular matrix"
+  mtx2.upper-triangle() is
+  [matrix(3, 3): 1, 1, 1,
+                 0, 2, 2, 
+                 0, 0, 3]
+  mtx1.lower-triangle() raises "Cannot make a non-square lower-triangular matrix"
+  mtx2.lower-triangle() is
+  [matrix(3,3): 1, 0, 0, 
+                2, 2, 0, 
+                3, 3, 3]
+
+end
+
+check "Matrix-to-List Conversion":
+
+  mtx1.row-list() is [list: [matrix(1,3): 1, 2, 3], [matrix(1,3): 4, 5, 6]]
+  mtx3.col-list() is [list: 
+    [matrix(3,1): 1, 3, 5],
+    [matrix(3,1): 2, 4, 6]]
+
+end
+
+check "Matrix Morphisms":
+
+  mtx1.map(num-sqr) is 
+  [matrix(2,3): 1,  4,  9,
+               16, 25, 36]
+  
+  mtx1.row-map(lam(r): r.scale(2) end) is
+  [matrix(2,3): 2,  4,  6,
+                8, 10, 12]
+  
+  mtx1.col-map(lam(c): [matrix(1,1): c.dot(c)] end) is
+  [matrix(1,3): 17, 29, 45]
+
+end
+
+check "Matrix Concatenation":
+
+  mtx2.augment(mtx3) is
+  [matrix(3,5): 1, 1, 1, 1, 2,
+                2, 2, 2, 3, 4,
+                3, 3, 3, 5, 6]
+  
+  mtx1.stack(mtx2) is
+  [matrix(5, 3): 1, 2, 3,
+                 4, 5, 6,
+                 1, 1, 1,
+                 2, 2, 2,
+                 3, 3, 3]
+
+end
+
+check "Matrix Scaling and Trace":
+  mtx1.scale(2) is [matrix(2,3): 2,  4,  6,
+                                 8, 10, 12]
+  
+  mtx2.trace() is 6
+
+end
+
+check "Matrix Operations":
+
+  (mtx1 + mtx1) is [matrix(2,3): 2,  4,  6,
+                                 8, 10, 12]
+  
+  mtx1 + [matrix(2,3): 1, 1, 1,
+                       1, 1, 1] is
+  [matrix(2,3): 2, 3, 4,
+                5, 6, 7]
+  
+  mtx1 - [matrix(2,3): 1, 1, 1,
+                       1, 1, 1] is
+  [matrix(2,3): 0, 1, 2, 
+                3, 4, 5]  
+  
+  mtx1 * [matrix(3,2): 1, 1, 1,
+                       1, 1, 1] is
+  [matrix(2,2): 6,  6, 
+               15, 15]
+  
+  mtx2.expt(2) is mtx2 * mtx2
+  
+  [matrix(3,3): 1, 1, 1, 
+                1, 1, 1, 
+                2, 1, 2].expt(3) is
+  [matrix(3,3): 15, 11, 15,
+                15, 11, 15, 
+                26, 19, 26]
+end
+
+check "Matrix Determinant and Reduced-Row Echelon Form":
+
+  [matrix(5,5): 1, 2,1,2, 3,
+                2, 3,1,0, 1,
+                2, 2,1,0, 0,
+                1, 1,1,1, 1,
+                0,-2,0,2,-2].determinant() is -2
+  
+  mtx1.rref() is
+  [matrix(2,3): 1, 0, -1,
+                0, 1,  2]
+end
+
+check "Matrix Norms":
+
+  mtx4.lp-norm(3) is%(within(0.00001)) num-expt(6, 2/3)
+  mtx5.lp-norm(3) is%(within(0.00001)) (mtx5 * mtx4).lp-norm(3)
+  
+  mtx4.l1-norm() is%(within(0.00001)) 6
+  mtx4.l2-norm() is%(within(0.00001)) num-sqrt(14)
+  mtx4.l-inf-norm() is%(within(0.00001)) 3
+  
+  mtx5.l-inf-norm() is%(within(0.00001)) (mtx5 * mtx4).l-inf-norm()
+
+end
+
+check "Matrix Decomposition":
+
+  [matrix(3,3):1, 2, 3, -1, 0, -3, 0, -2, 3].qr-decomposition() is%(list-matrix-within(0.00001))
+  [list: 
+    [matrix(3,3):(1 / num-sqrt(2)), (1 / num-sqrt(6)), (1 / num-sqrt(3)),
+      (-1 / num-sqrt(2)), (1 / num-sqrt(6)), (1 / num-sqrt(3)),
+      0, (-2 / num-sqrt(6)), (1 / num-sqrt(3))],
+    [matrix(3,3): num-sqrt(2), num-sqrt(2), num-sqrt(18),
+      0, num-sqrt(6), -1 * num-sqrt(6),
+      0, 0, num-sqrt(3)]]
+  
+  [matrix(3,3):1, 2, 3, -1, 0, -3, 0, -2, 3].gram-schmidt() is%(matrix-within(0.00001))
+    [matrix(3,3):(1 / num-sqrt(2)), (1 / num-sqrt(6)), (1 / num-sqrt(3)),
+      (-1 / num-sqrt(2)), (1 / num-sqrt(6)), (1 / num-sqrt(3)),
+      0, (-2 / num-sqrt(6)), (1 / num-sqrt(3))]
+end
+
+check "Alternative Matrix Constructors":
+
+  [row-matrix: 1, 2, 3, 4] is [matrix(1,4): 1, 2, 3, 4]
+  
+  [col-matrix: 1, 2, 3, 4] is [matrix(4,1): 1, 2, 3, 4]
+
+end
+
+check "Matrix Inversion":
+
+  [matrix(3,3): 1, 0, 4, 1, 1, 6, -3, 0, -10].inverse() is 
+  [matrix(3,3): -5, 0, -2, -4, 1, -1, 3/2, 0, 1/2]
+
+end
+
+check "Linear System Solvability":
+
+  [matrix(3,2): 3, -6, 4, -8, 0, 1].least-squares-solve([matrix(3,1): -1, 7, 2]) is 
+  [matrix(2,1): 5, 2]
+
+end


### PR DESCRIPTION
Adds support for matrices. This has been sitting around for a little while, but, from what I recall, this should implement most everything that Racket's `math/matrix` library does.