### PR TITLE
Mode and opts

### DIFF
--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -46,7 +46,7 @@ fun mean(l :: L.List<Number>) -> Number:
   end
 end
 
-fun median(l :: L.List):
+fun median(l :: L.List) -> Number:
   doc: "returns the median element of the list"
 
   fun is-odd(n :: Number) -> Boolean:

--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -67,6 +67,69 @@ fun median(l :: L.List) -> Number:
   end
 end
 
+fun modes(l :: L.List) -> L.List<Number>:
+  doc: ```returns a list containing each mode of the input list, 
+       or an empty list if the input list is empty```
+  length-of-repeated = lam(lst :: L.List<Number>) -> L.List<{Number; Number}>:
+    aggregate = lam(prev :: L.List<{Number; Number}>, current-val :: Number) 
+      -> L.List<{Number; Number}>:
+      
+      cases (L.List) prev:
+        | empty => [L.list: {current-val; 1}]
+        | link(first, rest) => 
+          prev-val = first.{0}
+          prev-count = first.{1}
+          
+          if within(~0.0)(prev-val, current-val):
+            L.link({prev-val; prev-count + 1}, rest)
+          else:
+            L.link({current-val; 1}, prev)
+          end
+      end
+    end
+    
+    L.fold(aggregate, [L.list: ], lst)
+  end
+  
+  sorted-list = l.sort()
+  number-counts = length-of-repeated(sorted-list)
+  
+  find-maximal-appearing = lam(prev :: L.List<{Number; Number}>, 
+      current-elt :: {Number; Number}) -> L.List<{Number; Number}>:
+    
+    cases (L.List) prev:
+      | empty => [L.list: current-elt]
+      | link(f, r) =>
+        current-elt-count = current-elt.{1}
+        list-head-count = f.{1}
+        
+        if current-elt-count > list-head-count:
+          [L.list: current-elt]
+        else if current-elt-count == list-head-count:
+          L.link(current-elt, prev)
+        else:
+          prev
+        end
+    end
+  end
+
+  maximal-appearing = L.fold(find-maximal-appearing, [L.list: ], number-counts)
+  L.map(lam(x :: {Number; Number}): x.{0} end, maximal-appearing)
+  
+end
+
+fun mode(l :: L.List) -> O.Option<Number>:
+  doc: ```returns an option containing the mode of the
+       input list, or none if the input list is empty.
+       If the input has multiple modes, this function
+       returns the mode with the least value```
+
+  cases (L.List) modes(l):
+    | empty => O.none
+    | link(f, r) => O.some(f)
+  end
+end
+
 fun stdev(l :: L.List) -> Number:
   doc: "returns the standard deviation of the list of numbers"
   reg-mean = mean(l)

--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -40,7 +40,7 @@ end
 fun mean(l :: L.List<Number>) -> Number:
   doc: "Find the average of a list of numbers"
   if L.length(l) == 0:
-    raise("You can't take the average of an empty list")
+    raise("The input list is empty")
   else:
     math.sum(l) / L.length(l)
   end
@@ -57,7 +57,7 @@ fun median(l :: L.List) -> Number:
   size = L.length(sorted)
   index_of_median = num-floor(size / 2)
   cases (L.List) sorted:
-    |empty => raise("The list is empty")
+    |empty => raise("The input list is empty")
     |link(first, rest) => 
       if is-odd(size):
         sorted.get(index_of_median)
@@ -118,20 +118,21 @@ fun modes(l :: L.List) -> L.List<Number>:
   
 end
 
-fun mode(l :: L.List) -> O.Option<Number>:
+fun mode(l :: L.List) -> Number:
   doc: ```returns an option containing the mode of the
-       input list, or none if the input list is empty.
+       input list, or raises an error if input list is empty.
        If the input has multiple modes, this function
        returns the mode with the least value```
 
   cases (L.List) modes(l):
