### PR TITLE
Exit code

### DIFF
--- a/examples/exit-code/failure.arr
+++ b/examples/exit-code/failure.arr
@@ -1,19 +1,19 @@
-import error as ERR
+import system as SYS
 
 # By convention, an exit code not equal to 0 indicates that
 # the program failed to run successfully.
 exit-code = 1
 
 # check blocks are processed after the program finishes running
-# because we will raise an `exit`, no checks will be run
+# because we will call `system.exit`, no checks will be run
 check "this block gets skipped":
   "x" is "y"
 end
 
 # This will print "Exited with code 1" and terminate execution
-# To terminate execution without such a message, use the `exit-quiet`
-# variant instead
-raise(ERR.exit(exit-code))
-# raise(ERR.exit-quiet(exit-code))
+# To terminate execution without such a message, use the `system.exit-quiet`
+# function instead
+SYS.exit(exit-code)
+# SYS.exit-quiet(exit-code)
 
 print("This is after the exit, and hence will not print\n")

--- a/examples/exit-code/failure.arr
+++ b/examples/exit-code/failure.arr
@@ -1,0 +1,19 @@
+import error as ERR
+
+# By convention, an exit code not equal to 0 indicates that
+# the program failed to run successfully.
+exit-code = 1
+
+# check blocks are processed after the program finishes running
+# because we will raise an `exit`, no checks will be run
+check "this block gets skipped":
+  "x" is "y"
+end
+
+# This will print "Exited with code 1" and terminate execution
+# To terminate execution without such a message, use the `exit-quiet`
+# variant instead
+raise(ERR.exit(exit-code))
+# raise(ERR.exit-quiet(exit-code))
+
+print("This is after the exit, and hence will not print\n")

--- a/examples/exit-code/success.arr
+++ b/examples/exit-code/success.arr
@@ -1,0 +1,19 @@
+import error as ERR
+
+# By convention, an exit code of 0 indicates that
+# the program ran successfully.
+exit-code = 0
+
+# check blocks are processed after the program finishes running
+# because we will raise an `exit`, no checks will be run
+check "this block gets skipped":
+  "x" is "y"
+end
+
+# This will print "Exited with code 0" and terminate execution
+# To terminate execution without such a message, use the `exit-quiet`
+# variant instead
+raise(ERR.exit(exit-code))
+# raise(ERR.exit-quiet(exit-code))
+
+print("This is after the exit, and hence will not print\n")

--- a/examples/exit-code/success.arr
+++ b/examples/exit-code/success.arr
@@ -1,19 +1,19 @@
-import error as ERR
+import system as SYS
 
 # By convention, an exit code of 0 indicates that
 # the program ran successfully.
 exit-code = 0
 
 # check blocks are processed after the program finishes running
-# because we will raise an `exit`, no checks will be run
+# because we will call `system.exit`, no checks will be run
 check "this block gets skipped":
   "x" is "y"
 end
 
 # This will print "Exited with code 0" and terminate execution
-# To terminate execution without such a message, use the `exit-quiet`
-# variant instead
-raise(ERR.exit(exit-code))
-# raise(ERR.exit-quiet(exit-code))
+# To terminate execution without such a message, use the `system.exit-quiet`
+# function instead
+SYS.exit(exit-code)
+# SYS.exit-quiet(exit-code)
 
 print("This is after the exit, and hence will not print\n")

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -1,10 +1,10 @@
 #lang pyret
 
 import cmdline as C
-import error as ERR
 import file as F
 import render-error-display as RED
 import string-dict as D
+import system as SYS
 import file("cli-module-loader.arr") as CLI
 import file("compile-lib.arr") as CL
 import file("compile-structs.arr") as CS
@@ -187,4 +187,4 @@ fun main(args :: List<String>) -> Number:
 end
 
 exit-code = main(C.args)
-raise(ERR.exit-quiet(exit-code))
+SYS.exit-quiet(exit-code)

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -92,8 +92,8 @@ fun main(args :: List<String>) -> Number:
       when r.has-key("allow-builtin-overrides"):
         B.set-allow-builtin-overrides(r.get-value("allow-builtin-overrides"))
       end
-      if not(is-empty(rest)):
-        _ = print("No longer supported\n")
+      if not(is-empty(rest)) block:
+        print-error("No longer supported\n")
         failure-code
       else:
         if r.has-key("build-runnable") block:
@@ -102,7 +102,7 @@ fun main(args :: List<String>) -> Number:
           else:
             r.get-value("build-runnable") + ".jarr"
           end
