### PR TITLE
New world-lib

### DIFF
--- a/docs/written/trove/world.js.rkt
+++ b/docs/written/trove/world.js.rkt
@@ -11,6 +11,7 @@
   (unknown-item (name "on-tick-n"))
   (unknown-item (name "to-draw"))
   (unknown-item (name "stop-when"))
+  (unknown-item (name "close-when-stop"))
   (unknown-item (name "on-key"))
   (unknown-item (name "on-mouse"))
   (unknown-item (name "on-particle"))
@@ -49,8 +50,9 @@
     when to shut down, etc. A world specification may not contain more than
     one @secref[(tag-name "world" "to-draw")] or @secref[(tag-name "world"
     "on-tick")] handlers. This function will return the last world state
-    when the stop condition is satisfied (see @secref[(tag-name "world"
-    "stop-when")]) or when the canvas is closed.
+    when the canvas is closed, either by clicking at the close button, or
+    by satisfying the closing condition (see @secref[(tag-name "world"
+    "stop-when")] and @secref[(tag-name "world" "close-when-stop")]).
   }
   @function["to-draw"
             #:contract (a-arrow (a-arrow "a"
@@ -154,7 +156,21 @@
     @secref[(tag-name "world" "big-bang")], will be called to determine if
     the world should stop running. If the function returns @pyret["true"],
     then no other handlers will be called. The @secref[(tag-name "world" "big-bang")] 
-    function will return this last world state.
+    function will return this last world state after the canvas is closed.
+  }
+  @function["close-when-stop"
+            #:contract (a-arrow B
+                                WC)
+            #:args (list '("stopper" ""))]{
+    Consumes a boolean and returns a handler that, when passed to
+    @secref[(tag-name "world" "big-bang")], will be used to determine if
+    the canvas should be closed when the world stops running by
+    @secref[(tag-name "world" "stop-when")]. If the value is @pyret["true"]
+    and the world stops running, then the canvas will be closed and 
+    the @secref[(tag-name "world" "big-bang")] function will return the last world
+    state. Otherwise, if the value is @pyret["false"] or
+    @secref[(tag-name "world" "close-when-stop")] is missing, then users need to
+    manually click the close button to close the canvas and return the last world state.
   }
   @function["is-world-config"
             #:contract (a-arrow "Any" B)


### PR DESCRIPTION
Changes:

1. Resume computation when closing a big-bang window correctly
Prior this PR, when we have nested big-bangs and close the topmost big-bang window,
the computation of the previous window will not resume. Instead, the world value
of the bottommost window will be returned. Thix PR fixes this by
resuming the computation in the previous window properly.
2. Change changingWorld to a stack
Prior this PR, if the first big-bang has on-tick (which fires very frequently),
`changingWorld` could be set to true while the the second big-bang is loaded.
This shared changingWorld would cause the second big-bang to wait for the variable
to be false, but it will never be. Thus, the second big-bang will be in non-responsive state.
   
   Setting `changingWorld` to false when resuming the computation to the previous window is also
dangerous. It's possible that the new window is populated by something like:
   
        on-tick(lam(_):
            call-new-big-bang()
            wait-for-an-hour()
          end)
   
   Then, setting `changingWorld` to false could lead the callback to be called again while the old
one is still active. This could lead to an error like "Internal: run called while already running"
Thus, the best way to do this is to keep a stack of changingWorld instead.
   
   This fixes #543
   
3. Add `close-when-stop` per a discussion with @joe
A new WorldConfig which could be used to close the big-bang window when `stop-when` returns true.

4. Enforce modal dialog correctly
When a modal dialog appears, it should grey out everything else, including other dialog.
This is the correct functionality of JQuery UI modal dialog.
Prior this PR manual changes to z-index in Pyret make all dialogs accessible. This PR fixes
this issue.

   Note that one nice consequence is that we do not need to worry whether
the current computation / window should be halted / closed if users close the previous
window because the correct modal dialog will force users to interact with only the topmost window.

5. Prevent computation resuming until the dialog is closed
It doesn't make sense to resume the computation while the dialog is open
(even when the world has stoped) because the computation could then trigger a new big-bang
which will prevent viewing the old window which is the only reason we do not close the window
right away when the big-bang stops.

6. Clean big-bang box when closed
This fixes #483.

This PR should be merged along with https://github.com/brownplt/code.pyret.org/pull/77

With this PR, the following program should be able to run properly:
https://code.pyret.org/editor#share=0Bxr4FfLa3goOREVhM1hRMUJtWW8