-    | empty => O.none
-    | link(f, r) => O.some(f)
+    | empty => raise("The input list is empty")
+    | link(f, r) => f
   end
 end
 
 fun stdev(l :: L.List) -> Number:
-  doc: "returns the standard deviation of the list of numbers"
+  doc: ```returns the standard deviation of the list 
+       of numbers, or raises an error if the list is empty```
   reg-mean = mean(l)
   sq-diff = l.map(lam(k): num-expt((k - reg-mean), 2) end)
   sq-mean = mean(sq-diff)

--- a/tests/pyret/tests/test-statistics.arr
+++ b/tests/pyret/tests/test-statistics.arr
@@ -23,6 +23,25 @@ check "numeric helpers":
   median([list: -1, 0, ~2, 3]) is-roughly ~1
   median([list: ~0, ~1, ~2, ~2, ~6, ~8]) is-roughly ~2
 
+  # Mode
+  mode([list: ]) is none
+  mode([list: 1]) is some(1)
+  mode([list: 1, 1, 2]) is some(1)
+  mode([list: -1, 0, -1, 2, 3, -33, ~0.1]) is some(-1)
+  mode([list: ~2, ~1.0002, ~2, ~1.0001, ~1]) is-roughly some(~2)
+
+  # For multimode distributions, returns smallest mode
+  mode([list: -1, 0, 1, 2]) is some(-1)
+  mode([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly some(~0.1)
+
+  # Modes (Plural) returns each mode in a list with multiple
+  modes([list: ]) is [list: ]
+  modes([list: 1]) is [list: 1]
+  modes([list: -1, 0, 1, 2]) is [list: -1, 0, 1, 2]
+  modes([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly [list: ~0.1, ~0.2]
+  modes([list: -1, 2, -1, 2, -1]) is [list: -1]
+  modes([list: 1, 1, 2, 2, 3, 3, 3]) is [list: 3]
+
   stdev([list:]) raises "empty"
   stdev([list: 5]) is 0
   stdev([list: 3, 4, 5, 6, 7]) is%(within(0.01)) 1.41

--- a/tests/pyret/tests/test-statistics.arr
+++ b/tests/pyret/tests/test-statistics.arr
@@ -24,15 +24,15 @@ check "numeric helpers":
   median([list: ~0, ~1, ~2, ~2, ~6, ~8]) is-roughly ~2
 
   # Mode
-  mode([list: ]) is none
-  mode([list: 1]) is some(1)
-  mode([list: 1, 1, 2]) is some(1)
-  mode([list: -1, 0, -1, 2, 3, -33, ~0.1]) is some(-1)
-  mode([list: ~2, ~1.0002, ~2, ~1.0001, ~1]) is-roughly some(~2)
+  mode([list: ]) raises "empty" 
+  mode([list: 1]) is 1
+  mode([list: 1, 1, 2]) is 1
+  mode([list: -1, 0, -1, 2, 3, -33, ~0.1]) is -1
+  mode([list: ~2, ~1.0002, ~2, ~1.0001, ~1]) is-roughly ~2
 
   # For multimode distributions, returns smallest mode
-  mode([list: -1, 0, 1, 2]) is some(-1)
-  mode([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly some(~0.1)
+  mode([list: -1, 0, 1, 2]) is -1
+  mode([list: ~0.1, ~0.2, ~0.2, ~0.1]) is-roughly ~0.1
 
   # Modes (Plural) returns each mode in a list with multiple
   modes([list: ]) is [list: ]


### PR DESCRIPTION
 - Adds and tests `mode` and `modes` to statistics library.  These functions consume `List<Number>` and return the most commonly occurring element/elements from the input, respectively.
 - `mode` returns an `Option<Number>`, instead or raising an error on empty inputs.  If everyone agrees with this change, I'm going to modify the `mean`, `median` and `stdev` functions & documentation to have this same signature.
 - `modes` returns a `List`, rather than a `Set`, because the input may contain rough-nums, and the built in `Set` structure cannot contain rough-nums.