### PR TITLE
Change runtime to only bounce if a flag is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ clean:
 .PHONY : test-clean
 test-clean:
 	$(call RMDIR, tests/compiled)
+	$(call RM, tests/pyret/*.jarr)
 
 # Written this way because cmd.exe complains about && in command lines
 new-bootstrap: no-diff-standalone

--- a/src/arr/compiler/cli-module-loader.arr
+++ b/src/arr/compiler/cli-module-loader.arr
@@ -425,16 +425,18 @@ fun build-runnable-standalone(path, require-config-path, outfile, options) block
       end
 
       when options.collect-times: stats.set-now("standalone", time-now()) end
-      ans = MS.make-standalone(program.natives, program.js-ast,
-        JSON.j-obj(config.freeze()).serialize(), options.standalone-file)
-      when options.collect-times block:
-        standalone-end = time-now() - stats.get-value-now("standalone")
-        stats.set-now("standalone", [list: "Outputing JS: " + tostring(standalone-end) + "ms"])
-        for SD.each-key-now(key from stats):
-          print(key + ": \n" + stats.get-value-now(key).join-str(", \n") + "\n")
+
+      callback = lam(_):
+        when options.collect-times block:
+          standalone-end = time-now() - stats.get-value-now("standalone")
+          stats.set-now("standalone", [list: "Outputing JS: " + tostring(standalone-end) + "ms"])
+          for SD.each-key-now(key from stats):
+            print(key + ": \n" + stats.get-value-now(key).join-str(", \n") + "\n")
+          end
         end
       end
-      ans
+      MS.make-standalone(program.natives, program.js-ast,
+        JSON.j-obj(config.freeze()).serialize(), options.standalone-file, callback)
   end
 end
 

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -171,7 +171,8 @@ require(["pyret-base/js/runtime", "program"], function(runtimeLib, program) {
           process.exit(EXIT_ERROR_CHECK_FAILURES);
         }
         else {
-          process.exit(EXIT_SUCCESS);
+          console.log("Process exited succesfully...");
+          //process.exit(EXIT_SUCCESS);
         }
       }
     });
@@ -254,7 +255,8 @@ require(["pyret-base/js/runtime", "program"], function(runtimeLib, program) {
     if(runtime.isSuccessResult(result)) {
       //console.log("The program completed successfully");
       //console.log(result);
-      process.exit(EXIT_SUCCESS);
+      //process.exit(EXIT_SUCCESS);
+        console.log("Program is done...waiting for event loop to clear");
     }
     else if (runtime.isFailureResult(result)) {
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5822,7 +5822,6 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       }
     };
 
-<<<<<<< b7f9c9016754ed2a86e852980708822e67ff1fed
     // Deal with name shortening
     var nameMap = {
         'addModuleToNamespace': 'aMTN',

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3072,7 +3072,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
         stackFrame = $ar.args[2];
         $fun_ans = $ar.vars[0];
       }
-      if (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0) {
+      if (thisRuntime.bounceAllowed && (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0)) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         skipLoop = true;
         $ans = thisRuntime.makeCont();
@@ -3116,7 +3116,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
             i = i + 1;
           }
         }
-        if (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0) {
+        if (thisRuntime.bounceAllowed && (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0)) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           return thisRuntime.makeCont();
         }
@@ -3127,7 +3127,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
 
           if (isContinuation(res)) { return res; }
 
-          if (--thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }  
@@ -3490,6 +3490,9 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
     }
 
     function pauseStack(resumer) {
+      if (!thisRuntime.bounceAllowed) {
+        throw new Error("pauseStack called while runtime bounceAllowed is false");
+      }
       // CONSOLE.log("Pausing stack: ", RUN_ACTIVE, new Error().stack);
       RUN_ACTIVE = false;
       thisRuntime.EXN_STACKHEIGHT = 0;
@@ -3568,7 +3571,19 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
     }
 
     function runThunk(f, then) {
-      return thisRuntime.run(f, thisRuntime.namespace, {}, then);
+      if (thisRuntime.bounceAllowed) {
+        return thisRuntime.run(f, thisRuntime.namespace, {}, then);
+      } else {
+        // Just run it on this stack and use a try/catch handler
+        var result;
+        try {
+          result = f();
+          result = otherRuntime.makeSuccessResult(result, {});
+        } catch (e) {
+          result = otherRuntime.makeFailureResult(e, {});
+        }
+        return then(result);
+      }
     }
 
     function execThunk(thunk) {
@@ -3587,20 +3602,38 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
           return;
         }
       }
-      return thisRuntime.pauseStack(function(restarter) {
-        thisRuntime.run(function(_, __) {
-          return thunk.app();
-        }, thisRuntime.namespace, {
-          sync: false
-        }, function(result) {
-          if(isFailureResult(result) &&
-             isPyretException(result.exn) &&
-             thisRuntime.ffi.isUserBreak(result.exn.exn)) { restarter.break(); }
-          else {
-            restarter.resume(wrapResult(result));
-          }
+
+
+      var fn = function(_, __) {
+        return thunk.app();
+      };
+
+      if (thisRuntime.bounceAllowed) {
+        /* thunk may bounce, so clear the stack and let it run */
+        return thisRuntime.pauseStack(function(restarter) {
+          thisRuntime.run(fn, thisRuntime.namespace,{
+            sync: false
+          }, function(result) {
+            if(isFailureResult(result) &&
+               isPyretException(result.exn) &&
+               thisRuntime.ffi.isUserBreak(result.exn.exn)) { restarter.break(); }
+            else {
+              restarter.resume(wrapResult(result));
+            }
+          });
         });
-      });
+      } else {
+        /* thunk won't bounce (and we're not allowed to use pauseStack)
+           so we just run on this stack and catch any exceptions */
+        var result;
+        try {
+          result = fn(undefined, undefined);
+          result = new SuccessResult(result, {});
+        } catch(e) {
+          result = makeFailureResult(e, {});
+        }
+        return wrapResult(result);
+      }
     }
 
     function runWhileRunning(thunk) {
@@ -3816,14 +3849,14 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
         var $step = 0;
       }
       var cleanQuit = true;