-          _ = CLI.build-runnable-standalone(
+          CLI.build-runnable-standalone(
               r.get-value("build-runnable"),
               r.get-value("require-config"),
               outfile,
@@ -124,7 +124,7 @@ fun main(args :: List<String>) -> Number:
           S.serve(port)
           success-code
         else if r.has-key("build-standalone"):
-          _ = print("Use build-runnable instead of build-standalone\n")
+          print-error("Use build-runnable instead of build-standalone\n")
           failure-code
           #|
           CLI.build-require-standalone(r.get-value("build-standalone"),
@@ -153,15 +153,15 @@ fun main(args :: List<String>) -> Number:
               display-progress: display-progress
             })
           failures = filter(CS.is-err, result.loadables)
-          if is-link(failures):
+          if is-link(failures) block:
             for each(f from failures) block:
               for lists.each(e from f.errors) block:
                 print-error(tostring(e))
                 print-error("\n")
               end
-              _ = print("There were compilation errors\n")
-              failure-code
+              print-error("There were compilation errors\n")
             end
+            failure-code
           else:
             success-code
           end

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -93,7 +93,7 @@ fun main(args :: List<String>) -> Number:
         B.set-allow-builtin-overrides(r.get-value("allow-builtin-overrides"))
       end
       if not(is-empty(rest)):
-        _ = print("No longer supported")
+        _ = print("No longer supported\n")
         failure-code
       else:
         if r.has-key("build-runnable") block:
@@ -153,7 +153,7 @@ fun main(args :: List<String>) -> Number:
               display-progress: display-progress
             })
           failures = filter(CS.is-err, result.loadables)
-          when is-link(failures):
+          if is-link(failures):
             for each(f from failures) block:
               for lists.each(e from f.errors) block:
                 print-error(tostring(e))
@@ -162,6 +162,8 @@ fun main(args :: List<String>) -> Number:
               _ = print("There were compilation errors\n")
               failure-code
             end
