### PR TITLE
Threading an error-callbacks object through all the js-numbers methods

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -446,23 +446,23 @@ define(function() {
       }
     },
     function(x, y, errbacks) {
-      if (equalsAnyZero(y)) {
+      if (equalsAnyZero(y, errbacks)) {
         errbacks.throwDivByZero('/: division by zero, ' + x + ' ' + y);
       }
       return x.divide(y, errbacks);
     },
     {
       isXSpecialCase: function(x, errbacks) {
-        return equalsAnyZero(x);
+        return equalsAnyZero(x, errbacks);
       },
       onXSpecialCase: function(x, y, errbacks) {
-        if (equalsAnyZero(y)) {
+        if (equalsAnyZero(y, errbacks)) {
           errbacks.throwDivByZero("/: division by zero, " + x + ' ' + y);
         }
         return 0;
       },
       isYSpecialCase: function(y, errbacks) {
-        return equalsAnyZero(y);
+        return equalsAnyZero(y, errbacks);
       },
       onYSpecialCase: function(x, y, errbacks) {
         errbacks.throwDivByZero("/: division by zero, " + x + ' ' + y);
@@ -475,13 +475,13 @@ define(function() {
       return x === y;
     },
     function(x, y, errbacks) {
-      return x.equals(y);
+      return x.equals(y, errbacks);
     });
 
-  var equalsAnyZero = function(x) {
+  var equalsAnyZero = function(x, errbacks) {
     if (typeof(x) === 'number') return x === 0;
     if (isRoughnum(x)) return x.n === 0;
-    return x.equals(0);
+    return x.equals(0, errbacks);
   };
 
   // eqv: pyretnum pyretnum -> boolean
@@ -524,7 +524,7 @@ define(function() {
 
   var roughlyEqualsRel = function(computedValue, trueValue, delta, errbacks) {
     if (isNegative(delta)) {
-      errbacks.throwRelToleranceError('negative relative tolerance' + delta)
+      errbacks.throwRelToleranceError('negative relative tolerance ' + delta)
     }
 
     if (computedValue === trueValue) {

--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -115,15 +115,15 @@ define(function() {
   // coerced to be the same kind.
   var makeNumericBinop = function(onFixnums, onBoxednums, options) {
     options = options || {};
-    return function(x, y) {
-      if (options.isXSpecialCase && options.isXSpecialCase(x))
-        return options.onXSpecialCase(x, y);
-      if (options.isYSpecialCase && options.isYSpecialCase(y))
-        return options.onYSpecialCase(x, y);
+    return function(x, y, errbacks) {
+      if (options.isXSpecialCase && options.isXSpecialCase(x, errbacks))
+        return options.onXSpecialCase(x, y, errbacks);
+      if (options.isYSpecialCase && options.isYSpecialCase(y, errbacks))
+        return options.onYSpecialCase(x, y, errbacks);
 
       if (typeof(x) === 'number' &&
           typeof(y) === 'number') {
-        return onFixnums(x, y);
+        return onFixnums(x, y, errbacks);
       }
       if (typeof(x) === 'number') {
         x = liftFixnumInteger(x, y);
@@ -136,11 +136,11 @@ define(function() {
         // y is rough, rat or bigint
         if (!(y instanceof Roughnum)) {
           // y is rat or bigint
-          y = y.toRoughnum();
+          y = y.toRoughnum(errbacks);
         }
       } else if (y instanceof Roughnum) {
         // x is rat or bigint
-        x = x.toRoughnum();
+        x = x.toRoughnum(errbacks);
       } else if (x instanceof Rational) {
         // y is rat or bigint
         if (!(y instanceof Rational)) {
@@ -152,14 +152,14 @@ define(function() {
         x = new Rational(x, 1);
       }
 
-      return onBoxednums(x, y);
+      return onBoxednums(x, y, errbacks);
     };
   };
 
   // fromFixnum: fixnum -> pyretnum
-  var fromFixnum = function(x) {
+  var fromFixnum = function(x, errbacks) {
     if (!isFinite(x)) {
-      return Roughnum.makeInstance(x);
+      return Roughnum.makeInstance(x, errbacks);
     }
     var nf = Math.floor(x);
     if (nf === x) {
@@ -177,9 +177,9 @@ define(function() {
         var factorToInt = Math.pow(10, match[2].length);
         var extraFactor = _integerGcd(factorToInt, afterDecimal);
         var multFactor = factorToInt / extraFactor;
-        return Rational.makeInstance(Math.round(x*multFactor), Math.round(factorToInt/extraFactor));
+        return Rational.makeInstance(Math.round(x*multFactor), Math.round(factorToInt/extraFactor), errbacks);
       } else {
-        return Rational.makeInstance(x, 1);
+        return Rational.makeInstance(x, 1, errbacks);
       }
 
     }
@@ -222,31 +222,15 @@ define(function() {
   // liftFixnumInteger: fixnum-integer boxed-pyretnum -> boxed-pyretnum
   // Lifts up fixnum integers to a boxed type.
 
-  var liftFixnumInteger = function(x, other) {
+  var liftFixnumInteger = function(x, other, errbacks) {
     if (other instanceof Roughnum)
-      return new Roughnum(x);
+      return new Roughnum(x, errbacks);
     else if (other instanceof BigInteger)
       return makeBignum(x);
     else
-      return new Rational(x, 1);
+      return new Rational(x, 1, errbacks);
   };
 
-  // throwRuntimeError: string (pyretnum | undefined) (pyretnum | undefined) -> void
-  // Throws a runtime error with the given message string.
-  var throwRuntimeError = function(msg, x, y) {
-    Numbers['onThrowRuntimeError'](msg, x, y);
-  };
-
-  var setThrowRuntimeError = function(fn) {
-    throwRuntimeError = fn;
-  };
-
-  // onThrowRuntimeError: string (pyretnum | undefined) (pyretnum | undefined) -> void
-  // By default, will throw a new Error with the given message.
-  // Override Numbers['onThrowRuntimeError'] if you need to do something special.
-  var onThrowRuntimeError = function(msg, x, y) {
-    throw new Error(msg);
-  };
 
   // isPyretNumber: any -> boolean
   // Returns true if the thing is a pyretnum
@@ -325,28 +309,28 @@ define(function() {
   };
 
   // toRational: pyretnum -> pyretnum
-  var toRational = function(n) {
+  var toRational = function(n, errbacks) {
     if (typeof(n) === 'number')
       return n;
-    return n.toRational();
+    return n.toRational(errbacks);
   };
 
   var toExact = toRational;
 
   // toRoughnum: pyretnum -> pyretnum
 
-  var toRoughnum = function(n) {
+  var toRoughnum = function(n, errbacks) {
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(n);
+      return Roughnum.makeInstance(n, errbacks);
     } else {
-      return n.toRoughnum();
+      return n.toRoughnum(errbacks);
     }
   };
 
   //////////////////////////////////////////////////////////////////////
 
   // add: pyretnum pyretnum -> pyretnum
-  var add = function(x, y) {
+  var add = function(x, y, errbacks) {
     var sum;
     if (typeof(x) === 'number' && typeof(y) === 'number') {
       sum = x + y;
@@ -354,11 +338,11 @@ define(function() {
         return (makeBignum(x)).add(makeBignum(y));
       }
     }
-    return addSlow(x, y);
+    return addSlow(x, y, errbacks);
   };
 
   var addSlow = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       var sum = x + y;
       if (isOverflow(sum)) {
         return (makeBignum(x)).add(makeBignum(y));
@@ -366,20 +350,20 @@ define(function() {
         return sum;
       }
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.add(y);
     },
-    {isXSpecialCase: function(x) {
+    {isXSpecialCase: function(x, errbacks) {
       return isInteger(x) && _integerIsZero(x) },
-     onXSpecialCase: function(x, y) { return y; },
-     isYSpecialCase: function(y) {
+     onXSpecialCase: function(x, y, errbacks) { return y; },
+     isYSpecialCase: function(y, errbacks) {
        return isInteger(y) && _integerIsZero(y) },
-     onYSpecialCase: function(x, y) { return x; }
+     onYSpecialCase: function(x, y, errbacks) { return x; }
     });
 
   // subtract: pyretnum pyretnum -> pyretnum
   var subtract = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       var diff = x - y;
       if (isOverflow(diff)) {
         return (makeBignum(x)).subtract(makeBignum(y));
@@ -387,19 +371,19 @@ define(function() {
         return diff;
       }
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.subtract(y);
     },
-    {isXSpecialCase: function(x) {
+    {isXSpecialCase: function(x, errbacks) {
       return isInteger(x) && _integerIsZero(x) },
-     onXSpecialCase: function(x, y) { return negate(y); },
-     isYSpecialCase: function(y) {
+     onXSpecialCase: function(x, y, errbacks) { return negate(y); },
+     isYSpecialCase: function(y, errbacks) {
        return isInteger(y) && _integerIsZero(y) },
-     onYSpecialCase: function(x, y) { return x; }
+     onYSpecialCase: function(x, y, errbacks) { return x; }
     });
 
   // mulitply: pyretnum pyretnum -> pyretnum
-  var multiply = function(x, y) {
+  var multiply = function(x, y, errbacks) {
     var prod;
     if (typeof(x) === 'number' && typeof(y) === 'number') {
       prod = x * y;
@@ -409,10 +393,10 @@ define(function() {
         return prod;
       }
     }
-    return multiplySlow(x, y);
+    return multiplySlow(x, y, errbacks);
   };
   var multiplySlow = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       var prod = x * y;
       if (isOverflow(prod)) {
         return (makeBignum(x)).multiply(makeBignum(y));
@@ -420,13 +404,13 @@ define(function() {
         return prod;
       }
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.multiply(y);
     },
-    {isXSpecialCase: function(x) {
+    {isXSpecialCase: function(x, errbacks) {
       return (isInteger(x) &&
               (_integerIsZero(x) || _integerIsOne(x) || _integerIsNegativeOne(x))) },
-     onXSpecialCase: function(x, y) {
+     onXSpecialCase: function(x, y, errbacks) {
        if (_integerIsZero(x))
          return 0;
        if (_integerIsOne(x))
@@ -434,10 +418,10 @@ define(function() {
        if (_integerIsNegativeOne(x))
          return negate(y);
      },
-     isYSpecialCase: function(y) {
+     isYSpecialCase: function(y, errbacks) {
        return (isInteger(y) &&
                (_integerIsZero(y) || _integerIsOne(y) || _integerIsNegativeOne(y)))},
-     onYSpecialCase: function(x, y) {
+     onYSpecialCase: function(x, y, errbacks) {
        if (_integerIsZero(y))
          return 0;
        if (_integerIsOne(y))
@@ -449,48 +433,48 @@ define(function() {
 
   // divide: pyretnum pyretnum -> pyretnum
   var divide = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       if (_integerIsZero(y))
-        throwRuntimeError("/: division by zero, " + x + ' ' + y);
+        errbacks.throwDivByZero("/: division by zero, " + x + ' ' + y);
       var div = x / y;
       if (isOverflow(div)) {
-        return (makeBignum(x)).divide(makeBignum(y));
+        return (makeBignum(x)).divide(makeBignum(y), errbacks);
       } else if (Math.floor(div) !== div) {
-        return Rational.makeInstance(x, y);
+        return Rational.makeInstance(x, y, errbacks);
       } else {
         return div;
       }
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       if (equalsAnyZero(y)) {
-        throwRuntimeError('/: division by zero, ' + x + ' ' + y);
+        errbacks.throwDivByZero('/: division by zero, ' + x + ' ' + y);
       }
-      return x.divide(y);
+      return x.divide(y, errbacks);
     },
     {
-      isXSpecialCase: function(x) {
+      isXSpecialCase: function(x, errbacks) {
         return equalsAnyZero(x);
       },
-      onXSpecialCase: function(x, y) {
+      onXSpecialCase: function(x, y, errbacks) {
         if (equalsAnyZero(y)) {
-          throwRuntimeError("/: division by zero, " + x + ' ' + y);
+          errbacks.throwDivByZero("/: division by zero, " + x + ' ' + y);
         }
         return 0;
       },
-      isYSpecialCase: function(y) {
+      isYSpecialCase: function(y, errbacks) {
         return equalsAnyZero(y);
       },
-      onYSpecialCase: function(x, y) {
-        throwRuntimeError("/: division by zero, " + x + ' ' + y);
+      onYSpecialCase: function(x, y, errbacks) {
+        errbacks.throwDivByZero("/: division by zero, " + x + ' ' + y);
       }
     });
 
   // equals: pyretnum pyretnum -> boolean
   var equals = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       return x === y;
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.equals(y);
     });
 
@@ -501,25 +485,25 @@ define(function() {
   };
 
   // eqv: pyretnum pyretnum -> boolean
-  var eqv = function(x, y) {
+  var eqv = function(x, y, errbacks) {
     if (x === y)
       return true;
     if (typeof(x) === 'number' && typeof(y) === 'number')
       return x === y;
     var ex = isRational(x), ey = isRational(y);
-    return (((ex && ey) || (!ex && !ey)) && equals(x, y));
+    return (((ex && ey) || (!ex && !ey)) && equals(x, y, errbacks));
   };
 
   // approxEqual: pyretnum pyretnum pyretnum -> boolean
-  var approxEquals = function(x, y, delta) {
-    return lessThanOrEqual(abs(subtract(x, y)),
-                           delta);
+  var approxEquals = function(x, y, delta, errbacks) {
+    return lessThanOrEqual(abs(subtract(x, y, errbacks), errbacks),
+                           delta, errbacks);
   };
 
   // used for within
-  var roughlyEquals = function(x, y, delta) {
+  var roughlyEquals = function(x, y, delta, errbacks) {
     if (isNegative(delta)) {
-      throwRuntimeError("negative tolerance " + delta);
+      errbacks.throwToleranceError("negative tolerance " + delta);
     }
 
     if (x === y) return true;
@@ -527,20 +511,20 @@ define(function() {
     if (isRoughnum(delta) && delta.n === Number.MIN_VALUE) {
       if ((isRoughnum(x) || isRoughnum(y)) &&
             (Math.abs(subtract(x,y).n) === Number.MIN_VALUE)) {
-      throwRuntimeError("roughnum tolerance too small for meaningful comparison, " + x + ' ' + y + ' ' + delta);
+        errbacks.throwToleranceError("roughnum tolerance too small for meaningful comparison, " + x + ' ' + y + ' ' + delta);
       }
     }
 
-    var ratx = isRoughnum(x) ? x.toRational() : x;
-    var raty = isRoughnum(y) ? y.toRational() : y;
+    var ratx = isRoughnum(x) ? x.toRational(errbacks) : x;
+    var raty = isRoughnum(y) ? y.toRational(errbacks) : y;
 
-    var ratdelta = isRoughnum(delta) ? delta.toRational() : delta;
-    return approxEquals(ratx, raty, ratdelta);
+    var ratdelta = isRoughnum(delta) ? delta.toRational(errbacks) : delta;
+    return approxEquals(ratx, raty, ratdelta, errbacks);
   };
 
-  var roughlyEqualsRel = function(computedValue, trueValue, delta) {
+  var roughlyEqualsRel = function(computedValue, trueValue, delta, errbacks) {
     if (isNegative(delta)) {
-      throwRuntimeError('negative relative tolerance' + delta)
+      errbacks.throwRelToleranceError('negative relative tolerance' + delta)
     }
 
     if (computedValue === trueValue) {
@@ -550,76 +534,76 @@ define(function() {
     var deltaIsRough = isRoughnum(delta)
     var argNumsAreRough = isRoughnum(computedValue) || isRoughnum(trueValue)
 
-    var ratCv = isRoughnum(computedValue) ? computedValue.toRational() : computedValue
-    var ratTv = isRoughnum(trueValue) ? trueValue.toRational() : trueValue
+    var ratCv = isRoughnum(computedValue) ? computedValue.toRational(errbacks) : computedValue
+    var ratTv = isRoughnum(trueValue) ? trueValue.toRational(errbacks) : trueValue
 
-    var ratDelta = isRoughnum(delta) ? delta.toRational(): delta
+    var ratDelta = isRoughnum(delta) ? delta.toRational(errbacks): delta
 
-    var err = abs(subtract(ratCv, ratTv))
+    var err = abs(subtract(ratCv, ratTv, errbacks), errbacks)
 
-    if (lessThanOrEqual(ratDelta, 1)) {
-      var absDelta = multiply(ratDelta, abs(ratTv))
+    if (lessThanOrEqual(ratDelta, 1, errbacks)) {
+      var absDelta = multiply(ratDelta, abs(ratTv, errbacks), errbacks)
       if (deltaIsRough && toRoughnum(absDelta).n === Number.MIN_VALUE) {
         if (argNumsAreRough && Math.abs(toRoughnum(err).n) === Number.MIN_VALUE) {
-          throwRuntimeError('roughnum tolerance too small for meaningful comparison, ' +
+          errbacks.throwRelToleranceError('roughnum tolerance too small for meaningful comparison, ' +
                             computedValue + ' ' + trueValue + ' ' + delta)
         }
       }
 
-      return lessThanOrEqual(err, absDelta)
+      return lessThanOrEqual(err, absDelta, errbacks)
     } else {
-      var errRatio = divide(err, abs(ratTv))
+      var errRatio = divide(err, abs(ratTv, errbacks), errbacks)
 
       if (deltaIsRough && delta.n === Number.MIN_VALUE) {
         if (argNumsAreRough && Math.abs(toRoughnum(errRatio).n) === Number.MIN_VALUE) {
-          throwRuntimeError('roughnum tolerance too small for meaningful comparison, ' +
+          errbacks.throwRelToleranceError('roughnum tolerance too small for meaningful comparison, ' +
                             computedValue + ' ' + trueValue + ' ' + delta)
         }
       }
 
-      return lessThanOrEqual(errRatio, ratDelta)
+      return lessThanOrEqual(errRatio, ratDelta, errbacks)
     }
   }
 
   // greaterThanOrEqual: pyretnum pyretnum -> boolean
   var greaterThanOrEqual = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       return x >= y;
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.greaterThanOrEqual(y);
     });
 
   // lessThanOrEqual: pyretnum pyretnum -> boolean
   var lessThanOrEqual = makeNumericBinop(
-    function(x, y){
+    function(x, y, errbacks){
       return x <= y;
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.lessThanOrEqual(y);
     });
 
   // greaterThan: pyretnum pyretnum -> boolean
   var greaterThan = makeNumericBinop(
-    function(x, y){
+    function(x, y, errbacks){
       return x > y;
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.greaterThan(y);
     });
 
   // lessThan: pyretnum pyretnum -> boolean
   var lessThan = makeNumericBinop(
-    function(x, y){
+    function(x, y, errbacks){
       return x < y;
     },
-    function(x, y) {
+    function(x, y, errbacks) {
       return x.lessThan(y);
     });
 
   // expt: pyretnum pyretnum -> pyretnum
   var expt = makeNumericBinop(
-    function(x, y) {
+    function(x, y, errbacks) {
       var pow = Math.pow(x, y);
       if (isOverflow(pow)) {
         return (makeBignum(x)).expt(makeBignum(y));
@@ -627,19 +611,19 @@ define(function() {
         return pow;
       }
     },
-    function(x, y) {
-      return x.expt(y);
+    function(x, y, errbacks) {
+      return x.expt(y, errbacks);
     },
     {
-      isXSpecialCase: function(x) {
-        return eqv(x, 0) || eqv(x,1);
+      isXSpecialCase: function(x, errbacks) {
+        return eqv(x, 0, errbacks) || eqv(x, 1, errbacks);
       },
-      onXSpecialCase: function(x, y) {
-        if (eqv(x, 0)) {
-          if (eqv(y, 0)) {
+      onXSpecialCase: function(x, y, errbacks) {
+        if (eqv(x, 0, errbacks)) {
+          if (eqv(y, 0, errbacks)) {
             return 1;
-          } else if (lessThan(y, 0)) {
-            throwRuntimeError("expt: division by zero");
+          } else if (lessThan(y, 0, errbacks)) {
+            errbacks.throwDivByZero("expt: division by zero");
           } else {
             return 0;
           }
@@ -648,44 +632,44 @@ define(function() {
         }
       },
 
-      isYSpecialCase: function(y) {
-        return eqv(y, 0) || lessThan(y, 0);
+      isYSpecialCase: function(y, errbacks) {
+        return eqv(y, 0, errbacks) || lessThan(y, 0, errbacks);
       },
-      onYSpecialCase: function(x, y) {
-        if (eqv(y, 0)) {
+      onYSpecialCase: function(x, y, errbacks) {
+        if (eqv(y, 0, errbacks)) {
           return 1;
         } else { // i.e., y is negative
-          return expt(divide(1, x), negate(y));
+          return expt(divide(1, x, errbacks), negate(y), errbacks);
         }
       }
     });
 
   // exp: pyretnum -> pyretnum
-  var exp = function(n) {
-    if ( eqv(n, 0) ) {
+  var exp = function(n, errbacks) {
+    if ( eqv(n, 0, errbacks) ) {
       return 1;
     }
     if (typeof(n) === 'number') {
       var res = Math.exp(n);
       if (!isFinite(res))
-        throwRuntimeError('exp: argument too large: ' + n);
-      return Roughnum.makeInstance(res);
+        errbacks.throwGeneralError('exp: argument too large: ' + n);
+      return Roughnum.makeInstance(res, errbacks);
     }
     return n.exp();
   };
 
   // modulo: pyretnum pyretnum -> pyretnum
-  var modulo = function(m, n) {
+  var modulo = function(m, n, errbacks) {
     if (! isInteger(m)) {
-      throwRuntimeError('modulo: the first argument '
-                        + m + " is not an integer.", m, n);
+      errbacks.throwDomainError('modulo: the first argument '
+                                + m + " is not an integer.", m, n);
     }
     if (! isInteger(n)) {
-      throwRuntimeError('modulo: the second argument '
-                        + n + " is not an integer.", m, n);
+      errbacks.throwDomainError('modulo: the second argument '
+                                + n + " is not an integer.", m, n);
     }
     if (_integerIsZero(n)) {
-      throwRuntimeError('modulo: the second argument is zero');
+      errbacks.throwDomainError('modulo: the second argument is zero');
     }
     var result;
     if (typeof(m) === 'number') {
@@ -704,195 +688,195 @@ define(function() {
     }
     result = _integerModulo(floor(m), floor(n));
     // The sign of the result should match the sign of n.
-    if (lessThan(n, 0)) {
-      if (lessThanOrEqual(result, 0)) {
+    if (lessThan(n, 0, errbacks)) {
+      if (lessThanOrEqual(result, 0, errbacks)) {
         return result;
       }
-      return add(result, n);
+      return add(result, n, errbacks);
 
     } else {
-      if (lessThan(result, 0)) {
-        return add(result, n);
+      if (lessThan(result, 0, errbacks)) {
+        return add(result, n, errbacks);
       }
       return result;
     }
   };
 
   // numerator: pyretnum -> pyretnum
-  var numerator = function(n) {
+  var numerator = function(n, errbacks) {
     if (typeof(n) === 'number')
       return n;
     return n.numerator();
   };
 
   // denominator: pyretnum -> pyretnum
-  var denominator = function(n) {
+  var denominator = function(n, errbacks) {
     if (typeof(n) === 'number')
       return 1;
     return n.denominator();
   };
 
   // sqrt: pyretnum -> pyretnum
-  var sqrt = function(n) {
-    if (lessThan(n, 0)) {
-      throwRuntimeError('sqrt: negative argument ' + n);
+  var sqrt = function(n, errbacks) {
+    if (lessThan(n, 0, errbacks)) {
+      errbacks.throwSqrtNegative('sqrt: negative argument ' + n);
     }
     if (typeof(n) === 'number') {
       var result = Math.sqrt(n);
       if (Math.floor(result) === result) {
         return result;
       } else {
-        return Roughnum.makeInstance(result);
+        return Roughnum.makeInstance(result, errbacks);
       }
     }
     return n.sqrt();
   };
 
   // abs: pyretnum -> pyretnum
-  var abs = function(n) {
+  var abs = function(n, errbacks) {
     if (typeof(n) === 'number') {
       return Math.abs(n);
     }
-    return n.abs();
+    return n.abs(errbacks);
   };
 
   // floor: pyretnum -> pyretnum
-  var floor = function(n) {
+  var floor = function(n, errbacks) {
     if (typeof(n) === 'number')
       return Math.floor(n);
-    return n.floor();
+    return n.floor(errbacks);
   };
 
   // ceiling: pyretnum -> pyretnum
-  var ceiling = function(n) {
+  var ceiling = function(n, errbacks) {
     if (typeof(n) === 'number')
       return Math.ceil(n);
-    return n.ceiling();
+    return n.ceiling(errbacks);
   };
 
   // round: pyretnum -> pyretnum
-  var round = function(n) {
+  var round = function(n, errbacks) {
     if (typeof(n) === 'number') {
       return n;
     }
-    return n.round();
+    return n.round(errbacks);
   };
 
-  var roundEven = function(n) {
+  var roundEven = function(n, errbacks) {
     if (typeof(n) === 'number') return n;
-    return n.roundEven();
+    return n.roundEven(errbacks);
   };
 
   // NB: all of these trig-gy generic functions should now return roughnum rather than float
   // (except for an arg of 0, etc)
 
   // log: pyretnum -> pyretnum
-  var log = function(n) {
-    if ( eqv(n, 1) ) {
+  var log = function(n, errbacks) {
+    if ( eqv(n, 1, errbacks) ) {
       return 0;
     }
-    if (lessThanOrEqual(n, 0)) {
-      throwRuntimeError('log: non-positive argument ' + n);
+    if (lessThanOrEqual(n, 0, errbacks)) {
+      errbacks.throwLogNonPositive('log: non-positive argument ' + n);
     }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.log(n));
+      return Roughnum.makeInstance(Math.log(n), errbacks);
     }
     return n.log();
   };
 
   // tan: pyretnum -> pyretnum
-  var tan = function(n) {
-    if (eqv(n, 0)) { return 0; }
+  var tan = function(n, errbacks) {
+    if (eqv(n, 0, errbacks)) { return 0; }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.tan(n));
+      return Roughnum.makeInstance(Math.tan(n), errbacks);
     }
     return n.tan();
   };
 
   // atan: pyretnum -> pyretnum
-  var atan = function(n) {
-    if (eqv(n, 0)) { return 0; }
+  var atan = function(n, errbacks) {
+    if (eqv(n, 0, errbacks)) { return 0; }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.atan(n));
+      return Roughnum.makeInstance(Math.atan(n), errbacks);
     }
     return n.atan();
   };
 
   // cos: pyretnum -> pyretnum
-  var cos = function(n) {
-    if (eqv(n, 0)) { return 1; }
+  var cos = function(n, errbacks) {
+    if (eqv(n, 0, errbacks)) { return 1; }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.cos(n));
+      return Roughnum.makeInstance(Math.cos(n), errbacks);
     }
     return n.cos();
   };
 
   // sin: pyretnum -> pyretnum
-  var sin = function(n) {
-    if (eqv(n, 0)) { return 0; }
+  var sin = function(n, errbacks) {
+    if (eqv(n, 0, errbacks)) { return 0; }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.sin(n));
+      return Roughnum.makeInstance(Math.sin(n), errbacks);
     }
     return n.sin();
   };
 
   // acos: pyretnum -> pyretnum
-  var acos = function(n) {
-    if (eqv(n, 1)) { return 0; }
-    if (lessThan(n, -1) || greaterThan(n, 1)) {
-      throwRuntimeError('acos: out of domain argument ' + n);
+  var acos = function(n, errbacks) {
+    if (eqv(n, 1, errbacks)) { return 0; }
+    if (lessThan(n, -1, errbacks) || greaterThan(n, 1, errbacks)) {
+      errbacks.throwDomainError('acos: out of domain argument ' + n);
     }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.acos(n));
+      return Roughnum.makeInstance(Math.acos(n), errbacks);
     }
     return n.acos();
   };
 
   // asin: pyretnum -> pyretnum
-  var asin = function(n) {
-    if (eqv(n, 0)) { return 0; }
-    if (lessThan(n, -1) || greaterThan(n, 1)) {
-      throwRuntimeError('asin: out of domain argument ' + n);
+  var asin = function(n, errbacks) {
+    if (eqv(n, 0, errbacks)) { return 0; }
+    if (lessThan(n, -1, errbacks) || greaterThan(n, 1, errbacks)) {
+      errbacks.throwDomainError('asin: out of domain argument ' + n);
     }
     if (typeof(n) === 'number') {
-      return Roughnum.makeInstance(Math.asin(n));
+      return Roughnum.makeInstance(Math.asin(n), errbacks);
     }
     return n.asin();
   };
 
   // sqr: pyretnum -> pyretnum
-  var sqr = function(x) {
+  var sqr = function(x, errbacks) {
     return multiply(x, x);
   };
 
   // integerSqrt: pyretnum -> pyretnum
-  var integerSqrt = function(x) {
+  var integerSqrt = function(x, errbacks) {
     if (! isInteger(x)) {
-      throwRuntimeError('integer-sqrt: the argument ' + x.toString() +
+      errbacks.throwDomainError('integer-sqrt: the argument ' + x.toString() +
                         " is not an integer.", x);
     }
     if (typeof (x) === 'number') {
       if(x < 0) {
-        throwRuntimeError('integerSqrt of negative number', x);
+        errbacks.throwSqrtNegative('integerSqrt of negative number', x);
       } else {
         return Math.floor(Math.sqrt(x));
       }
     }
-    return x.integerSqrt();
+    return x.integerSqrt(errbacks);
   };
 
   // gcd: pyretnum [pyretnum ...] -> pyretnum
-  var gcd = function(first, rest) {
+  var gcd = function(first, rest, errbacks) {
     if (! isInteger(first)) {
-      throwRuntimeError('gcd: the argument ' + first.toString() +
-                        " is not an integer.", first);
+      errbacks.throwDomainError('gcd: the argument ' + first.toString() +
+                                " is not an integer.", first);
     }
-    var a = abs(first), t, b;
+    var a = abs(first, errbacks), t, b;
     for(var i = 0; i < rest.length; i++) {
-      b = abs(rest[i]);
+      b = abs(rest[i], errbacks);
       if (! isInteger(b)) {
-        throwRuntimeError('gcd: the argument ' + b.toString() +
-                          " is not an integer.", b);
+        errbacks.throwDomainError('gcd: the argument ' + b.toString() +
+                                  " is not an integer.", b);
       }
       while (! _integerIsZero(b)) {
         t = a;
@@ -904,47 +888,47 @@ define(function() {
   };
 
   // lcm: pyretnum [pyretnum ...] -> pyretnum
-  var lcm = function(first, rest) {
+  var lcm = function(first, rest, errbacks) {
     if (! isInteger(first)) {
-      throwRuntimeError('lcm: the argument ' + first.toString() +
-                        " is not an integer.", first);
+      errbacks.throwDomainError('lcm: the argument ' + first.toString() +
+                                " is not an integer.", first);
     }
-    var result = abs(first);
+    var result = abs(first, errbacks);
     if (_integerIsZero(result)) { return 0; }
     for (var i = 0; i < rest.length; i++) {
       if (! isInteger(rest[i])) {
-        throwRuntimeError('lcm: the argument ' + rest[i].toString() +
-                          " is not an integer.", rest[i]);
+        errbacks.throwDomainError('lcm: the argument ' + rest[i].toString() +
+                                  " is not an integer.", rest[i]);
       }
       var divisor = _integerGcd(result, rest[i]);
       if (_integerIsZero(divisor)) {
         return 0;
       }
-      result = divide(multiply(result, rest[i]), divisor);
+      result = divide(multiply(result, rest[i], errbacks), divisor, errbacks);
     }
     return result;
   };
 
-  var quotient = function(x, y) {
+  var quotient = function(x, y, errbacks) {
     if (! isInteger(x)) {
-      throwRuntimeError('quotient: the first argument ' + x.toString() +
-                        " is not an integer.", x);
+      errbacks.throwDomainError('quotient: the first argument ' + x.toString() +
+                                " is not an integer.", x);
     }
     if (! isInteger(y)) {
-      throwRuntimeError('quotient: the second argument ' + y.toString() +
-                        " is not an integer.", y);
+      errbacks.throwDomainError('quotient: the second argument ' + y.toString() +
+                                " is not an integer.", y);
     }
     return _integerQuotient(x, y);
   };
 
-  var remainder = function(x, y) {
+  var remainder = function(x, y, errbacks) {
     if (! isInteger(x)) {
-      throwRuntimeError('remainder: the first argument ' + x.toString() +
-                        " is not an integer.", x);
+      errbacks.throwDomainError('remainder: the first argument ' + x.toString() +
+                                " is not an integer.", x);
     }
     if (! isInteger(y)) {
-      throwRuntimeError('remainder: the second argument ' + y.toString() +
-                        " is not an integer.", y);
+      errbacks.throwDomainError('remainder: the second argument ' + y.toString() +
+                                " is not an integer.", y);
     }
     return _integerRemainder(x, y);
   };
@@ -972,25 +956,25 @@ define(function() {
 
   // halve: pyretnum -> pyretnum
   // Divide a number by 2.
-  var halve = function(n) {
-    return divide(n, 2);
+  var halve = function(n, errbacks) {
+    return divide(n, 2, errbacks);
   };
 
   // fastExpt: computes n^k by squaring.
   // n^k = (n^2)^(k/2)
   // Assumes k is non-negative integer.
-  var fastExpt = function(n, k) {
+  var fastExpt = function(n, k, errbacks) {
     var acc = 1;
     while (true) {
       if (_integerIsZero(k)) {
         return acc;
       }
-      if (equals(modulo(k, 2), 0)) {
-        n = multiply(n, n);
-        k = divide(k, 2);
+      if (equals(modulo(k, 2, errbacks), 0, errbacks)) {
+        n = multiply(n, n, errbacks);
+        k = divide(k, 2, errbacks);
       } else {
-        acc = multiply(acc, n);
-        k = subtract(k, 1);
+        acc = multiply(acc, n, errbacks);
+        k = subtract(k, 1, errbacks);
       }
     }
   };
@@ -1027,7 +1011,7 @@ define(function() {
       }
       if (m instanceof Roughnum || n instanceof Roughnum) {
         return Roughnum.makeInstance(
-          onFixnums(toFixnum(m), toFixnum(n)));
+          onFixnums(toFixnum(m), toFixnum(n)), errbacks);
       }
       if (typeof(m) === 'number') {
         m = makeBignum(m);
@@ -1039,7 +1023,7 @@ define(function() {
     });
   };
 
-  var makeIntegerUnOp = function(onFixnums, onBignums, options) {
+  var makeIntegerUnOp = function(onFixnums, onBignums, options, errbacks) {
     options = options || {};
     return (function(m) {
       if (m instanceof Rational) {
@@ -1054,7 +1038,7 @@ define(function() {
         }
       }
       if (m instanceof Roughnum) {
-        return Roughnum.makeInstance(onFixnums(toFixnum(m)));
+        return Roughnum.makeInstance(onFixnums(toFixnum(m)), errbacks);
       }
       if (typeof(m) === 'number') {
         m = makeBignum(m);
@@ -1335,9 +1319,9 @@ define(function() {
     this.d = d;
   };
 
-  Rational.makeInstance = function(n, d) {
+  Rational.makeInstance = function(n, d, errbacks) {
     if (n === undefined)
-      throwRuntimeError("n undefined", n, d);
+      errbacks.throwUndefinedValue("n undefined", n, d);
 
     if (d === undefined) { d = 1; }
 
@@ -1346,7 +1330,7 @@ define(function() {
       d = negate(d);
     }
 
-    var divisor = _integerGcd(abs(n), abs(d));
+    var divisor = _integerGcd(abs(n, errbacks), abs(d, errbacks));
     n = _integerQuotient(n, divisor);
     d = _integerQuotient(d, divisor);
 
@@ -1371,7 +1355,7 @@ define(function() {
     return true;
   };
 
-  Rational.prototype.equals = function(other) {
+  Rational.prototype.equals = function(other, errbacks) {
     return (other instanceof Rational &&
             _integerEquals(this.n, other.n) &&
             _integerEquals(this.d, other.d));
@@ -1412,33 +1396,33 @@ define(function() {
     return this.n <= 0;
   };
 
-  Rational.prototype.add = function(other) {
+  Rational.prototype.add = function(other, errbacks) {
     return Rational.makeInstance(_integerAdd(_integerMultiply(this.n, other.d),
                                              _integerMultiply(this.d, other.n)),
-                                 _integerMultiply(this.d, other.d));
+                                 _integerMultiply(this.d, other.d), errbacks);
   };
 
-  Rational.prototype.subtract = function(other) {
+  Rational.prototype.subtract = function(other, errbacks) {
     return Rational.makeInstance(_integerSubtract(_integerMultiply(this.n, other.d),
                                                   _integerMultiply(this.d, other.n)),
-                                 _integerMultiply(this.d, other.d));
+                                 _integerMultiply(this.d, other.d), errbacks);
   };
 
-  Rational.prototype.negate = function() {
-    return Rational.makeInstance(negate(this.n), this.d)
+  Rational.prototype.negate = function(errbacks) {
+    return Rational.makeInstance(negate(this.n), this.d, errbacks)
   };
 
-  Rational.prototype.multiply = function(other) {
+  Rational.prototype.multiply = function(other, errbacks) {
     return Rational.makeInstance(_integerMultiply(this.n, other.n),
-                                 _integerMultiply(this.d, other.d));
+                                 _integerMultiply(this.d, other.d), errbacks);
   };
 
-  Rational.prototype.divide = function(other) {
+  Rational.prototype.divide = function(other, errbacks) {
     if (_integerIsZero(this.d) || _integerIsZero(other.n)) {  // dead code!
-      throwRuntimeError("/: division by zero", this, other);
+      errbacks.throwDivByZero("/: division by zero", this, other);
     }
     return Rational.makeInstance(_integerMultiply(this.n, other.d),
-                                 _integerMultiply(this.d, other.n));
+                                 _integerMultiply(this.d, other.n), errbacks);
   };
 
   Rational.prototype.toRational = function() {
@@ -1451,8 +1435,8 @@ define(function() {
     return _integerDivideToFixnum(this.n, this.d);
   };
 
-  Rational.prototype.toRoughnum = function() {
-    return Roughnum.makeInstance(this.toFixnum());
+  Rational.prototype.toRoughnum = function(errbacks) {
+    return Roughnum.makeInstance(this.toFixnum(), errbacks);
   };
 
   Rational.prototype.numerator = function() {
@@ -1463,131 +1447,131 @@ define(function() {
     return this.d;
   };
 
-  Rational.prototype.greaterThan = function(other) {
+  Rational.prototype.greaterThan = function(other, errbacks) {
     return _integerGreaterThan(_integerMultiply(this.n, other.d),
                                _integerMultiply(this.d, other.n));
   };
 
-  Rational.prototype.greaterThanOrEqual = function(other) {
+  Rational.prototype.greaterThanOrEqual = function(other, errbacks) {
     return _integerGreaterThanOrEqual(_integerMultiply(this.n, other.d),
                                       _integerMultiply(this.d, other.n));
   };
 
-  Rational.prototype.lessThan = function(other) {
+  Rational.prototype.lessThan = function(other, errbacks) {
     return _integerLessThan(_integerMultiply(this.n, other.d),
                             _integerMultiply(this.d, other.n));
   };
 
-  Rational.prototype.lessThanOrEqual = function(other) {
+  Rational.prototype.lessThanOrEqual = function(other, errbacks) {
     return _integerLessThanOrEqual(_integerMultiply(this.n, other.d),
                                    _integerMultiply(this.d, other.n));
   };
 
-  Rational.prototype.integerSqrt = function() {
+  Rational.prototype.integerSqrt = function(errbacks) {
     var result = sqrt(this);
-    return toRational(floor(result));
+    return toRational(floor(result, errbacks), errbacks);
   };
 
-  Rational.prototype.sqrt = function() {
+  Rational.prototype.sqrt = function(errbacks) {
     var newN = sqrt(this.n);
     var newD = sqrt(this.d);
     if (isRational(newN) && isRational(newD) &&
         equals(floor(newN), newN) &&
         equals(floor(newD), newD)) {
-      return Rational.makeInstance(newN, newD);
+      return Rational.makeInstance(newN, newD, errbacks);
     } else {
-      return divide(newN, newD);
+      return divide(newN, newD, errbacks);
     }
   };
 
-  Rational.prototype.abs = function() {
-    return Rational.makeInstance(abs(this.n),
-                                 this.d);
+  Rational.prototype.abs = function(errbacks) {
+    return Rational.makeInstance(abs(this.n, errbacks),
+                                 this.d, errbacks);
   };
 
-  Rational.prototype.floor = function() {
+  Rational.prototype.floor = function(errbacks) {
     var quotient = _integerQuotient(this.n, this.d);
     if (_integerLessThan(this.n, 0)) {
-      return subtract(quotient, 1);
+      return subtract(quotient, 1, errbacks);
     } else {
       return quotient;
     }
   };
 
-  Rational.prototype.ceiling = function() {
+  Rational.prototype.ceiling = function(errbacks) {
     var quotient = _integerQuotient(this.n, this.d);
     if (_integerLessThan(this.n, 0)) {
       return quotient;
     } else {
-      return add(quotient, 1);
+      return add(quotient, 1, errbacks);
     }
   };
 
-  Rational.prototype.round = function() {
+  Rational.prototype.round = function(errbacks) {
     var halfintp = equals(this.d, 2);
     var negativep = _integerLessThan(this.n, 0);
     var n = this.n;
     if (negativep) {
-      n = negate(n);
+      n = negate(n, errbacks);
     }
     var quo = _integerQuotient(n, this.d);
     if (halfintp) {
       // rounding half to away from 0
       // uncomment following if rounding half to even
       // if (_integerIsOne(_integerModulo(quo, 2)))
-      quo = add(quo, 1);
+      quo = add(quo, 1, errbacks);
     } else {
       var rem = _integerRemainder(n, this.d);
-      if (greaterThan(multiply(rem, 2), this.d)) {
-        quo = add(quo, 1);
+      if (greaterThan(multiply(rem, 2, errbacks), this.d, errbacks)) {
+        quo = add(quo, 1, errbacks);
       }
     }
     if (negativep) {
-      quo = negate(quo);
+      quo = negate(quo, errbacks);
     }
     return quo;
   };
 
-  Rational.prototype.roundEven = function() {
+  Rational.prototype.roundEven = function(errbacks) {
     // rounds half-integers to even
-    var halfintp = equals(this.d, 2);
+    var halfintp = equals(this.d, 2, errbacks);
     var negativep = _integerLessThan(this.n, 0);
     var n = this.n;
-    if (negativep) n = negate(n);
+    if (negativep) n = negate(n, errbacks);
     var quo = _integerQuotient(n, this.d);
     if (halfintp) {
       if (_integerIsOne(_integerModulo(quo, 2)))
-        quo = add(quo, 1);
+        quo = add(quo, 1, errbacks);
     } else {
       var rem = _integerRemainder(n, this.d);
-      if (greaterThan(multiply(rem, 2), this.d))
-        quo = add(quo, 1);
+      if (greaterThan(multiply(rem, 2, errbacks), this.d, errbacks))
+        quo = add(quo, 1, errbacks);
     }
-    if (negativep) quo = negate(quo);
+    if (negativep) quo = negate(quo, errbacks);
     return quo;
   };
 
-  Rational.prototype.log = function(){
-    return Roughnum.makeInstance(Math.log(this.toFixnum()));
+  Rational.prototype.log = function(errbacks){
+    return Roughnum.makeInstance(Math.log(this.toFixnum()), errbacks);
   };
 
-  Rational.prototype.tan = function(){
-    return Roughnum.makeInstance(Math.tan(this.toFixnum()));
+  Rational.prototype.tan = function(errbacks){
+    return Roughnum.makeInstance(Math.tan(this.toFixnum()), errbacks);
   };
 
-  Rational.prototype.atan = function(){
-    return Roughnum.makeInstance(Math.atan(this.toFixnum()));
+  Rational.prototype.atan = function(errbacks){
+    return Roughnum.makeInstance(Math.atan(this.toFixnum()), errbacks);
   };
 
-  Rational.prototype.cos = function(){
-    return Roughnum.makeInstance(Math.cos(this.toFixnum()));
+  Rational.prototype.cos = function(errbacks){
+    return Roughnum.makeInstance(Math.cos(this.toFixnum()), errbacks);
   };
 
-  Rational.prototype.sin = function(){
-    return Roughnum.makeInstance(Math.sin(this.toFixnum()));
+  Rational.prototype.sin = function(errbacks){
+    return Roughnum.makeInstance(Math.sin(this.toFixnum()), errbacks);
   };
 
-  var integerNthRoot = function(n, m) {
+  var integerNthRoot = function(n, m, errbacks) {
     var guessPrev, guessToTheN;
     var guess = m;
 
@@ -1598,76 +1582,77 @@ define(function() {
     // if x_k stops evolving
 
     while(true) {
-      guessToTheN = expt(guess, n);
-      if (lessThanOrEqual(guessToTheN, m) &&
-          lessThan(m, expt(add(guess, 1), n))) break;
+      guessToTheN = expt(guess, n, errbacks);
+      if (lessThanOrEqual(guessToTheN, m, errbacks) &&
+          lessThan(m, expt(add(guess, 1, errbacks), n, errbacks), errbacks)) break;
       guessPrev = guess;
-      guess = floor(subtract(guess, divide(subtract(guessToTheN, m),
-            multiply(n, divide(guessToTheN, guess)))));
-      if (equals(guess, guessPrev)) break;
+      guess = floor(subtract(guess, divide(subtract(guessToTheN, m, errbacks),
+            multiply(n, divide(guessToTheN, guess, errbacks), errbacks), errbacks), errbacks), errbacks);
+      if (equals(guess, guessPrev, errbacks)) break;
     }
 
     return guess;
   };
 
-  var nthRoot = function(n, m) {
+  var nthRoot = function(n, m, errbacks) {
     var mNeg = (sign(m) < 0);
-    var mAbs = (mNeg ? abs(m) : m);
+    var mAbs = (mNeg ? abs(m, errbacks) : m);
     var approx;
 
     if (mNeg && _integerModulo(n, 2) === 0)
-      throwRuntimeError('expt: taking even (' + n + ') root of negative integer ' + m);
+      errbacks.throwDomainError('expt: taking even (' + n + ') root of negative integer ' + m);
 
-    approx = integerNthRoot(n, mAbs);
-    if (mNeg) approx = negate(approx);
-    if (eqv(expt(approx, n), m)) return approx;
+    approx = integerNthRoot(n, mAbs, errbacks);
+    if (mNeg) approx = negate(approx, errbacks);
+    if (eqv(expt(approx, n, errbacks), m, errbacks)) return approx;
 
-    approx = Roughnum.makeInstance(Math.pow(toFixnum(mAbs), toFixnum(divide(1,n))));
-    return (mNeg ? negate(approx) : approx);
+    approx = Roughnum.makeInstance(Math.pow(toFixnum(mAbs),
+                                            toFixnum(divide(1,n, errbacks))), errbacks);
+    return (mNeg ? negate(approx, errbacks) : approx);
   };
 
-  Rational.prototype.expt = function(a) {
-    if (isInteger(a) && greaterThanOrEqual(a, 0)) {
-      return fastExpt(this, a);
+  Rational.prototype.expt = function(a, errbacks) {
+    if (isInteger(a) && greaterThanOrEqual(a, 0, errbacks)) {
+      return fastExpt(this, a, errbacks);
     } else if (_integerLessThanOrEqual(a.d, 8)) {
-      var nRaisedToAn = expt(this.n, a.n);
-      var dRaisedToAn = expt(this.d, a.n);
-      var newN = nthRoot(a.d, nRaisedToAn);
-      var newD = nthRoot(a.d, dRaisedToAn);
+      var nRaisedToAn = expt(this.n, a.n, errbacks);
+      var dRaisedToAn = expt(this.d, a.n, errbacks);
+      var newN = nthRoot(a.d, nRaisedToAn, errbacks);
+      var newD = nthRoot(a.d, dRaisedToAn, errbacks);
       if (isRational(newN) && isRational(newD) &&
-          equals(floor(newN), newN) &&
-          equals(floor(newD), newD)) {
-        return Rational.makeInstance(newN, newD);
+          equals(floor(newN), newN, errbacks) &&
+          equals(floor(newD), newD, errbacks)) {
+        return Rational.makeInstance(newN, newD, errbacks);
       } else {
-        return divide(newN, newD);
+        return divide(newN, newD, errbacks);
      }
     } else {
       if (this.isNegative() && !a.isInteger())
-        throwRuntimeError('expt: raising negative number ' + this + ' to nonintegral power ' + a);
-      return Roughnum.makeInstance(Math.pow(this.toFixnum(), a.toFixnum()));
+        errbacks.throwDomainError('expt: raising negative number ' + this + ' to nonintegral power ' + a);
+      return Roughnum.makeInstance(Math.pow(this.toFixnum(), a.toFixnum()), errbacks);
     }
   };
 
-  Rational.prototype.exp = function(){
+  Rational.prototype.exp = function(errbacks){
     var res = Math.exp(this.toFixnum());
     if (!isFinite(res))
-      throwRuntimeError('exp: argument too large: ' + this);
-    return Roughnum.makeInstance(res);
+      errbacks.throwDomainError('exp: argument too large: ' + this);
+    return Roughnum.makeInstance(res, errbacks);
   };
 
-  Rational.prototype.acos = function(){
-    return acos(this.toFixnum());
+  Rational.prototype.acos = function(errbacks){
+    return acos(this.toFixnum(), errbacks);
   };
 
-  Rational.prototype.asin = function(){
-    return asin(this.toFixnum());
+  Rational.prototype.asin = function(errbacks){
+    return asin(this.toFixnum(), errbacks);
   };
 
   // sign: Number -> {-1, 0, 1}
-  var sign = function(n) {
-    if (lessThan(n, 0)) {
+  var sign = function(n, errbacks) {
+    if (lessThan(n, 0, errbacks)) {
       return -1;
-    } else if (greaterThan(n, 0)) {
+    } else if (greaterThan(n, 0, errbacks)) {
       return 1;
     } else {
       return 0;
@@ -1676,17 +1661,17 @@ define(function() {
 
   // Roughnums
 
-  var Roughnum = function(n) {
+  var Roughnum = function(n, errbacks) {
     if (!(typeof(n) === 'number'))
-      throwRuntimeError('roughnum constructor got unsuitable arg ' + n);
+      errbacks.throwGeneralError('roughnum constructor got unsuitable arg ' + n);
     this.n = n;
   };
 
-  Roughnum.makeInstance = function(n) {
+  Roughnum.makeInstance = function(n, errbacks) {
     if (typeof(n) === 'number' && !isFinite(n)) {
-      throwRuntimeError('roughnum overflow error');
+      errbacks.throwDomainError('roughnum overflow error');
     }
-    return new Roughnum(n);
+    return new Roughnum(n, errbacks);
   };
 
   Roughnum.prototype.isFinite = function() {
@@ -1694,13 +1679,13 @@ define(function() {
     return (isFinite(this.n));
   };
 
-  Roughnum.prototype.toRational = function() {
+  Roughnum.prototype.toRational = function(errbacks) {
     if (!isFinite(this.n)) {
       // this _should_ be dead, as we don't store overflows
-      throwRuntimeError("toRational: no exact representation for " + this);
+      errbacks.throwInternalError("toRational: no exact representation for " + this);
     }
 
-    return fromString(this.n.toString());
+    return fromString(this.n.toString(), errbacks);
   };
 
   Roughnum.prototype.toExact = Roughnum.prototype.toRational;
@@ -1709,8 +1694,8 @@ define(function() {
     return '~' + this.n.toString();
   };
 
-  Roughnum.prototype.equals = function(other, aUnionFind) {
-    throwRuntimeError("roughnums cannot be compared for equality");
+  Roughnum.prototype.equals = function(other, errbacks) {
+    errbacks.throwIncomparableValues("roughnums cannot be compared for equality");
   };
 
   Roughnum.prototype.isRational = function() {
@@ -1747,31 +1732,31 @@ define(function() {
     return this.n <= 0;
   };
 
-  Roughnum.prototype.add = function(other) {
-    return Roughnum.makeInstance(this.n + other.n);
+  Roughnum.prototype.add = function(other, errbacks) {
+    return Roughnum.makeInstance(this.n + other.n, errbacks);
   };
 
-  Roughnum.prototype.subtract = function(other) {
-    return Roughnum.makeInstance(this.n - other.n);
+  Roughnum.prototype.subtract = function(other, errbacks) {
+    return Roughnum.makeInstance(this.n - other.n, errbacks);
   };
 
-  Roughnum.prototype.negate = function() {
-    return Roughnum.makeInstance(-this.n);
+  Roughnum.prototype.negate = function(errbacks) {
+    return Roughnum.makeInstance(-this.n, errbacks);
   };
 
-  Roughnum.prototype.multiply = function(other) {
-    return Roughnum.makeInstance(this.n * other.n);
+  Roughnum.prototype.multiply = function(other, errbacks) {
+    return Roughnum.makeInstance(this.n * other.n, errbacks);
   };
 
-  Roughnum.prototype.divide = function(other) {
-    return Roughnum.makeInstance(this.n / other.n);
+  Roughnum.prototype.divide = function(other, errbacks) {
+    return Roughnum.makeInstance(this.n / other.n, errbacks);
   };
 
   Roughnum.prototype.toFixnum = function() {
     return this.n;
   };
 
-  Roughnum.prototype.toRoughnum = function() {
+  Roughnum.prototype.toRoughnum = function(errbacks) {
     return this;
   };
 
@@ -1802,15 +1787,15 @@ define(function() {
     }
   };
 
-  Roughnum.prototype.floor = function() {
+  Roughnum.prototype.floor = function(errbacks) {
     return Math.floor(this.n);
   };
 
-  Roughnum.prototype.ceiling = function() {
+  Roughnum.prototype.ceiling = function(errbacks) {
     return Math.ceil(this.n);
   };
 
-  Roughnum.prototype.round = function(){
+  Roughnum.prototype.round = function(errbacks){
     var negativep = (this.n < 0);
     var n = this.n;
     if (negativep) n = -n;
@@ -1819,7 +1804,7 @@ define(function() {
     return res;
   };
 
-  Roughnum.prototype.roundEven = function() {
+  Roughnum.prototype.roundEven = function(errbacks) {
     var negativep = (this.n < 0);
     var n = this.n;
     if (negativep) n = -n;
@@ -1829,86 +1814,86 @@ define(function() {
     return res;
   };
 
-  Roughnum.prototype.greaterThan = function(other) {
+  Roughnum.prototype.greaterThan = function(other, errbacks) {
     return this.n > other.n;
   };
 
-  Roughnum.prototype.greaterThanOrEqual = function(other) {
+  Roughnum.prototype.greaterThanOrEqual = function(other, errbacks) {
     return this.n >= other.n;
   };
 
-  Roughnum.prototype.lessThan = function(other) {
+  Roughnum.prototype.lessThan = function(other, errbacks) {
     return this.n < other.n;
   };
 
-  Roughnum.prototype.lessThanOrEqual = function(other) {
+  Roughnum.prototype.lessThanOrEqual = function(other, errbacks) {
     return this.n <= other.n;
   };
 
-  Roughnum.prototype.integerSqrt = function() {
+  Roughnum.prototype.integerSqrt = function(errbacks) {
     if (isInteger(this)) {
       if(this.n >= 0) {
-        return Roughnum.makeInstance(Math.floor(Math.sqrt(this.n)));
+        return Roughnum.makeInstance(Math.floor(Math.sqrt(this.n)), errbacks);
       } else {
-        throwRuntimeError('integerSqrt of negative roughnum', this.n);
+        errbacks.throwDomainError('integerSqrt of negative roughnum', this.n);
       }
     } else {
-      throwRuntimeError("integerSqrt: can only be applied to an integer", this);
+      errbacks.throwDomainError("integerSqrt: can only be applied to an integer", this);
     }
   };
 
-  Roughnum.prototype.sqrt = function() {
-    return Roughnum.makeInstance(Math.sqrt(this.n));
+  Roughnum.prototype.sqrt = function(errbacks) {
+    return Roughnum.makeInstance(Math.sqrt(this.n), errbacks);
   };
 
-  Roughnum.prototype.abs = function() {
-    return Roughnum.makeInstance(Math.abs(this.n));
+  Roughnum.prototype.abs = function(errbacks) {
+    return Roughnum.makeInstance(Math.abs(this.n), errbacks);
   };
 
-  Roughnum.prototype.log = function(){
+  Roughnum.prototype.log = function(errbacks){
     if (this.n < 0)
-      throwRuntimeError('log of negative roughnum', this.n);
+      errbacks.throwDomainError('log of negative roughnum', this.n);
     else
-      return Roughnum.makeInstance(Math.log(this.n));
+      return Roughnum.makeInstance(Math.log(this.n), errbacks);
   };
 
-  Roughnum.prototype.tan = function(){
-    return Roughnum.makeInstance(Math.tan(this.n));
+  Roughnum.prototype.tan = function(errbacks){
+    return Roughnum.makeInstance(Math.tan(this.n), errbacks);
   };
 
-  Roughnum.prototype.atan = function(){
-    return Roughnum.makeInstance(Math.atan(this.n));
+  Roughnum.prototype.atan = function(errbacks){
+    return Roughnum.makeInstance(Math.atan(this.n), errbacks);
   };
 
-  Roughnum.prototype.cos = function(){
-    return Roughnum.makeInstance(Math.cos(this.n));
+  Roughnum.prototype.cos = function(errbacks){
+    return Roughnum.makeInstance(Math.cos(this.n), errbacks);
   };
 
-  Roughnum.prototype.sin = function(){
-    return Roughnum.makeInstance(Math.sin(this.n));
+  Roughnum.prototype.sin = function(errbacks){
+    return Roughnum.makeInstance(Math.sin(this.n), errbacks);
   };
 
-  Roughnum.prototype.expt = function(a){
+  Roughnum.prototype.expt = function(a, errbacks){
     if (this.n === 1) {
       return this;
     } else {
-      return Roughnum.makeInstance(Math.pow(this.n, a.n));
+      return Roughnum.makeInstance(Math.pow(this.n, a.n), errbacks);
     }
   };
 
-  Roughnum.prototype.exp = function(){
+  Roughnum.prototype.exp = function(errbacks){
     var res = Math.exp(this.n);
     if (!isFinite(res))
-      throwRuntimeError('exp: argument too large: ' + this);
+      errbacks.throwDomainError('exp: argument too large: ' + this);
     return Roughnum.makeInstance(res);
   };
 
-  Roughnum.prototype.acos = function(){
-    return acos(this.n);
+  Roughnum.prototype.acos = function(errbacks){
+    return acos(this.n, errbacks);
   };
 
-  Roughnum.prototype.asin = function(){
-    return asin(this.n);
+  Roughnum.prototype.asin = function(errbacks){
+    return asin(this.n, errbacks);
   };
 
   var rationalRegexp = new RegExp("^([+-]?\\d+)/(\\d+)$");
@@ -1918,7 +1903,7 @@ define(function() {
   var scientificPattern = new RegExp("^([+-]?\\d*\\.?\\d*)[Ee]([+]?\\d+)$");
 
   // fromString: string -> (pyretnum | false)
-  var fromString = function(x) {
+  var fromString = function(x, errbacks) {
     if (x.match(digitRegexp)) {
       var n = Number(x);
       if (isOverflow(n)) {
@@ -1931,7 +1916,7 @@ define(function() {
     var aMatch = x.match(rationalRegexp);
     if (aMatch) {
       return Rational.makeInstance(fromString(aMatch[1]),
-                                   fromString(aMatch[2]));
+                                   fromString(aMatch[2]), errbacks);
     }
 
     aMatch = x.match(flonumRegexp);
@@ -1971,7 +1956,7 @@ define(function() {
       var finalDen = denominatorTen;
       var finalNum = _integerAdd(_integerMultiply(beforeDecimal, denominatorTen), afterDecimal);
       if (negativeP) {
-        finalNum = negate(finalNum);
+        finalNum = negate(finalNum, errbacks);
       }
       //
       if (!equals(exponent, 1)) {
@@ -1981,12 +1966,12 @@ define(function() {
           finalNum = _integerMultiply(finalNum, exponent);
         }
       }
-      return Rational.makeInstance(finalNum, finalDen);
+      return Rational.makeInstance(finalNum, finalDen, errbacks);
     }
 
     aMatch = x.match(roughnumRegexp);
     if (aMatch) {
-      return Roughnum.makeInstance(Number(aMatch[1]));
+      return Roughnum.makeInstance(Number(aMatch[1]), errbacks);
     }
 
     return false; // if all else fails
@@ -2001,11 +1986,11 @@ define(function() {
 
     function schemeRationalRegexp(digits) { return new RegExp("^([+-]?["+digits+"]+)/(["+digits+"]+)$"); }
 
-    function matchComplexRegexp(radix, x) {
+    function matchComplexRegexp(radix, x, errbacks) {
 	var sign = "[+-]";
 	var maybeSign = "[+-]?";
-	var digits = digitsForRadix(radix)
-	var expmark = "["+expMarkForRadix(radix)+"]"
+	var digits = digitsForRadix(radix, errbacks)
+	var expmark = "["+expMarkForRadix(radix, errbacks)+"]"
 	var digitSequence = "["+digits+"]+"
 
 	var unsignedRational = digitSequence+"/"+digitSequence
@@ -2065,17 +2050,17 @@ define(function() {
 			  ")["+exp_mark+"]([+-]?["+digits+"]+))$");
     }
 
-    function digitsForRadix(radix) {
+    function digitsForRadix(radix, errbacks) {
 	return radix === 2  ? "01" :
 	       radix === 8  ? "0-7" :
 	       radix === 10 ? "0-9" :
 	       radix === 16 ? "0-9a-fA-F" :
-	       throwRuntimeError("digitsForRadix: invalid radix", this, radix)
+	       errbacks.throwInternalError("digitsForRadix: invalid radix", this, radix)
     }
-    function expMarkForRadix(radix) {
+    function expMarkForRadix(radix, errbacks) {
 	return (radix === 2 || radix === 8 || radix === 10) ? "defsl" :
 	       (radix === 16)                               ? "sl" :
-	       throwRuntimeError("expMarkForRadix: invalid radix", this, radix)
+	       errbacks.throwInternalError("expMarkForRadix: invalid radix", this, radix)
     }
 
     function Exactness(i) {
@@ -2092,15 +2077,15 @@ define(function() {
     Exactness.prototype.floatAsInexactp = function () { return this.defaultp() || this.inexactp(); };
 
     // fromSchemeString: string boolean -> (scheme-number | false)
-    var fromSchemeString = function(x, exactness) {
+    var fromSchemeString = function(x, exactness, errbacks) {
 
 	var radix = 10
 	var exactness = typeof exactness === 'undefined' ? Exactness.def :
 			exactness === true               ? Exactness.on :
 			exactness === false              ? Exactness.off :
-	   /* else */  throwRuntimeError( "exactness must be true or false"
-                                        , this
-                                        , r) ;
+	   /* else */  errbacks.throwInternalError( "exactness must be true or false"
+                                                   , this
+                                                   , r) ;
 
 	var hMatch = x.toLowerCase().match(hashModifiersRegexp)
 	if (hMatch) {
@@ -2114,7 +2099,7 @@ define(function() {
 		exactness = f === 'e' ? Exactness.on :
 			    f === 'i' ? Exactness.off :
 			 // this case is unreachable
-			 throwRuntimeError("invalid exactness flag", this, r)
+			 errbacks.throwInternalError("invalid exactness flag", this, r)
 	    }
 	    if (radixFlag) {
 		var f = radixFlag[1].charAt(1)
@@ -2123,7 +2108,7 @@ define(function() {
             f === 'd' ? 10 :
             f === 'x' ? 16 :
 			 // this case is unreachable
-			throwRuntimeError("invalid radix flag", this, r)
+			errbacks.throwInternalError("invalid radix flag", this, r)
 	    }
 	}
 
@@ -2133,29 +2118,32 @@ define(function() {
 	// when the item could potentially have been read as a symbol.
 	var mustBeANumberp = hMatch ? true : false
 
-	return fromSchemeStringRaw(numberString, radix, exactness, mustBeANumberp)
+	return fromSchemeStringRaw(numberString, radix, exactness, mustBeANumberp, errbacks)
     };
 
-    function fromSchemeStringRaw(x, radix, exactness, mustBeANumberp) {
-	var cMatch = matchComplexRegexp(radix, x);
+    function fromSchemeStringRaw(x, radix, exactness, mustBeANumberp, errbacks) {
+	var cMatch = matchComplexRegexp(radix, x, errbacks);
 	if (cMatch) {
           throw "Complex Numbers are not supported in Pyret";
 	}
 
-        return fromSchemeStringRawNoComplex(x, radix, exactness, mustBeANumberp)
+        return fromSchemeStringRawNoComplex(x, radix, exactness, mustBeANumberp, errbacks)
     }
 
-    function fromSchemeStringRawNoComplex(x, radix, exactness, mustBeANumberp) {
-	var aMatch = x.match(schemeRationalRegexp(digitsForRadix(radix)));
+    function fromSchemeStringRawNoComplex(x, radix, exactness, mustBeANumberp, errbacks) {
+	var aMatch = x.match(schemeRationalRegexp(digitsForRadix(radix, errbacks)));
 	if (aMatch) {
-	    return Rational.makeInstance( fromSchemeStringRawNoComplex( aMatch[1]
-                                                                , radix
-                                                                , exactness
-                                                                )
+	  return Rational.makeInstance( fromSchemeStringRawNoComplex( aMatch[1]
+                                                                      , radix
+                                                                      , exactness
+                                                                      , errbacks
+                                                                    )
                                         , fromSchemeStringRawNoComplex( aMatch[2]
-                                                                , radix
-                                                                , exactness
-                                                                ));
+                                                                        , radix
+                                                                        , exactness
+                                                                        , errbacks
+                                                                      )
+                                        , errbacks);
 	}
 
         if (x === '+nan.0' ||
@@ -2166,29 +2154,30 @@ define(function() {
           return Roughnum.makeInstance(Infinity);
         }
 
-	var fMatch = x.match(schemeFlonumRegexp(digitsForRadix(radix)))
+	var fMatch = x.match(schemeFlonumRegexp(digitsForRadix(radix, errbacks)))
 	if (fMatch) {
 	    var integralPart = fMatch[3] !== undefined ? fMatch[3] : fMatch[5];
 	    var fractionalPart = fMatch[4] !== undefined ? fMatch[4] : fMatch[6];
 	    return parseFloat( fMatch[1]
-                             , integralPart
-                             , fractionalPart
-                             , radix
-                             , exactness
+                               , integralPart
+                               , fractionalPart
+                               , radix
+                               , exactness
+                               , errbacks
                              )
 	}
 
-	var sMatch = x.match(schemeScientificPattern( digitsForRadix(radix)
-					      , expMarkForRadix(radix)
+	var sMatch = x.match(schemeScientificPattern( digitsForRadix(radix, errbacks)
+					      , expMarkForRadix(radix, errbacks)
 					      ))
 	if (sMatch) {
-	    var coefficient = fromSchemeStringRawNoComplex(sMatch[1], radix, exactness)
-	    var exponent = fromSchemeStringRawNoComplex(sMatch[2], radix, exactness)
-	    return multiply(coefficient, expt(radix, exponent));
+	    var coefficient = fromSchemeStringRawNoComplex(sMatch[1], radix, exactness, errbacks)
+	    var exponent = fromSchemeStringRawNoComplex(sMatch[2], radix, exactness, errbacks)
+	    return multiply(coefficient, expt(radix, exponent, errbacks), errbacks);
 	}
 
 	// Finally, integer tests.
-	if (x.match(schemeDigitRegexp(digitsForRadix(radix)))) {
+	if (x.match(schemeDigitRegexp(digitsForRadix(radix, errbacks)))) {
 	    var n = parseInt(x, radix);
 	    if (isOverflow(n)) {
 		return makeBignum(x);
@@ -2198,42 +2187,42 @@ define(function() {
 		return Roughnum.makeInstance(n)
 	    }
 	} else if (mustBeANumberp) {
-	    if(x.length===0) throwRuntimeError("no digits");
-	    throwRuntimeError("bad number: " + x, this);
+	    if(x.length===0) errbacks.throwGeneralError("no digits");
+	    errbacks.throwGeneralError("bad number: " + x, this);
 	} else {
 	    return false;
 	}
     };
 
-    function parseFloat(sign, integralPart, fractionalPart, radix, exactness) {
+    function parseFloat(sign, integralPart, fractionalPart, radix, exactness, errbacks) {
 	var sign = (sign == "-" ? -1 : 1);
 	var integralPartValue = integralPart === ""  ? 0  :
-				exactness.intAsExactp() ? parseExactInt(integralPart, radix) :
+				exactness.intAsExactp() ? parseExactInt(integralPart, radix, errbacks) :
 							  parseInt(integralPart, radix)
 
 	var fractionalNumerator = fractionalPart === "" ? 0 :
-				  exactness.intAsExactp() ? parseExactInt(fractionalPart, radix) :
+				  exactness.intAsExactp() ? parseExactInt(fractionalPart, radix, errbacks) :
 							    parseInt(fractionalPart, radix)
 	/* unfortunately, for these next two calculations, `expt` and `divide` */
 	/* will promote to Bignum and Rational, respectively, but we only want */
 	/* these if we're parsing in exact mode */
-	var fractionalDenominator = exactness.intAsExactp() ? expt(radix, fractionalPart.length) :
+	var fractionalDenominator = exactness.intAsExactp() ? expt(radix, fractionalPart.length, errbacks) :
 							      Math.pow(radix, fractionalPart.length)
 	var fractionalPartValue = fractionalPart === "" ? 0 :
-				  exactness.intAsExactp() ? divide(fractionalNumerator, fractionalDenominator) :
+				  exactness.intAsExactp() ? divide(fractionalNumerator, fractionalDenominator, errbacks) :
 							    fractionalNumerator / fractionalDenominator
 
 	var forceInexact = function(o) {
-	    return typeof o === "number" ? Roughnum.makeInstance(o) :
-					   o.toRoughnum();
+	    return typeof o === "number" ? Roughnum.makeInstance(o, errbacks) :
+					   o.toRoughnum(errbacks);
 	}
 
 	return exactness.floatAsInexactp() ? forceInexact(multiply(sign, add( integralPartValue, fractionalPartValue))) :
 					     multiply(sign, add(integralPartValue, fractionalPartValue));
     }
 
-    function parseExactInt(str, radix) {
-	return fromSchemeStringRawNoComplex(str, radix, Exactness.on, true);
+    function parseExactInt(str, radix, errbacks) {
+	return fromSchemeStringRawNoComplex(str, radix, Exactness.on, true, errbacks);
     }
 
   //////////////////////////////////////////////////////////////////////
@@ -3573,35 +3562,35 @@ define(function() {
     return result;
   } ;
 
-  BigInteger.prototype.toRoughnum = function() {
-    return Roughnum.makeInstance(this.toFixnum());
+  BigInteger.prototype.toRoughnum = function(errbacks) {
+    return Roughnum.makeInstance(this.toFixnum(), errbacks);
   };
 
-  BigInteger.prototype.greaterThan = function(other) {
-    return this.compareTo(other) > 0;
+  BigInteger.prototype.greaterThan = function(other, errbacks) {
+    return this.compareTo(other, errbacks) > 0;
   };
 
-  BigInteger.prototype.greaterThanOrEqual = function(other) {
-    return this.compareTo(other) >= 0;
+  BigInteger.prototype.greaterThanOrEqual = function(other, errbacks) {
+    return this.compareTo(other, errbacks) >= 0;
   };
 
-  BigInteger.prototype.lessThan = function(other) {
-    return this.compareTo(other) < 0;
+  BigInteger.prototype.lessThan = function(other, errbacks) {
+    return this.compareTo(other, errbacks) < 0;
   };
 
-  BigInteger.prototype.lessThanOrEqual = function(other) {
-    return this.compareTo(other) <= 0;
+  BigInteger.prototype.lessThanOrEqual = function(other, errbacks) {
+    return this.compareTo(other, errbacks) <= 0;
   };
 
   // divide: pyretnum -> pyretnum
   // WARNING NOTE: we override the old version of divide.
-  BigInteger.prototype.divide = function(other) {
+  BigInteger.prototype.divide = function(other, errbacks) {
     var quotientAndRemainder = bnDivideAndRemainder.call(this, other);
     if (quotientAndRemainder[1].compareTo(BigInteger.ZERO) === 0) {
       return quotientAndRemainder[0];
     } else {
       var result = add(quotientAndRemainder[0],
-                       Rational.makeInstance(quotientAndRemainder[1], other));
+                       Rational.makeInstance(quotientAndRemainder[1], other, errbacks), errbacks);
       return result;
     }
   };
@@ -3618,23 +3607,23 @@ define(function() {
     // Classic implementation of Newton-Raphson square-root search,
     // adapted for integer-sqrt.
     // http://en.wikipedia.org/wiki/Newton's_method#Square_root_of_a_number
-    var searchIter = function(n, guess) {
-      while(!(lessThanOrEqual(sqr(guess),n) &&
-              lessThan(n,sqr(add(guess, 1))))) {
+    var searchIter = function(n, guess, errbacks) {
+      while(!(lessThanOrEqual(sqr(guess),n, errbacks) &&
+              lessThan(n,sqr(add(guess, 1, errbacks), errbacks), errbacks))) {
         guess = floor(divide(add(guess,
-                                 floor(divide(n, guess))),
-                             2));
+                                 floor(divide(n, guess, errbacks), errbacks), errbacks),
+                             2, errbacks), errbacks);
       }
       return guess;
     };
 
     // integerSqrt: -> pyretnum
-    BigInteger.prototype.integerSqrt = function() {
+    BigInteger.prototype.integerSqrt = function(errbacks) {
       var n;
       if(sign(this) >= 0) {
-        return searchIter(this, this);
+        return searchIter(this, this, errbacks);
       } else {
-        throwRuntimeError('integerSqrt of negative bignum ' + this);
+        errbacks.throwDomainError('integerSqrt of negative bignum ' + this);
       }
     };
   })();
@@ -3642,14 +3631,14 @@ define(function() {
   (function() {
     // Get an approximation using integerSqrt, and then start another
     // Newton-Raphson search if necessary.
-    BigInteger.prototype.sqrt = function() {
-      var approx = this.integerSqrt(), fix;
-      if (eqv(sqr(approx), this)) {
+    BigInteger.prototype.sqrt = function(errbacks) {
+      var approx = this.integerSqrt(errbacks), fix;
+      if (eqv(sqr(approx, errbacks), this, errbacks)) {
         return approx;
       }
       fix = toFixnum(this);
       if (isFinite(fix)) {
-        return Roughnum.makeInstance(Math.sqrt(fix));
+        return Roughnum.makeInstance(Math.sqrt(fix), errbacks);
       } else {
         return approx;
       }
@@ -3662,81 +3651,81 @@ define(function() {
 
   // floor: -> pyretnum
   // Produce the floor.
-  BigInteger.prototype.floor = function() {
+  BigInteger.prototype.floor = function(errbacks) {
     return this;
   }
 
   // ceiling: -> pyretnum
   // Produce the ceiling.
-  BigInteger.prototype.ceiling = function() {
+  BigInteger.prototype.ceiling = function(errbacks) {
     return this;
   }
 
   // round: -> pyretnum
   // Round to the nearest integer.
-  BigInteger.prototype.round = function(n) {
+  BigInteger.prototype.round = function(n, errbacks) {
     return this;
   };
 
-  BigInteger.prototype.roundEven = function(n) {
+  BigInteger.prototype.roundEven = function(n, errbacks) {
     return this;
   };
 
   // log: -> pyretnum
   // Produce the log.
-  BigInteger.prototype.log = function(n) {
-    return log(this.toFixnum());
+  BigInteger.prototype.log = function(n, errbacks) {
+    return log(this.toFixnum(), errbacks);
   };
 
   // tan: -> pyretnum
   // Produce the tan.
-  BigInteger.prototype.tan = function(n) {
-    return tan(this.toFixnum());
+  BigInteger.prototype.tan = function(n, errbacks) {
+    return tan(this.toFixnum(), errbacks);
   };
 
   // atan: -> pyretnum
   // Produce the arc tangent.
-  BigInteger.prototype.atan = function(n) {
-    return atan(this.toFixnum());
+  BigInteger.prototype.atan = function(n, errbacks) {
+    return atan(this.toFixnum(), errbacks);
   };
 
   // cos: -> pyretnum
   // Produce the cosine.
-  BigInteger.prototype.cos = function(n) {
-    return cos(this.toFixnum());
+  BigInteger.prototype.cos = function(n, errbacks) {
+    return cos(this.toFixnum(), errbacks);
   };
 
   // sin: -> pyretnum
   // Produce the sine.
-  BigInteger.prototype.sin = function(n) {
-    return sin(this.toFixnum());
+  BigInteger.prototype.sin = function(n, errbacks) {
+    return sin(this.toFixnum(), errbacks);
   };
 
   // expt: pyretnum -> pyretnum
   // Produce the power to the input.
-  BigInteger.prototype.expt = function(n) {
+  BigInteger.prototype.expt = function(n, errbacks) {
     return bnPow.call(this, n);
   };
 
   // exp: -> pyretnum
   // Produce e raised to the given power.
-  BigInteger.prototype.exp = function() {
+  BigInteger.prototype.exp = function(errbacks) {
     var res = Math.exp(this.toFixnum());
     if (!isFinite(res))
-      throwRuntimeError('exp: argument too large: ' + this);
-    return Roughnum.makeInstance(res);
+      errbacks.throwDomainError('exp: argument too large: ' + this);
+    return Roughnum.makeInstance(res, errbacks);
   };
 
   // acos: -> pyretnum
   // Produce the arc cosine.
-  BigInteger.prototype.acos = function(n) {
-    return acos(this.toFixnum());
+  BigInteger.prototype.acos = function(n, errbacks) {
+    return acos(this.toFixnum(), errbacks);
   };
 
   // asin: -> pyretnum
   // Produce the arc sine.
-  BigInteger.prototype.asin = function(n) {
-    return asin(this.toFixnum());
+  BigInteger.prototype.asin = function(n, errbacks) {
+    return asin(this.toFixnum(), errbacks);
   };
 
   //////////////////////////////////////////////////////////////////////
@@ -3807,30 +3796,30 @@ define(function() {
 
     };
 
-    return function(n, d, options) {
+    return function(n, d, options, errbacks) {
       // default limit on decimal expansion; can be overridden
       var limit = 512;
       if (options && typeof(options.limit) !== 'undefined') {
         limit = options.limit;
       }
       if (! isInteger(n)) {
-        throwRuntimeError('toRepeatingDecimal: n ' + n.toString() +
-                          " is not an integer.");
+        errbacks.throwDomainError('toRepeatingDecimal: n ' + n.toString() +
+                                  " is not an integer.");
       }
       if (! isInteger(d)) {
-        throwRuntimeError('toRepeatingDecimal: d ' + d.toString() +
-                          " is not an integer.");
+        errbacks.throwDomainError('toRepeatingDecimal: d ' + d.toString() +
+                                  " is not an integer.");
       }
-      if (equals(d, 0)) {
-        throwRuntimeError('toRepeatingDecimal: d equals 0');
+      if (equals(d, 0, errbacks)) {
+        errbacks.throwDomainError('toRepeatingDecimal: d equals 0');
       }
-      if (lessThan(d, 0)) {
-        throwRuntimeError('toRepeatingDecimal: d < 0');
+      if (lessThan(d, 0, errbacks)) {
+        errbacks.throwDomainError('toRepeatingDecimal: d < 0');
       }
       var sign = (lessThan(n, 0) ? "-" : "");
-      n = abs(n);
-      var beforeDecimalPoint = sign + quotient(n, d);
-      var afterDecimals = getResidue(remainder(n, d), d, limit);
+      n = abs(n, errbacks);
+      var beforeDecimalPoint = sign + quotient(n, d, errbacks);
+      var afterDecimals = getResidue(remainder(n, d, errbacks), d, limit);
       return [beforeDecimalPoint].concat(afterDecimals);
     };
   })();
@@ -3845,8 +3834,6 @@ define(function() {
   Numbers['makeRational'] = Rational.makeInstance;
   Numbers['makeRoughnum'] = Roughnum.makeInstance;
 
-  Numbers['onThrowRuntimeError'] = onThrowRuntimeError;
-  Numbers['setThrowRuntimeError'] = setThrowRuntimeError;
   Numbers['isPyretNumber'] = isPyretNumber;
   Numbers['isRational'] = isRational;
   Numbers['isReal'] = isReal;

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -522,7 +522,7 @@ function makeNumberBig(n) {
   @return {!PNumber} with value n
 */
 function makeNumber(n) {
-  return jsnums.fromFixnum(n);
+  return jsnums.fromFixnum(n, NumberErrbacks);
 }
 
 /**Makes a PNumber using the given string
@@ -531,7 +531,7 @@ function makeNumber(n) {
   @return {!PNumber} with value n
 */
 function makeNumberFromString(s) {
-  var result = jsnums.fromString(s);
+  var result = jsnums.fromString(s, NumberErrbacks);
   if(result === false) {
     thisRuntime.ffi.throwMessageException("Could not create number from: " + s);
   }
@@ -1193,7 +1193,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     function confirm(val, test) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["runtime"], 2, $a); }
       if(!test(val)) {
-          throw makeMessageException("Pyret Type Error: " + test + ": " + JSON.stringify(val))
+          thisRuntime.ffi.throwMessageException("Pyret Type Error: " + test + ": " + JSON.stringify(val))
       }
       return thisRuntime.unwrap(val);
     }
@@ -1686,17 +1686,6 @@ function isMethod(obj) { return obj instanceof PMethod; }
       return new PyretFailException(exn);
     }
 
-    /**
-      Raises a PyretFailException with the given string
-      @param {!string} str
-      @return {!PyretFailException}
-    */
-    function makeMessageException(str) {
-      thisRuntime.ffi.throwMessageException(str);
-    }
-
-    jsnums.setThrowRuntimeError(makeMessageException);
-
     var raiseJSJS =
       /**
         Raises any Pyret value as an exception
@@ -1798,19 +1787,19 @@ function isMethod(obj) { return obj instanceof PMethod; }
           } else if (isNumber(curLeft) && isNumber(curRight)) {
             if (tol) {
               if (rel) {
-                if (jsnums.roughlyEqualsRel(curLeft, curRight, tol)) {
+                if (jsnums.roughlyEqualsRel(curLeft, curRight, tol, NumberErrbacks)) {
                   continue;
                 } else {
                   toCompare.curAns = thisRuntime.ffi.notEqual.app(current.path, curLeft, curRight);
                 }
-              } else if (jsnums.roughlyEquals(curLeft, curRight, tol)) {
+              } else if (jsnums.roughlyEquals(curLeft, curRight, tol, NumberErrbacks)) {
                 continue;
               } else {
                 toCompare.curAns = thisRuntime.ffi.notEqual.app(current.path, curLeft, curRight);
               }
             } else if (jsnums.isRoughnum(curLeft) || jsnums.isRoughnum(curRight)) {
               toCompare.curAns = thisRuntime.ffi.unknown.app("Roughnums", curLeft, curRight);
-            } else if (jsnums.equals(curLeft, curRight)) {
+            } else if (jsnums.equals(curLeft, curRight, NumberErrbacks)) {
               continue;
             } else {
               toCompare.curAns = thisRuntime.ffi.notEqual.app(current.path, curLeft, curRight);
@@ -2016,8 +2005,8 @@ function isMethod(obj) { return obj instanceof PMethod; }
     function equalWithinAbsNow3(tol) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs-now3"], 1, $a); }
       thisRuntime.checkNumber(tol);
-      if (jsnums.lessThan(tol, 0)) {
-        throw makeMessageException('negative tolerance ' + tol);
+      if (jsnums.lessThan(tol, 0, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException('negative tolerance ' + tol);
       }
       return makeFunction(function(l, r) {
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs-now3(...)"], 2, $a); }
@@ -2037,8 +2026,8 @@ function isMethod(obj) { return obj instanceof PMethod; }
     function equalWithinAbs3(tol) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs3"], 1, $a); }
       thisRuntime.checkNumber(tol);
-      if (jsnums.lessThan(tol, 0)) {
-        throw makeMessageException('negative tolerance ' + tol);
+      if (jsnums.lessThan(tol, 0, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException('negative tolerance ' + tol);
       }
       return makeFunction(function(l, r) {
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs3(...)"], 2, $a); }
@@ -2072,8 +2061,8 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var equalWithinAbsNowPy = makeFunction(function(tol) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs-now"], 1, $a); }
       thisRuntime.checkNumber(tol);
-      if (jsnums.lessThan(tol, 0)) {
-        throw makeMessageException('negative toelrance ' + tol);
+      if (jsnums.lessThan(tol, 0, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException('negative toelrance ' + tol);
       }
       return makeFunction(function(l, r) {
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs-now(...)"], 2, $a); }
@@ -2098,8 +2087,8 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var equalWithinAbsPy = makeFunction(function(tol) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs"], 1, $a); }
       thisRuntime.checkNumber(tol);
-      if (jsnums.lessThan(tol, 0)) {
-        throw makeMessageException('negative tolerance ' + tol);
+      if (jsnums.lessThan(tol, 0, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException('negative tolerance ' + tol);
       }
       return makeFunction(function(l, r) {
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within-abs(...)"], 2, $a); }
@@ -2219,7 +2208,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
         left = current.left;
         right = current.right;
         if (left === right) { continue; }
-        if (isNumber(left) && isNumber(right) && jsnums.equals(left, right)) {
+        if (isNumber(left) && isNumber(right) && jsnums.equals(left, right, NumberErrbacks)) {
           continue;
         }
         // redundant becase it's just === now
@@ -3456,10 +3445,23 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if(DEBUGLOG) { CONSOLE.log.apply(CONSOLE, arguments); }
     }
 
+    var NumberErrbacks = {
+      throwDivByZero: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwToleranceError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwRelToleranceErrror: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwGeneralError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwDomainError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwSqrtNegative: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwLogNonPositive: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwIncomparableValues: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwInternalError: function(msg) { thisRuntime.ffi.throwInternalError(msg); },
+    };
+
+
     var plus = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_plus"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeNumberBig(jsnums.add(l, r));
+        return thisRuntime.makeNumberBig(jsnums.add(l, r, NumberErrbacks));
       } else if (thisRuntime.isString(l) && thisRuntime.isString(r)) {
         return thisRuntime.makeString(l.concat(r));
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_plus")) {
@@ -3474,7 +3476,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var minus = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_minus"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeNumberBig(jsnums.subtract(l, r));
+        return thisRuntime.makeNumberBig(jsnums.subtract(l, r, NumberErrbacks));
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_minus")) {
         return safeTail(function() {
             return thisRuntime.getField(l, "_minus").app(r);
@@ -3487,7 +3489,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var times = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_times"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeNumberBig(jsnums.multiply(l, r));
+        return thisRuntime.makeNumberBig(jsnums.multiply(l, r, NumberErrbacks));
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_times")) {
         return safeTail(function() {
             return thisRuntime.getField(l, "_times").app(r);
@@ -3501,9 +3503,9 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_divide"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
         if (jsnums.equalsAnyZero(r)) {
-          throw makeMessageException("Division by zero");
+          NumberErrbacks.throwDivByZero("Division by zero");
         }
-        return thisRuntime.makeNumberBig(jsnums.divide(l, r));
+        return thisRuntime.makeNumberBig(jsnums.divide(l, r, NumberErrbacks));
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_divide")) {
         return safeTail(function() {
             return thisRuntime.getField(l, "_divide").app(r);
@@ -3516,7 +3518,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var lessthan = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_lessthan"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeBoolean(jsnums.lessThan(l, r));
+        return thisRuntime.makeBoolean(jsnums.lessThan(l, r, NumberErrbacks));
       } else if (thisRuntime.isString(l) && thisRuntime.isString(r)) {
         return thisRuntime.makeBoolean(l < r);
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_lessthan")) {
@@ -3531,7 +3533,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var greaterthan = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_greaterthan"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeBoolean(jsnums.greaterThan(l, r));
+        return thisRuntime.makeBoolean(jsnums.greaterThan(l, r, NumberErrbacks));
       } else if (thisRuntime.isString(l) && thisRuntime.isString(r)) {
         return thisRuntime.makeBoolean(l > r);
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_greaterthan")) {
@@ -3546,7 +3548,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var lessequal = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_lessequal"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeBoolean(jsnums.lessThanOrEqual(l, r));
+        return thisRuntime.makeBoolean(jsnums.lessThanOrEqual(l, r, NumberErrbacks));
       } else if (thisRuntime.isString(l) && thisRuntime.isString(r)) {
         return thisRuntime.makeBoolean(l <= r);
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_lessequal")) {
@@ -3561,7 +3563,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var greaterequal = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_greaterequal"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        return thisRuntime.makeBoolean(jsnums.greaterThanOrEqual(l, r));
+        return thisRuntime.makeBoolean(jsnums.greaterThanOrEqual(l, r, NumberErrbacks));
       } else if (thisRuntime.isString(l) && thisRuntime.isString(r)) {
         return thisRuntime.makeBoolean(l >= r);
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_greaterequal")) {
@@ -3869,16 +3871,17 @@ function isMethod(obj) { return obj instanceof PMethod; }
       }
       exactCheck("start", min);
       exactCheck("end", max);
-      if(jsnums.greaterThan(min, max)) {
-        throw makeMessageException("substring: min index " + String(min) + " is greater than max index " + String(max));
+      if(jsnums.greaterThan(min, max, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException("substring: min index " + String(min) + " is greater than max index " + String(max));
       }
-      if(jsnums.lessThan(min, 0)) {
-        throw makeMessageException("substring: min index " + String(min) + " is less than 0");
+      if(jsnums.lessThan(min, 0, NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException("substring: min index " + String(min) + " is less than 0");
       }
-      if(jsnums.greaterThan(max, string_length(s))) {
-        throw makeMessageException("substring: max index " + String(max) + " is larger than the string length " + String(string_length(s)));
+      if(jsnums.greaterThan(max, string_length(s), NumberErrbacks)) {
+        thisRuntime.ffi.throwMessageException("substring: max index " + String(max) + " is larger than the string length " + String(string_length(s)));
       }
-      return thisRuntime.makeString(s.substring(jsnums.toFixnum(min), jsnums.toFixnum(max)));
+      return thisRuntime.makeString(s.substring(jsnums.toFixnum(min, NumberErrbacks), 
+                                                jsnums.toFixnum(max, NumberErrbacks)));
     }
     var string_replace = function(s, find, replace) {
       if (arguments.length !== 3) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-replace"], 3, $a); }
@@ -3914,14 +3917,14 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var string_isnumber = function(s) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-isnumber"], 1, $a); }
       checkString(s);
-      var num = jsnums.fromString(s);
+      var num = jsnums.fromString(s, NumberErrbacks);
       if(num !== false) { return true; }
       else { return false; }
     }
     var string_tonumber = function(s) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-tonumber"], 1, $a); }
       thisRuntime.checkString(s);
-      var num = jsnums.fromString(s);
+      var num = jsnums.fromString(s, NumberErrbacks);
       if(num !== false) {
         return makeNumberBig(/**@type {Bignum}*/ (num));
       }
@@ -3932,7 +3935,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var string_to_number = function(s) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-to-number"], 1, $a); }
       thisRuntime.checkString(s);
-      var num = jsnums.fromString(s);
+      var num = jsnums.fromString(s, NumberErrbacks);
       if(num !== false) {
         return thisRuntime.ffi.makeSome(makeNumberBig(/**@type {Bignum}*/ (num)));
       }
@@ -3946,7 +3949,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
       thisRuntime.checkNumber(n);
       var resultStr = "";
       // TODO(joe): loop up to a fixnum?
-      for(var i = 0; i < jsnums.toFixnum(n); i++) {
+      for(var i = 0; i < jsnums.toFixnum(n, NumberErrbacks); i++) {
         resultStr += s;
       }
       return makeString(resultStr);
@@ -3980,7 +3983,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if(n > (s.length - 1)) { thisRuntime.ffi.throwMessageException("string-char-at: index " + n + " is greater than the largest index the string " + s); }
 
       //TODO: Handle bignums that are beyond javascript
-      return thisRuntime.makeString(String(s.charAt(jsnums.toFixnum(n))));
+      return thisRuntime.makeString(String(s.charAt(jsnums.toFixnum(n, NumberErrbacks))));
     }
     var string_toupper = function(s) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-toupper"], 1, $a); }
@@ -4018,12 +4021,12 @@ function isMethod(obj) { return obj instanceof PMethod; }
       }
     }
     var checkNatural = makeCheckType(function(val) {
-        return thisRuntime.isNumber(val) && jsnums.isInteger(val) && jsnums.greaterThanOrEqual(val, 0);
+        return thisRuntime.isNumber(val) && jsnums.isInteger(val) && jsnums.greaterThanOrEqual(val, 0, NumberErrbacks);
       }, "Natural Number");
     var string_from_code_point = function(c) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["string-from-code-point"], 1, $a); }
       checkNatural(c);
-      var c = jsnums.toFixnum(c);
+      var c = jsnums.toFixnum(c, NumberErrbacks);
       var ASTRAL_CUTOFF = 65535;
       if(c > ASTRAL_CUTOFF) {
         thisRuntime.ffi.throwMessageException("Invalid code point: " + c);
@@ -4074,7 +4077,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-random"], 1, $a); }
       checkNumber(max);
       var f = rng();
-      return makeNumber(Math.floor(jsnums.toFixnum(max) * f));
+      return makeNumber(Math.floor(jsnums.toFixnum(max, NumberErrbacks) * f));
     };
 
     var num_random_seed = function(seed) {
@@ -4088,20 +4091,20 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-equals"], 2, $a); }
       thisRuntime.checkNumber(l);
       thisRuntime.checkNumber(r);
-      return thisRuntime.makeBoolean(jsnums.equals(l, r));
+      return thisRuntime.makeBoolean(jsnums.equals(l, r, NumberErrbacks));
     };
 
     var num_within_abs = function(delta) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["within"], 1, $a); }
       thisRuntime.checkNumber(delta);
-      if (jsnums.lessThan(delta, 0)) {
-        throw makeMessageException('negative tolerance ' + delta);
+      if (jsnums.lessThan(delta, 0, NumberErrbacks)) {
+        NumberErrbacks.throwToleranceError('negative tolerance ' + delta);
       }
       return makeFunction(function(l, r) {
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["from within"], 2, $a); }
         thisRuntime.checkNumber(l);
         thisRuntime.checkNumber(r);
-        return makeBoolean(jsnums.roughlyEquals(l, r, delta));
+        return makeBoolean(jsnums.roughlyEquals(l, r, delta, NumberErrbacks));
       });
     }
 
@@ -4112,7 +4115,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
         if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["from within-rel"], 2, $a); }
         thisRuntime.checkNumber(l);
         thisRuntime.checkNumber(r);
-        return makeBoolean(jsnums.roughlyEqualsRel(l, r, relTol));
+        return makeBoolean(jsnums.roughlyEqualsRel(l, r, relTol, NumberErrbacks));
       });
     }
 
@@ -4120,127 +4123,127 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-max"], 2, $a); }
       thisRuntime.checkNumber(l);
       thisRuntime.checkNumber(r);
-      if (jsnums.greaterThanOrEqual(l, r)) { return l; } else { return r; }
+      if (jsnums.greaterThanOrEqual(l, r, NumberErrbacks)) { return l; } else { return r; }
     }
 
     var num_min = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-min"], 2, $a); }
       thisRuntime.checkNumber(l);
       thisRuntime.checkNumber(r);
-      if (jsnums.lessThanOrEqual(l, r)) { return l; } else { return r; }
+      if (jsnums.lessThanOrEqual(l, r, NumberErrbacks)) { return l; } else { return r; }
     }
 
     var num_abs = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-abs"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.abs(n));
+      return thisRuntime.makeNumberBig(jsnums.abs(n, NumberErrbacks));
     }
 
     var num_sin = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-sin"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.sin(n));
+      return thisRuntime.makeNumberBig(jsnums.sin(n, NumberErrbacks));
     }
     var num_cos = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-cos"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.cos(n));
+      return thisRuntime.makeNumberBig(jsnums.cos(n, NumberErrbacks));
     }
     var num_tan = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-tan"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.tan(n));
+      return thisRuntime.makeNumberBig(jsnums.tan(n, NumberErrbacks));
     }
     var num_asin = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-asin"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.asin(n));
+      return thisRuntime.makeNumberBig(jsnums.asin(n, NumberErrbacks));
     }
     var num_acos = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-acos"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.acos(n));
+      return thisRuntime.makeNumberBig(jsnums.acos(n, NumberErrbacks));
     }
     var num_atan = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-atan"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.atan(n));
+      return thisRuntime.makeNumberBig(jsnums.atan(n, NumberErrbacks));
     }
 
     var num_modulo = function(n, mod) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-modulo"], 2, $a); }
       thisRuntime.checkNumber(n);
       thisRuntime.checkNumber(mod);
-      return thisRuntime.makeNumberBig(jsnums.modulo(n, mod));
+      return thisRuntime.makeNumberBig(jsnums.modulo(n, mod, NumberErrbacks));
     }
     var num_truncate = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-truncate"], 1, $a); }
       thisRuntime.checkNumber(n);
-      if (jsnums.greaterThanOrEqual(n, 0)) {
-        return thisRuntime.makeNumberBig(jsnums.floor(n));
+      if (jsnums.greaterThanOrEqual(n, 0, NumberErrbacks)) {
+        return thisRuntime.makeNumberBig(jsnums.floor(n, NumberErrbacks));
       } else {
-        return thisRuntime.makeNumberBig(jsnums.ceiling(n));
+        return thisRuntime.makeNumberBig(jsnums.ceiling(n, NumberErrbacks));
       }
     }
     var num_sqrt = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-sqrt"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.sqrt(n));
+      return thisRuntime.makeNumberBig(jsnums.sqrt(n, NumberErrbacks));
     }
     var num_sqr = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-sqr"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.sqr(n));
+      return thisRuntime.makeNumberBig(jsnums.sqr(n, NumberErrbacks));
     }
     var num_ceiling = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-ceiling"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.ceiling(n));
+      return thisRuntime.makeNumberBig(jsnums.ceiling(n, NumberErrbacks));
     }
     var num_floor = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-floor"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.floor(n));
+      return thisRuntime.makeNumberBig(jsnums.floor(n, NumberErrbacks));
     }
     var num_round = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-round"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.round(n));
+      return thisRuntime.makeNumberBig(jsnums.round(n, NumberErrbacks));
     }
     var num_round_even = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-round-even"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.roundEven(n));
+      return thisRuntime.makeNumberBig(jsnums.roundEven(n, NumberErrbacks));
     }
     var num_log = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-log"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.log(n));
+      return thisRuntime.makeNumberBig(jsnums.log(n, NumberErrbacks));
     }
     var num_exp = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-exp"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.exp(n));
+      return thisRuntime.makeNumberBig(jsnums.exp(n, NumberErrbacks));
     }
     var num_exact = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-exact"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.toRational(n));
+      return thisRuntime.makeNumberBig(jsnums.toRational(n, NumberErrbacks));
     }
     var num_to_rational = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-to-rational"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.toRational(n));
+      return thisRuntime.makeNumberBig(jsnums.toRational(n, NumberErrbacks));
     }
     var num_to_roughnum = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-to-roughnum"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.toRoughnum(n));
+      return thisRuntime.makeNumberBig(jsnums.toRoughnum(n, NumberErrbacks));
     }
     var num_to_fixnum = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-to-fixnum"], 1, $a); }
       thisRuntime.checkNumber(n);
-      return thisRuntime.makeNumberBig(jsnums.toFixnum(n));
+      return thisRuntime.makeNumberBig(jsnums.toFixnum(n, NumberErrbacks));
     }
     var num_is_integer = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-is-integer"], 1, $a); }
@@ -4286,7 +4289,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-expt"], 2, $a); }
       thisRuntime.checkNumber(n);
       thisRuntime.checkNumber(pow);
-      return thisRuntime.makeNumberBig(jsnums.expt(n, pow));
+      return thisRuntime.makeNumberBig(jsnums.expt(n, pow, NumberErrbacks));
     }
     var num_tostring = function(n) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-tostring"], 1, $a); }
@@ -4297,14 +4300,14 @@ function isMethod(obj) { return obj instanceof PMethod; }
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["num-tostring-digits"], 2, $a); }
       thisRuntime.checkNumber(n);
       thisRuntime.checkNumber(digits);
-      var d = jsnums.toFixnum(digits);
-      var tenDigits = jsnums.expt(10, digits);
+      var d = jsnums.toFixnum(digits, NumberErrbacks);
+      var tenDigits = jsnums.expt(10, digits, NumberErrbacks);
       if (n != n) { return thisRuntime.makeString("NaN"); }
-      else if (jsnums.equals(n, Number.POSITIVE_INFINITY)) { return thisRuntime.makeString("+inf"); }
-      else if (jsnums.equals(n, Number.NEGATIVE_INFINITY)) { return thisRuntime.makeString("-inf"); }
+      else if (jsnums.equals(n, Number.POSITIVE_INFINITY, NumberErrbacks)) { return thisRuntime.makeString("+inf"); }
+      else if (jsnums.equals(n, Number.NEGATIVE_INFINITY, NumberErrbacks)) { return thisRuntime.makeString("-inf"); }
       else if (jsnums.isReal(n)) {
-        n = jsnums.divide(jsnums.round(jsnums.multiply(n, tenDigits)), tenDigits)
-        var s = jsnums.toFixnum(n).toString().split(".");
+        n = jsnums.divide(jsnums.round(jsnums.multiply(n, tenDigits, NumberErrbacks), NumberErrbacks), tenDigits, NumberErrbacks)
+        var s = jsnums.toFixnum(n, NumberErrbacks).toString().split(".");
         s[1] = (s[1] || "").substring(0, d);
         for (var i = s[1].length; i < d; i++)
           s[1] += "0";
@@ -4923,6 +4926,8 @@ function isMethod(obj) { return obj instanceof PMethod; }
         'GAS': INITIAL_GAS,
         'INITIAL_GAS': INITIAL_GAS,
 
+        'NumberErrbacks': NumberErrbacks,
+
         'namedBrander': namedBrander,
 
         'checkAnn': checkAnn,
@@ -5142,7 +5147,11 @@ function isMethod(obj) { return obj instanceof PMethod; }
         'checkTuple' : checkTuple,
         'makeCheckType' : makeCheckType,
         'confirm'      : confirm,
-        'makeMessageException'      : makeMessageException,
+        'makeMessageException'      : function(str) {
+          console.error("You shouldn't be using this any more!\n");
+          console.trace();
+          throw new Error(str);
+        },
         'serial' : Math.random(),
         'log': log,
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3448,7 +3448,7 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var NumberErrbacks = {
       throwDivByZero: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
       throwToleranceError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
-      throwRelToleranceErrror: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
+      throwRelToleranceError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
       throwGeneralError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
       throwDomainError: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
       throwSqrtNegative: function(msg) { thisRuntime.ffi.throwMessageException(msg); },
@@ -3502,9 +3502,6 @@ function isMethod(obj) { return obj instanceof PMethod; }
     var divide = function(l, r) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["_divide"], 2, $a); }
       if (thisRuntime.isNumber(l) && thisRuntime.isNumber(r)) {
-        if (jsnums.equalsAnyZero(r)) {
-          NumberErrbacks.throwDivByZero("Division by zero");
-        }
         return thisRuntime.makeNumberBig(jsnums.divide(l, r, NumberErrbacks));
       } else if (thisRuntime.isObject(l) && hasProperty(l.dict, "_divide")) {
         return safeTail(function() {

--- a/src/js/trove/d3-lib.js
+++ b/src/js/trove/d3-lib.js
@@ -40,13 +40,13 @@
          * @return {Function}
          */
         return function (k) {
-          var oldDiff = jsnums.subtract(k, oldX);
-          var oldRange = jsnums.subtract(oldY, oldX);
-          var portion = jsnums.divide(oldDiff, oldRange);
-          var newRange = jsnums.subtract(newY, newX);
-          var newPortion = jsnums.multiply(portion, newRange);
-          var result = jsnums.add(newPortion, newX);
-          return toFixnum ? jsnums.toFixnum(result) : result;
+          var oldDiff = jsnums.subtract(k, oldX, RUNTIME.NumberErrbacks);
+          var oldRange = jsnums.subtract(oldY, oldX, RUNTIME.NumberErrbacks);
+          var portion = jsnums.divide(oldDiff, oldRange, RUNTIME.NumberErrbacks);
+          var newRange = jsnums.subtract(newY, newX, RUNTIME.NumberErrbacks);
+          var newPortion = jsnums.multiply(portion, newRange, RUNTIME.NumberErrbacks);
+          var result = jsnums.add(newPortion, newX, RUNTIME.NumberErrbacks);
+          return toFixnum ? jsnums.toFixnum(result, RUNTIME.NumberErrbacks) : result;
         };
       }
 
@@ -59,8 +59,8 @@
          * @param {jsnums} vmax
          * @return {jsnums}
          */
-        if (jsnums.lessThan(k, vmin)) return vmin;
-        else if (jsnums.lessThan(vmax, k)) return vmax;
+        if (jsnums.lessThan(k, vmin, RUNTIME.NumberErrbacks)) return vmin;
+        else if (jsnums.lessThan(vmax, k, RUNTIME.NumberErrbacks)) return vmax;
         else return k;
       }
 
@@ -72,7 +72,7 @@
          * @param {jsnums} b
          * @return {jsnums}
          */
-        return jsnums.lessThan(a, b) ? b : a;
+        return jsnums.lessThan(a, b, RUNTIME.NumberErrbacks) ? b : a;
       }
 
       function min(a, b) {
@@ -83,7 +83,7 @@
          * @param {jsnums} b
          * @return {jsnums}
          */
-        return jsnums.lessThan(a, b) ? a : b;
+        return jsnums.lessThan(a, b, RUNTIME.NumberErrbacks) ? a : b;
       }
 
       function random(a, b) {
@@ -92,7 +92,7 @@
 
       function format(num, digit) {
         if (num.toString().length > digit) {
-          var fixnum = jsnums.toFixnum(num);
+          var fixnum = jsnums.toFixnum(num, RUNTIME.NumberErrbacks);
           if (fixnum.toString().length > digit) {
             var digitRounded = digit - 1;
             if (fixnum < 0) digitRounded--;
@@ -118,8 +118,8 @@
       }
 
       function between(b, a, c) {
-        return (jsnums.lessThanOrEqual(a, b) && jsnums.lessThanOrEqual(b, c)) ||
-          (jsnums.lessThanOrEqual(c, b) && jsnums.lessThanOrEqual(b, a));
+        return (jsnums.lessThanOrEqual(a, b, RUNTIME.NumberErrbacks) && jsnums.lessThanOrEqual(b, c, RUNTIME.NumberErrbacks)) ||
+          (jsnums.lessThanOrEqual(c, b, RUNTIME.NumberErrbacks) && jsnums.lessThanOrEqual(b, a, RUNTIME.NumberErrbacks));
       }
 
       function calcPointOnEdge(pin, pout, xMin, xMax, yMin, yMax) {
@@ -134,9 +134,9 @@
         // c = y - m * x [2]
         // x = (y - c) / m // [4]
 
-        if(jsnums.eqv(pin.x, pout.x)) {
+        if(jsnums.eqv(pin.x, pout.x, RUNTIME.NumberErrbacks)) {
           // special mode
-          if (jsnums.lessThan(pout.y, yMin)) {
+          if (jsnums.lessThan(pout.y, yMin, RUNTIME.NumberErrbacks)) {
             return {x: pin.x, y: yMin};
           } else {
             return {x: pin.x, y: yMax};
@@ -144,12 +144,13 @@
         }
 
         var m = jsnums.divide(
-          jsnums.subtract(pin.y, pout.y),
-          jsnums.subtract(pin.x, pout.x)); // [1]
-        var c = jsnums.subtract(pin.y, jsnums.multiply(m, pin.x)); // [2]
+          jsnums.subtract(pin.y, pout.y, RUNTIME.NumberErrbacks),
+          jsnums.subtract(pin.x, pout.x, RUNTIME.NumberErrbacks),
+          RUNTIME.NumberErrbacks); // [1]
+        var c = jsnums.subtract(pin.y, jsnums.multiply(m, pin.x, RUNTIME.NumberErrbacks), RUNTIME.NumberErrbacks); // [2]
 
-        function f(x) { return jsnums.add(jsnums.multiply(m, x), c); } // [3]
-        function g(y) { return jsnums.divide(jsnums.subtract(y, c), m); } // [4]
+        function f(x) { return jsnums.add(jsnums.multiply(m, x), c, RUNTIME.NumberErrbacks); } // [3]
+        function g(y) { return jsnums.divide(jsnums.subtract(y, c), m, RUNTIME.NumberErrbacks); } // [4]
 
         var yCurrent = f(xMin); // if (xMin, yCurrent) is the answer
         if (between(xMin, pin.x, pout.x) &&
@@ -744,6 +745,6 @@ assert(testFenwick.sumInterval(1, 10) === 9);
 assert(testFenwick.sumInterval(1, 2) === 5);
 assert(testFenwick.sumInterval(2, 3) === 4);
 
-assert(calcPointOnEdge({x: 0, y: 0}, {x: -20, y: -30}, -10, 10, -10, 10), jsnums.divide(-20, 3));
-assert(calcPointOnEdge({x: -20, y: -30}, {x: 0, y: 0}, -10, 10, -10, 10), jsnums.divide(-20, 3));
+assert(calcPointOnEdge({x: 0, y: 0}, {x: -20, y: -30}, -10, 10, -10, 10), jsnums.divide(-20, 3, RUNTIME.NumberErrbacks));
+assert(calcPointOnEdge({x: -20, y: -30}, {x: 0, y: 0}, -10, 10, -10, 10), jsnums.divide(-20, 3, RUNTIME.NumberErrbacks));
 */

--- a/src/js/trove/plot.js
+++ b/src/js/trove/plot.js
@@ -65,7 +65,7 @@
       function getAxisConf(aMin, aMax) {
         var conf = {},
         scaler = libNum.scaler(aMin, aMax, 0, 1, false),
-        pos = jsnums.toFixnum(scaler(0));
+        pos = jsnums.toFixnum(scaler(0), RUNTIME.NumberErrbacks);
 
         if (0 <= pos && pos <= 1) {
           conf.bold = true;
@@ -262,25 +262,25 @@
           .reduce(libNum.max);
 
         var blockPortion = 10;
-        var xOneBlock = jsnums.divide(jsnums.subtract(xMax, xMin),
-                                      blockPortion);
-        var yOneBlock = jsnums.divide(jsnums.subtract(yMax, yMin),
-                                      blockPortion);
+        var xOneBlock = jsnums.divide(jsnums.subtract(xMax, xMin, RUNTIME.NumberErrbacks),
+                                      blockPortion, RUNTIME.NumberErrbacks);
+        var yOneBlock = jsnums.divide(jsnums.subtract(yMax, yMin, RUNTIME.NumberErrbacks),
+                                      blockPortion, RUNTIME.NumberErrbacks);
 
-        xMin = jsnums.subtract(xMin, xOneBlock);
-        xMax = jsnums.add(xMax, xOneBlock);
-        yMin = jsnums.subtract(yMin, yOneBlock);
-        yMax = jsnums.add(yMax, yOneBlock);
+        xMin = jsnums.subtract(xMin, xOneBlock, RUNTIME.NumberErrbacks);
+        xMax = jsnums.add(xMax, xOneBlock, RUNTIME.NumberErrbacks);
+        yMin = jsnums.subtract(yMin, yOneBlock, RUNTIME.NumberErrbacks);
+        yMax = jsnums.add(yMax, yOneBlock, RUNTIME.NumberErrbacks);
 
         // Plotting 1 point should be possible
         // but we need a wider range
-        if (jsnums.equals(xMin, xMax)) {
-          xMin = jsnums.subtract(xMin, 1);
-          xMax = jsnums.add(xMax, 1);
+        if (jsnums.equals(xMin, xMax, RUNTIME.NumberErrbacks)) {
+          xMin = jsnums.subtract(xMin, 1, RUNTIME.NumberErrbacks);
+          xMax = jsnums.add(xMax, 1, RUNTIME.NumberErrbacks);
         }
-        if (jsnums.equals(yMin, yMax)) {
-          yMin = jsnums.subtract(yMin, 1);
-          yMax = jsnums.add(yMax, 1);
+        if (jsnums.equals(yMin, yMax, RUNTIME.NumberErrbacks)) {
+          yMin = jsnums.subtract(yMin, 1, RUNTIME.NumberErrbacks);
+          yMax = jsnums.add(yMax, 1, RUNTIME.NumberErrbacks);
         }
       }
       return {xMin: xMin, xMax: xMax, yMin: yMin, yMax: yMax};
@@ -288,10 +288,10 @@
 
     function isInBoundGenerator(xMin, xMax, yMin, yMax){
       return function(point) {
-        return jsnums.lessThanOrEqual(xMin, point.x) &&
-          jsnums.lessThanOrEqual(point.x, xMax) &&
-          jsnums.lessThanOrEqual(yMin, point.y) &&
-          jsnums.lessThanOrEqual(point.y, yMax);
+        return jsnums.lessThanOrEqual(xMin, point.x, RUNTIME.NumberErrbacks) &&
+          jsnums.lessThanOrEqual(point.x, xMax, RUNTIME.NumberErrbacks) &&
+          jsnums.lessThanOrEqual(yMin, point.y, RUNTIME.NumberErrbacks) &&
+          jsnums.lessThanOrEqual(point.y, yMax, RUNTIME.NumberErrbacks);
       };
     }
 
@@ -480,7 +480,7 @@
       }
 
       function tooClose(coordA, coordB) {
-        return jsnums.roughlyEquals(coordA.px, coordB.px, DELTA);
+        return jsnums.roughlyEquals(coordA.px, coordB.px, DELTA, RUNTIME.NumberErrbacks);
       }
 
       if (isSafe) {
@@ -498,8 +498,8 @@
             RUNTIME.ffi.cases(PyretEither, "Either", result, {
               left: function(val){
                 if (jsnums.isReal(val) &&
-                    jsnums.lessThanOrEqual(yMin, val) &&
-                    jsnums.lessThanOrEqual(val, yMax)) {
+                    jsnums.lessThanOrEqual(yMin, val, RUNTIME.NumberErrbacks) &&
+                    jsnums.lessThanOrEqual(val, yMax, RUNTIME.NumberErrbacks)) {
 
                   pt.y = val;
                   pt.py = yToPixel(val);
@@ -577,8 +577,8 @@
           try {
             y = f.app(x);
             if (jsnums.isReal(y) &&
-                jsnums.lessThanOrEqual(yMin, y) &&
-                jsnums.lessThanOrEqual(y, yMax)) {
+                jsnums.lessThanOrEqual(yMin, y, RUNTIME.NumberErrbacks) &&
+                jsnums.lessThanOrEqual(y, yMax, RUNTIME.NumberErrbacks)) {
               this.y = y;
               this.py = yToPixel(y);
             }
@@ -652,8 +652,8 @@
       var yMin = gf(pyretWinOptions, "y-min");
       var yMax = gf(pyretWinOptions, "y-max");
 
-      if (jsnums.greaterThanOrEqual(xMin, xMax) ||
-          jsnums.greaterThanOrEqual(yMin, yMax)) {
+      if (jsnums.greaterThanOrEqual(xMin, xMax, RUNTIME.NumberErrbacks) ||
+          jsnums.greaterThanOrEqual(yMin, yMax, RUNTIME.NumberErrbacks)) {
         RUNTIME.throwMessageException(CError.RANGE);
       }
 
@@ -753,7 +753,7 @@
 
       var histogramData = d3.layout.histogram()
         .bins(n).value(function (val) {
-          return jsnums.toFixnum(dataScaler(val));
+          return jsnums.toFixnum(dataScaler(val), RUNTIME.NumberErrbacks);
         })(data);
 
       var yMax = d3.max(histogramData, function (d) { return d.y; });
@@ -808,7 +808,7 @@
       });
 
       var sum = data.map(function (e) { return e.value; })
-        .reduce(jsnums.add);
+        .reduce(function(a,b) { return jsnums.add(a, b, RUNTIME.NumberErrbacks); });
 
       var scaler = libNum.scaler(0, sum, 0, 100);
 
@@ -840,7 +840,7 @@
             "percent: <br />" +
             libNum.format(
               jsnums.toFixnum(
-                scaler(d.data.value)), 7) + "%";
+                scaler(d.data.value), RUNTIME.NumberErrbacks), 7) + "%";
         });
 
       var canvas = createCanvas(detached, margin, "center");

--- a/tests/pyret/tests/test-numbers.arr
+++ b/tests/pyret/tests/test-numbers.arr
@@ -1,10 +1,38 @@
 #lang pyret
 
+
 provide *
 
 check:
   fun negate(f): lam(x): not(f(x)) end end
   fun around(n, delta): lam(other): num-abs(other - n) < delta end end
+
+  3 / (4 - 4) raises "division by zero"
+
+  within-abs(-3)(1, 2) raises "negative tolerance"
+  within(-3)(2, 3) raises "negative relative tolerance"
+  within-rel(-3)(2, 3) raises "negative relative tolerance"
+
+  min-number = ~0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005
+  within-abs(min-number)(0, min-number) raises "roughnum tolerance too small"
+
+  num-expt(0, -1) raises "expt: division by zero"
+
+  num-exp(5000) raises "exp: argument too large"
+
+  num-modulo(0.5, 5) raises "first argument 1/2 is not an integer"
+  num-modulo(5, 0.5) raises "second argument 1/2 is not an integer"
+  num-modulo(6, 0) raises "second argument is zero"
+
+  num-sqrt(-3) raises "negative argument"
+
+  num-acos(-2) raises "acos: out of domain"
+  num-acos(2) raises "acos: out of domain"
+
+  num-asin(-2) raises "asin: out of domain"
+  num-asin(2) raises "asin: out of domain"
+
+  num-equal(~3, ~4) raises "cannot be compared for equality"
 
   num-max(1, 3) is 3
   num-max("not-a-num", 3) raises ""
@@ -83,7 +111,6 @@ check:
 
   num-log(0) raises "non-positive argument"
   num-log(1) is 0
-  # num-log(num-exp(1)) is 1  # can't compare rough with exact!
   num-log(num-exp(1)) satisfies around(1, 0.0001)
 
   2 is num-exact(2)


### PR DESCRIPTION
This both gives more precise error message possibilities, and avoids having generative-error-structure problems when sharing the js-numbers module between multiple runtimes.

Ideally this fixes #737.