-      if (--thisRuntime.GAS <= 0) {
+      if (thisRuntime.bounceAllowed && --thisRuntime.GAS <= 0) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         cleanQuit = false;
         $ans = thisRuntime.makeCont();
       }
       
       while (cleanQuit && (curIdx < len)) {
-        if (--thisRuntime.RUNGAS <= 0) {
+        if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           cleanQuit = false;
           $ans = thisRuntime.makeCont();
@@ -3874,14 +3907,14 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
         var $step = 0;
       }
       var cleanQuit = true;
-      if (--thisRuntime.GAS <= 0) {
+      if (thisRuntime.bounceAllowed && --thisRuntime.GAS <= 0) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         $ans = thisRuntime.makeCont();
         cleanQuit = false;
       }
       
       while (cleanQuit && curIdx < len) {
-        if (--thisRuntime.RUNGAS <= 0) {
+        if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           $ans = thisRuntime.makeCont();
           cleanQuit = false;
@@ -3991,7 +4024,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var length = arr.length;
       function foldHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4028,7 +4061,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4064,7 +4097,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var length = arr.length;
       function eachHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4097,7 +4130,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4134,7 +4167,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4177,7 +4210,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4215,7 +4248,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4257,7 +4290,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var newArray = new Array();
       function filterHelp() {
         while(currentIndex < (length - 1)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4299,7 +4332,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       var currentLst = lst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(--thisRuntime.RUNGAS <= 0) {
+          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -5032,17 +5065,25 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
 
         return thisRuntime.safeCall(function() {
           if (mod.nativeRequires.length === 0) {
-            // CONSOLE.log("Nothing to load, skipping stack-pause");
             return mod.nativeRequires;
           } else {
-            return thisRuntime.pauseStack(function(restarter) {
-              // CONSOLE.log("About to load: ", mod.nativeRequires);
-              require(mod.nativeRequires, function(/* varargs */) {
-                var nativeInstantiated = Array.prototype.slice.call(arguments);
-                //CONSOLE.log("Loaded: ", nativeInstantiated);
-                restarter.resume(nativeInstantiated);
+            if (thisRuntime.bounceAllowed) {
+              /* Use async version of require() */
+              return thisRuntime.pauseStack(function(restarter) {
+                require(mod.nativeRequires, function(/* varargs */) {
+                  var nativeInstantiated = Array.prototype.slice.call(arguments);
+                  restarter.resume(nativeInstantiated);
+                });
               });
-            });
+            } else {
+              /* require() should be synchronous */
+              var arr = [];
+              for(var i = 0; i < mod.nativeRequires.length; i++) {
+                var val = require(mod.nativeRequires[i]);
+                arr.push(val);
+              }
+              return arr;
+            }
           }
         }, function(natives) {
           function continu() {
@@ -5781,6 +5822,7 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
       }
     };
 
+<<<<<<< b7f9c9016754ed2a86e852980708822e67ff1fed
     // Deal with name shortening
     var nameMap = {
         'addModuleToNamespace': 'aMTN',
@@ -5830,6 +5872,9 @@ function (Namespace, jsnums, codePoint, seedrandom, util) {
         }
         thisRuntime[nameMap[longName]] = thisRuntime[longName];
     }
+
+    // FIXME: figure out how to set this in pyret code
+    thisRuntime.bounceAllowed = true;
 
     return thisRuntime;
   }

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -165,7 +165,7 @@
       return mr.val.runtime.getField(exn, "code");
     }
     function renderCheckResults(mr) {
-      return runtime.pauseStack(function(restarter) {
+      var pauseStack = function(restarter) {
         var res = getModuleResultResult(mr);
         var execRt = mr.val.runtime;
         var checkerMod = execRt.modules["builtin://checker"];
@@ -179,46 +179,60 @@
         };
         var getStackP = execRt.makeFunction(getStack, "get-stack");
         var checks = getModuleResultChecks(mr);
-        execRt.runThunk(function() { return toCall.app(checks, getStackP); },
-          function(renderedCheckResults) {
-            var resumeWith = {
-              message: "Unknown error!",
-              'exit-code': EXIT_ERROR_UNKNOWN
-            };
+        //      <<<<<<< b7f9c9016754ed2a86e852980708822e67ff1fed
+        var thunk = function() { return toCall.app(checks, getStackP); };
+        var thenFn = function(renderedCheckResults) {
+          var resumeWith = {
+            message: "Unknown error!",
+            'exit-code': EXIT_ERROR_UNKNOWN
+          };
 
-            if(execRt.isSuccessResult(renderedCheckResults)) {
-              resumeWith.message = execRt.unwrap(execRt.getField(renderedCheckResults.result, "message"));
-              var errs = execRt.getField(renderedCheckResults.result, "errored");
-              var failed = execRt.getField(renderedCheckResults.result, "failed");
-              if(errs !== 0 || failed !== 0) {
-                resumeWith["exit-code"] = EXIT_ERROR_CHECK_FAILURES;
-              } else {
-                resumeWith["exit-code"] = EXIT_SUCCESS;
-              }
+          if(execRt.isSuccessResult(renderedCheckResults)) {
+            resumeWith.message = execRt.unwrap(execRt.getField(renderedCheckResults.result, "message"));
+            var errs = execRt.getField(renderedCheckResults.result, "errored");
+            var failed = execRt.getField(renderedCheckResults.result, "failed");
+            if(errs !== 0 || failed !== 0) {
+              resumeWith["exit-code"] = EXIT_ERROR_CHECK_FAILURES;
+            } else {
+              resumeWith["exit-code"] = EXIT_SUCCESS;
             }
-            else if(execRt.isFailureResult(renderedCheckResults)) {
-              console.error(renderedCheckResults.exn);
-              resumeWith.message = "There was an exception while formatting the check results";
-              resumeWith["exit-code"] = EXIT_ERROR_RENDERING_ERROR;
-            }
+          }
+          else if(execRt.isFailureResult(renderedCheckResults)) {
+            console.error(renderedCheckResults.exn);
+            resumeWith.message = "There was an exception while formatting the check results";
+            resumeWith["exit-code"] = EXIT_ERROR_RENDERING_ERROR;
+          }
 
-            restarter.resume(runtime.makeObject({
-              message: runtime.makeString(resumeWith.message),
-              'exit-code': runtime.makeNumber(resumeWith["exit-code"])
-            }));
+          var result = runtime.makeObject({
+            message: runtime.makeString(resumeWith.message),
+            'exit-code': runtime.makeNumber(resumeWith["exit-code"])
           });
-      });
+
+          if (runtime.bounceAllowed) {
+            restarter.resume(result);
+          } else {
+            return result;
+          }
+        }
+        return execRt.runThunk(thunk, thenFn);
+      }
+
+      if (runtime.bounceAllowed) {
+        return runtime.pauseStack(pauseFn);
+      } else {
+        return pauseFn();
+      }
     }
     function renderErrorMessage(mr) {
       var res = getModuleResultResult(mr);
       var execRt = mr.val.runtime;
-      return runtime.pauseStack(function(restarter) {
+      var pauseStackFn = function(restarter) {
         // TODO(joe): This works because it's a builtin and already loaded on execRt.
         // In what situations may this not work?
         var rendererrorMod = execRt.modules["builtin://render-error-display"];
         var rendererror = execRt.getField(rendererrorMod, "provide-plus-types");
         var gf = execRt.getField;
-        execRt.runThunk(function() {
+        var renderFn = function() {
           if(execRt.isPyretVal(res.exn.exn) 
              && execRt.isObject(res.exn.exn) 
              && execRt.hasField(res.exn.exn, "render-reason")) {
@@ -242,21 +256,38 @@
           } else {
             return String(res.exn + "\n" + res.exn.stack);
           }
-        }, function(v) {
+        };
+
+        var thenFn = function(v) {
+          var resultObj;
           if(execRt.isSuccessResult(v)) {
-            restarter.resume(runtime.makeObject({
+            resultObj = runtime.makeObject({
               message: v.result,
               'exit-code': runtime.makeNumber(EXIT_ERROR)
-            }));
+            });
           } else {
             console.error(v.exn);
-            restarter.resume(runtime.makeObject({
+            resultObj = runtime.makeObject({
               message: runtime.makeString("Load error: there was an exception while rendering the exception."),
               'exit-code': runtime.makeNumber(EXIT_ERROR_RENDERING_ERROR)
-            }));
+            });
           }
-        })
-      });
+
+          if (execRt.bounceAllowed) {
+            restarter.resume(resultObj);
+          } else {
+            return resultObj;
+          }
+        };
+
+        return execRt.runThunk(renderFn, thenFn);
+      };
+
+      if (execRt.bounceAllowed) {
+        return runtime.pauseStack(pauseStackFn);
+      } else {
+        return pauseStackFn();
+      }
     }
     function getModuleResultAnswer(mr) {
       checkSuccess(mr, "answer");
@@ -310,31 +341,48 @@
         }
       };
 
-
-      return runtime.pauseStack(function(restarter) {
+      var pauseFunction = function(restarter) {
         var mainReached = false;
         var mainResult = "Main result unset: should not happen";
         postLoadHooks[main] = function(answer) {
           mainReached = true;
           mainResult = answer;
-        }
-        return otherRuntime.runThunk(function() {
+        };
+
+        var thunk = function() {
           otherRuntime.modules = realm;
           return otherRuntime.runStandalone(staticModules, realm, depMap, toLoad, postLoadHooks);
-        }, function(result) {
+        };
+
+        var then = function(result) {
+          var retVal;
+          
           if(!mainReached) {
             // NOTE(joe): we should only reach here if there was an error earlier
             // on in the chain of loading that stopped main from running
-            restarter.resume(makeModuleResult(otherRuntime, result, makeRealm(realm), runtime.nothing));
+            retVal = makeModuleResult(otherRuntime, result, makeRealm(realm), runtime.nothing);
           }
           else {
             var finalResult = otherRuntime.makeSuccessResult(mainResult);
             finalResult.stats = result.stats;
-            restarter.resume(makeModuleResult(otherRuntime, finalResult, makeRealm(realm), runtime.nothing));
+            retVal = makeModuleResult(otherRuntime, finalResult, makeRealm(realm), runtime.nothing);
           }
-        });
-      });
 
+          if (runtime.bounceAllowed) {
+            restarter.resume(retVal);
+          } else {
+            return retVal;
+          }
+        };
+
+        return otherRuntime.runThunk(thunk, then);
+      };
+
+      if (runtime.bounceAllowed) {
+        return runtime.pauseStack(pauseFunction);
+      } else {
+        return pauseFunction();
+      }
     }
     var vals = {
       "run-program": runtime.makeFunction(runProgram, "run-program"),

--- a/src/js/trove/make-standalone.js
+++ b/src/js/trove/make-standalone.js
@@ -16,8 +16,8 @@
       returns: The string produced by resolving dependencies with requirejs
 
     */
-    function makeStandalone(deps, body, configJSON, standaloneFile) {
-      runtime.checkArity(4, arguments, ["make-standalone"]);
+    function makeStandalone(deps, body, configJSON, standaloneFile, callback) {
+      runtime.checkArity(5, arguments, ["make-standalone"]);
       runtime.checkList(deps);
       runtime.checkString(configJSON);
 
@@ -41,36 +41,33 @@
       var realOut = config.out;
       config.out = path.join(storeDir, "program-deps.js");
       config.name = "program-require";
-      return runtime.pauseStack(function(restarter) {
-        requirejs.optimize(config, function(result) {
+      requirejs.optimize(config, function(result) {
           var programWithDeps = fs.readFileSync(config.out, {encoding: 'utf8'});
           // Browser/node check based on window below
           fs.open(realOut, "w", function(err, outFile) {
-            if (err) throw err;
-            fs.writeSync(outFile, "if(typeof window === 'undefined') {\n");
-            fs.writeSync(outFile, "var requirejs = require(\"requirejs\");\n");
-            fs.writeSync(outFile, "var define = requirejs.define;\n}\n");
-            fs.writeSync(outFile, programWithDeps);
-            fs.writeSync(outFile, "define(\"program\", " + depsLine + ", function() {\nreturn ");
-            var writeRealOut = function(str) { 
-              fs.writeSync(outFile, str, {encoding: 'utf8'}); 
-              return runtime.nothing; 
-            };
-            runtime.runThunk(function() { 
-              return runtime.getField(body, "print-ugly-source").app(runtime.makeFunction(writeRealOut, "write-real-out"));
-            }, function(_) {
+              if (err) throw err;
+              fs.writeSync(outFile, "if(typeof window === 'undefined') {\n");
+              fs.writeSync(outFile, "var requirejs = require(\"requirejs\");\n");
+              fs.writeSync(outFile, "var define = requirejs.define;\n}\n");
+              fs.writeSync(outFile, programWithDeps);
+              fs.writeSync(outFile, "define(\"program\", " + depsLine + ", function() {\nreturn ");
+              var writeRealOut = function(str) { 
+                  fs.writeSync(outFile, str, {encoding: 'utf8'}); 
+                  return runtime.nothing; 
+              };
+              runtime.getField(body, "print-ugly-source").app(runtime.makeFunction(writeRealOut, "write-real-out"));
               fs.writeSync(outFile, "\n});\n");
               fs.writeSync(outFile, handalone);
               fs.fsyncSync(outFile);
               fs.closeSync(outFile);
-              restarter.resume(true);
-            });
+              callback.app(runtime.makeNothing());
           });
-        }, function(err) {
+      }, function(err) {
           console.error("Error while using requirejs optimizer: ", err); 
-          restarter.error(runtime.ffi.makeMessageException("Error while using requirejs optimizer: ", String(err)));
-        });
+          callback(runtime.ffi.makeMessageException("Error while using requirejs optimizer: ", String(err)));
       });
+
+      return runtime.makeNothing();
     }
     return runtime.makeModuleReturn({
       "make-standalone": runtime.makeFunction(makeStandalone, "make-standalone")


### PR DESCRIPTION
When running in "everything-flat mode" we'll need to make sure that no bounces ever happen, so I'm trying to change the runtime to not bounce unless this new "allowBounce" flag is set. 

The main things I had to change were:
1) make-standalone() takes a pyret-level callback since it relies on the async requirejs.optimize function

2) When the allowBounce flag is false and we are running a chunk of pyret code that might fail (the checker does this with execThunk(), for example), instead of clearing the entire stack, and then running the potentially failing code, we use a try-catch block and run it on the same stack

3) When the allowBounce flag is false we use the synchronous version of require() in some places

This runtime code is pretty confusing so I'd very much like some feedback from someone who's worked with it before. It passes the tests with the allowBounce flag true, which is the "normal" behavior of the runtime (just to make sure that I didn't break anything just by adding the flag).

I have a local build that compiles everything as flat (with the allowBounce flag false) that passes all the tests, but I think it makes sense to just try to get the changes to the runtime reviewed first.

Passing travis build:
https://travis-ci.org/puppyofkosh/pyret-lang/builds/215244436