+          else:
+            success-code
           end
         else if r.has-key("run"):
           _ = CLI.run(r.get-value("run"), CS.default-compile-options.{
@@ -185,4 +187,4 @@ fun main(args :: List<String>) -> Number:
 end
 
 exit-code = main(C.args)
-raise(ERR.exit(exit-code))
+raise(ERR.exit-quiet(exit-code))

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -1787,6 +1787,14 @@ data RuntimeError:
     method _output(self):
       VS.vs-value(self.value)
     end
+
+  | exit(value :: Number) with:
+    method render-fancy-reason(self, _, _):
+      self.render-reason()
+    end,
+    method render-reason(self):
+      [ED.error: ED.text("exit code: "), ED.embed(self.value)]
+    end
 end
 
 data ParseError:

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -1788,13 +1788,21 @@ data RuntimeError:
       VS.vs-value(self.value)
     end
 
-  | exit(value :: Number) with:
-    method render-fancy-reason(self, _, _):
-      self.render-reason()
-    end,
-    method render-reason(self):
-      [ED.error: ED.text("exit code: "), ED.embed(self.value)]
-    end
+  | exit(code :: Number) with:
+     method render-fancy-reason(self, _, _):
+       self.render-reason()
+     end,
+     method render-reason(self):
+       [ED.error: ED.text("Exited with code "), ED.embed(self.code)]
+     end
+
+   | exit-quiet(code :: Number) with:
+     method render-fancy-reason(self, _, _):
+       self.render-reason()
+     end,
+     method render-reason(self):
+       ED.text("")
+     end
 end
 
 data ParseError:

--- a/src/arr/trove/system.arr
+++ b/src/arr/trove/system.arr
@@ -1,0 +1,14 @@
+provide *
+provide-types *
+
+import error as ERR
+import global as _
+import base as _
+
+fun exit(code :: Number):
+  raise(ERR.exit(code))
+end
+
+fun exit-quiet(code :: Number):
+  raise(ERR.exit-quiet(code))
+end

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -243,6 +243,10 @@ require(["pyret-base/js/runtime", "program"], function(runtimeLib, program) {
       process.exit(EXIT_SUCCESS);
     }
     else if (runtime.isFailureResult(result)) {
+      if (runtime.isPyretException(result.exn) && runtime.ffi.isExit(result.exn.exn)) {
+        var exitCode = result.exn.exn.dict.value;
+        process.exit(exitCode);
+      }
       console.error("The run ended in error:");
       try {
         renderErrorMessageAndExit(runtime, result);

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -236,6 +236,20 @@ require(["pyret-base/js/runtime", "program"], function(runtimeLib, program) {
     }
   }
 
+  function isExit(execRt, result) {
+    var exn = result.exn.exn;
+    return execRt.ffi.isExit(exn) || execRt.ffi.isExitQuiet(exn);
+  }
+
+  function processExit(execRt, exn) {
+    var exitCode = execRt.getField(exn, "code");
+    if (execRt.ffi.isExit(exn)) {
+      var message = "Exited with code " + exitCode.toString() + "\n";
+      process.stdout.write(message);
+    }
+    process.exit(exitCode);
+  }
+
   function onComplete(result) {
     if(runtime.isSuccessResult(result)) {
       //console.log("The program completed successfully");
@@ -243,9 +257,9 @@ require(["pyret-base/js/runtime", "program"], function(runtimeLib, program) {
       process.exit(EXIT_SUCCESS);
     }
     else if (runtime.isFailureResult(result)) {
-      if (runtime.isPyretException(result.exn) && runtime.ffi.isExit(result.exn.exn)) {
-        var exitCode = result.exn.exn.dict.value;
-        process.exit(exitCode);
+
+      if (runtime.isPyretException(result.exn) && isExit(runtime, result)) {
+        processExit(runtime, result.exn.exn);
       }
       console.error("The run ended in error:");
       try {

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -590,6 +590,7 @@
 
       userBreak: gf(ERR, "user-break"),
       isUserBreak: errPred("is-user-break"),
+      isExit: errPred("is-exit"),
 
       errPred: errPred,
 

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -591,6 +591,7 @@
       userBreak: gf(ERR, "user-break"),
       isUserBreak: errPred("is-user-break"),
       isExit: errPred("is-exit"),
+      isExitQuiet: errPred("is-exit-quiet"),
 
       errPred: errPred,
 

--- a/tests/pyret/tests/test-errors.arr
+++ b/tests/pyret/tests/test-errors.arr
@@ -333,4 +333,16 @@ check:
   constr-err = get-err(lam(): fresh-constr.foo end)
   constr-err satisfies E.is-lookup-constructor-not-object
 
+  exit-err-zero = get-err(lam(): raise(E.exit(0)) end)
+  exit-err-zero satisfies E.is-exit
+
+  exit-err-one = get-err(lam(): raise(E.exit(1)) end)
+  exit-err-one satisfies E.is-exit
+
+  exit-quiet-err-zero = get-err(lam(): raise(E.exit-quiet(0)) end)
+  exit-quiet-err-zero satisfies E.is-exit-quiet
+
+  exit-quiet-err-one = get-err(lam(): raise(E.exit-quiet(1)) end)
+  exit-quiet-err-one satisfies E.is-exit-quiet
+
 end

--- a/tests/pyret/tests/test-errors.arr
+++ b/tests/pyret/tests/test-errors.arr
@@ -7,6 +7,7 @@ import format as F
 import parse-pyret as P
 import string-dict as D
 import filelib as FL
+import system as SYS
 
 data FreshData:
   | fresh-constr()
@@ -333,16 +334,16 @@ check:
   constr-err = get-err(lam(): fresh-constr.foo end)
   constr-err satisfies E.is-lookup-constructor-not-object
 
-  exit-err-zero = get-err(lam(): raise(E.exit(0)) end)
+  exit-err-zero = get-err(lam(): SYS.exit(0) end)
   exit-err-zero satisfies E.is-exit
 
-  exit-err-one = get-err(lam(): raise(E.exit(1)) end)
+  exit-err-one = get-err(lam(): SYS.exit(1) end)
   exit-err-one satisfies E.is-exit
 
-  exit-quiet-err-zero = get-err(lam(): raise(E.exit-quiet(0)) end)
+  exit-quiet-err-zero = get-err(lam(): SYS.exit-quiet(0) end)
   exit-quiet-err-zero satisfies E.is-exit-quiet
 
-  exit-quiet-err-one = get-err(lam(): raise(E.exit-quiet(1)) end)
+  exit-quiet-err-one = get-err(lam(): SYS.exit-quiet(1) end)
   exit-quiet-err-one satisfies E.is-exit-quiet
 
 end


### PR DESCRIPTION
(See the comments on PR https://github.com/brownplt/pyret-lang/pull/961 for a discussion of design decisions about an exit code mechanism.)

This PR adds `exit(code :: Number)` and `exit-quiet(code :: Number)` error variants which are able to be `raise`d, leading directly to an invocation of `process.exit(<code>)`. Using the `exit` variant will cause the message `Exited with code <code>` to be written stdout prior to exiting.

This PR also changes `pyret.arr` to use the exit code mechanism (via `exit-quiet`*), rather than `raise`ing other errors (in response to invalid command-line arguments, etc). This is needed in the context of PR https://github.com/brownplt/pyret-lang/pull/961 so that an exit code based on checker results can be specified in Pyret (e.g. a successful run, but with failing checks, still needs a non-zero exit code).

*I opted for `exit-quiet` mainly in anticipation of an option to get detailed check results from `--run` in parse-able JSON, so that we will be able to do pipe the output into a script which reads valid JSON from stdin. (E.g. a grading script). See the `checker-api` branch for my progress on that.

Finally, this PR adds some examples and tests.

`make no-diff-standalone` and the travis build (`make all-pyret-test`) both pass.