### PR TITLE
[SD] Mode tests and implementation

### DIFF
--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -9,6 +9,7 @@ import equality as equality
 import valueskeleton as VS
 import lists as L
 import math as math
+import string-dict as sd
 
 # A StatModel is a data type for representing
 # statistical models.  We create this type so that
@@ -64,6 +65,80 @@ fun median(l :: L.List):
       else:
         (sorted.get(index_of_median) + sorted.get(index_of_median - 1)) / 2
       end
+  end
+end
+
+fun num-counts(lst :: L.List<Number>) -> sd.StringDict<Number>:
+  doc: "Returns dictionary mapping appearances of each list element"
+  cases (L.List) lst:
+    | empty => [sd.string-dict: ]
+    | link(f, r) => 
+      rest = num-counts(r)
+      key = num-to-string(f)
+      val = rest.get(key)
+
+      cases (O.Option) val:
+        | none => rest.set(key, 1)
+        | some(v) => rest.set(key, v + 1)
+      end
+  end 
+end
+
+fun force-unwrap-string(s :: String) -> Number:
+  cases (O.Option) string-to-number(s):
+    | none => raise("Mode does not appear in list") # Mode counts construction prevents this 
+    | some(v) => v
+  end
+end
+
+fun modes(lst :: L.List<Number>) -> L.List<Number>:
+  doc: "Gives every mode in a list of numbers"
+  count = num-counts(lst)
+  numbers = count.keys().to-list()
+  
+  cases (L.List) numbers:
+    | empty => raise("List is empty")
+    | link(first, rest) =>
+      
+      fun aggregate-modes(prev :: L.List<String>, current :: String) -> L.List<String>:
+        current-count :: Number = count.get-value(current)
+        prev-count :: Number = count.get-value(prev.first)
+        
+        if current-count > prev-count:
+          [L.list: current]
+        else if current-count == prev-count:
+          prev.push(current)
+        else:
+          prev
+        end
+      end
+      
+      m-list = L.fold(aggregate-modes, [L.list: first], rest)
+      L.map(force-unwrap-string, m-list).reverse()
+  end
+end
+
+fun mode(lst :: L.List<Number>):
+  doc: "Gives the mode for a list of numbers.  If multiple modes exist in list, may return any of them"
+  count = num-counts(lst)
+  numbers = count.keys().to-list()
+  
+  cases (L.List) numbers:
+    | empty => raise("List is empty")
+    | link(first, rest) =>
+      
+      fun compare-counts(prev :: String, current :: String) -> String:
+        current-count :: Number = count.get-value(current)
+        prev-count :: Number = count.get-value(prev)
+        if current-count > prev-count:
+          current
+        else:
+          prev
+        end
+      end
+      
+      m = L.fold(compare-counts, first, rest)
+      force-unwrap-string(m)
   end
 end
 

--- a/tests/pyret/tests/test-statistics.arr
+++ b/tests/pyret/tests/test-statistics.arr
@@ -1,7 +1,7 @@
 import equality as E
 include statistics
 
-check "numeric helpers":
+check "basic statistical functions":
   
   mean([list:]) raises "empty"
   mean([list: 1/2]) is 1/2
@@ -22,6 +22,25 @@ check "numeric helpers":
   median([list: 1, 2, 3, 4]) is 2.5
   median([list: -1, 0, ~2, 3]) is-roughly ~1
   median([list: ~0, ~1, ~2, ~2, ~6, ~8]) is-roughly ~2
+
+  # Mode
+  mode([list: ]) raises "empty"
+  mode([list: 1]) is 1
+  mode([list: 1, 1, 2]) is 1
+  mode([list: -1, 0, -1, 2, 3, -33, ~0.1]) is -1
+  mode([list: ~2, ~1.0002, ~2, ~1.0001, ~1]) is-roughly ~2
+
+  # For multimode distributions, returns smallest mode
+  mode([list: -1, 0, 1, 2]) is -1
+  mode([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly ~0.1
+
+  # Modes (Plural) returns each mode in a list with multiple
+  modes([list: ]) raises "empty"
+  modes([list: 1]) is [list: 1]
+  modes([list: -1, 0, 1, 2]) is [list: -1, 0, 1, 2]
+  modes([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly [list: ~0.1, ~0.2]
+  modes([list: -1, 2, -1, 2, -1]) is [list: -1]
+  modes([list: 1, 1, 2, 2, 3, 3, 3]) is [list: 3]
 
   stdev([list:]) raises "empty"
   stdev([list: 5]) is 0


### PR DESCRIPTION
Adds two functions:  `mode` and `modes`.  
 - `mode` will return a single number representing the mode from a list of numbers (if there are   multiple modes in the list, there is no guarantee which mode this function will return.
 - `modes` returns a list of numbers containing every and all modes in the list.

NOTE:  Originally the name of `modes` was `-modes`, but Pyret does not allow function definition with `-` as the first character.

EDIT:  This needs to be rewritten without the use of string-dicts.  Please ignore for the time being