### PR TITLE
[SD] implements simple linear regression with tests

### DIFF
--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -17,7 +17,30 @@ is-empty = lists.is-empty
 fold = lists.fold
 length = lists.length
 member3 = lists.member3
+map = lists.map
+map2 = lists.map2
 
+# A StatModel is a data type for representing
+# statistical models.  We create this type so that
+# users can extract, coefficients and meta-data from
+# models, as well as apply the model.
+#
+# This could be extended to include general linear 
+# regression, exponential and logistic regression, etc.
+
+data StatModel:
+  | simple-linear-model(alpha :: Number, beta :: Number) with:
+
+    method predictor(self :: StatModel) -> (Number -> Number):
+      doc: "the function predicting the value of a dependent variable"
+      lam(X): (self.beta * X) + self.alpha end
+    end,
+
+    method apply(self :: StatModel, l :: List<Number>) -> List<Number>:
+      doc: "applys the predictor function to a sample set of the independent variable"
+      lists.map(self.predictor(), l)
+    end
+end
 
 fun sum(l :: List<Number>) -> Number:
 	lists.fold(lam(a,b): a + b end, 0, l)
@@ -103,3 +126,22 @@ fun distinct(l :: List) -> List:
   end
 end
 
+fun lin-reg-2V(x :: List<Number>, y :: List<Number>) -> StatModel:
+  doc: "returns a linear regression model calculated with ordinary least squares"
+  if x.length() <> y.length():
+    raise("lin-reg-2V: input lists must have equal lengths")
+  else if x.length() < 2:
+    raise("lin-reg-2V: input lists must have at least 2 elements each")
+  else:
+    xpt_xy = sum(map2(lam(xi, yi): xi * yi end, x, y))
+    xpt_x_xpt_y = (sum(x) * sum(y)) / x.length()
+    covariance = xpt_xy - xpt_x_xpt_y
+    v1 = sum(map(lam(n): n * n end, x))
+    v2 = (sum(x) * sum(x)) / x.length()
+    variance = v1 - v2
+    beta = covariance / variance
+    alpha = mean(y) - (beta * mean(x))
+
+    simple-linear-model(alpha, beta)
+  end
+end

--- a/tests/pyret/tests/test-statistics.arr
+++ b/tests/pyret/tests/test-statistics.arr
@@ -39,3 +39,17 @@ check "numeric helpers":
 
 end
 
+check "linear regression":
+  statistics.lin-reg-2V([list: 0], [list: ]) raises "lists must have equal lengths"
+  statistics.lin-reg-2V([list: 0], [list: 1]) raises "lists must have at least 2 elements each"
+
+  f = statistics.lin-reg-2V([list: 0, 1, 2], [list: -5, -3, -1]).predictor()
+  f(0) is -5
+  f(2.5) is 0
+
+  g = statistics.lin-reg-2V([list: -3, 1, 2, 4], [list: ~4, ~1.5, ~0, -2.2]).predictor()
+  g(0) is%(within-abs(0.001)) 1.69423
+  g(1.94911) is%(within-abs(0.001)) 0.0
+
+end
+


### PR DESCRIPTION
Defines a new data type, StatModel.  This will be the data type for any statistical model (regressions) we choose to implement.  For now, the only regression feature that has been requested is simple least squares regression (1 independent & 1 dependent variable).

The naming conventions for methods of the `simple-linear-model` comes from [this](https://en.wikipedia.org/wiki/Linear_predictor_function) article.