### PR TITLE
allow command-line args pass to programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ in Pyret development, read on:
 
 The easiest way to *run* a Pyret program from the command-line is:
 
-    $ ./src/scripts/phaseX <path-to-pyret-program-here>
+    $ ./src/scripts/phaseX <path-to-pyret-program-here> [command-line-args...]
 
-Where `X` is `0`, `A`, `B`, or `C`, indicating a phase (described below).
+Where `X` is `0`, `A`, `B`, or `C`, indicating a phase (described below). For
+example:
+
+    $ ./src/scripts/phaseA src/scripts/show-compilation.arr examples/ahoy-world.arr
 
 Alternatively, you can compile and run a standalone JavaScript file via:
 

--- a/src/arr/compiler/cli-module-loader.arr
+++ b/src/arr/compiler/cli-module-loader.arr
@@ -328,13 +328,14 @@ fun propagate-exit(result) block:
   end
 end
 
-fun run(path, options):
+fun run(path, options, subsequent-command-line-arguments):
   maybe-program = build-program(path, options)
   cases(Either) maybe-program block:
     | left(problems) =>
       handle-compilation-errors(problems, options)
     | right(program) =>
-      result = L.run-program(R.make-runtime(), L.empty-realm(), program.js-ast.to-ugly-source(), options)
+      command-line-arguments = link(path, subsequent-command-line-arguments)
+      result = L.run-program(R.make-runtime(), L.empty-realm(), program.js-ast.to-ugly-source(), options, command-line-arguments)
       if L.is-success-result(result):
         L.render-check-results(result)
       else:

--- a/src/arr/compiler/compile-lib.arr
+++ b/src/arr/compiler/compile-lib.arr
@@ -443,7 +443,7 @@ fun run-program(ws :: List<ToCompile>, prog :: CompiledProgram, realm :: L.Realm
       #print("Make standalone program\n")
       program = make-standalone(ws, prog, options)
       #print("Run program\n")
-      ans = right(L.run-program(runtime, realm, program.v.js-ast.to-ugly-source(), options))
+      ans = right(L.run-program(runtime, realm, program.v.js-ast.to-ugly-source(), options, empty))
       #print("Done\n")
       ans
     | link(_, _) =>
@@ -467,7 +467,7 @@ fun compile-and-run-locator(locator, finder, context, realm, runtime, starter-mo
       #print("Run program\n")
 
       # NOTE(joe): program.v OK because no errors above
-      ans = right(L.run-program(runtime, realm, program.v.js-ast.to-ugly-source(), options))
+      ans = right(L.run-program(runtime, realm, program.v.js-ast.to-ugly-source(), options, empty))
       #print("Done\n")
       ans
     | link(_, _) =>

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -92,10 +92,7 @@ fun main(args :: List<String>) -> Number:
       when r.has-key("allow-builtin-overrides"):
         B.set-allow-builtin-overrides(r.get-value("allow-builtin-overrides"))
       end
-      if not(is-empty(rest)) block:
-        print-error("No longer supported\n")
-        failure-code
-      else:
+      if is-empty(rest) or (rest.first == "-"):
         if r.has-key("build-runnable") block:
           outfile = if r.has-key("outfile"):
             r.get-value("outfile")
@@ -166,24 +163,43 @@ fun main(args :: List<String>) -> Number:
             success-code
           end
         else if r.has-key("run"):
+          run-args =
+            if is-empty(rest):
+              empty
+            else:
+              rest.rest
+            end
           result = CLI.run(r.get-value("run"), CS.default-compile-options.{
               standalone-file: standalone-file,
               compile-module: true,
               display-progress: display-progress,
               check-all: check-all
-            })
+            }, run-args)
           _ = print(result.message + "\n")
           result.exit-code
         else:
-          _ = print(C.usage-info(options).join-str("\n"))
-          _ = print("Unknown command line options\n")
+          block:
+            print-error(C.usage-info(options).join-str("\n"))
+            print-error("Unknown command line options\n")
+            failure-code
+          end
+        end
+      else:
+        block:
+          print-error(C.usage-info(options).join-str("\n"))
+          print-error("Unknown command line options\n")
+          print-error("Could not parse:\n")
+          print-error(rest.join-str(" "))
+          print-error("\n")
           failure-code
         end
       end
     | arg-error(message, partial) =>
-      _ = print(message + "\n")
-      _ = print(C.usage-info(options).join-str("\n"))
-      failure-code
+      block:
+        print-error(message + "\n")
+        print-error(C.usage-info(options).join-str("\n"))
+        failure-code
+      end
   end
 end
 

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -264,9 +264,10 @@
     }
     /* ProgramString is a staticModules/depMap/toLoad tuple as a string */
     // TODO(joe): this should take natives as an argument, as well, and requirejs them
-    function runProgram(otherRuntimeObj, realmObj, programString, options) {
+    function runProgram(otherRuntimeObj, realmObj, programString, options, commandLineArguments) {
       var checkAll = runtime.getField(options, "check-all");
       var otherRuntime = runtime.getField(otherRuntimeObj, "runtime").val;
+      otherRuntime.setParam("command-line-arguments", runtime.ffi.toArray(commandLineArguments));
       var realm = Object.create(runtime.getField(realmObj, "realm").val);
       var program = loader.safeEval("return " + programString, {});
       var staticModules = program.staticModules;

--- a/src/scripts/run-phase
+++ b/src/scripts/run-phase
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+set -e
+set -o nounset
+#set -x
+
 NODE="node -max-old-space-size=8192"
 
 SYMLINK_NAME=`basename "$0"`
@@ -15,10 +19,10 @@ PHASE="$SYMLINK_NAME"
 PYRET_JARR="build/$PHASE/pyret.jarr"
 FILE=$1
 
-if [ "$#" -ne 1 ]
+if [ 1 -gt "$#" ]
 then
     echo "Expecting 1 argument; received $#"
-    echo "Usage: $PHASE file.arr"
+    echo "Usage: $PHASE file.arr [args]"
     exit 1
 fi
 
@@ -34,4 +38,11 @@ then
     exit 1
 fi
 
-$NODE $PYRET_JARR -no-display-progress --run "$@"
+shift 1
+
+if [ "$#" -gt 0 ]
+then
+    $NODE $PYRET_JARR -no-display-progress --run $FILE - "$@"
+else
+    $NODE $PYRET_JARR -no-display-progress --run $FILE
+fi


### PR DESCRIPTION
https://github.com/brownplt/pyret-lang/issues/998

This PR adds a mechanism for passing command-line arguments to programs being
run via the `--run` flag. Because this flag is abstracted into the `phaseX`
scripts, this PR also updates `run-phase` to handle the invocation.

Simple example: `phaseA` runs `show-compilation.arr` which shows the compilation of `ahoy-world.arr`.
```
./src/scripts/phaseA src/scripts/show-compilation.arr examples/ahoy-world.arr
Success
File is examples/ahoy-world.arr
[REMAINING OUTPUT TOO LONG - REDACTED]
```

Meta example: `phaseC` runs `pyret.arr`, which itself runs `ahoy-world.arr`.
```
$ ./src/scripts/phaseC src/arr/compiler/pyret.arr --run examples/ahoy-world.arr 
25/25 modules compiled (base)       
Cleaning up and generating standalone...
Ahoy world!The program didn't define any tests.
```

To make it even more interesting, we have to be aware of the mechanism: any arguments after a single `-` are passed to the program being run.

Meta-meta example: `phaseC`  runs `pyret.arr`, which itself runs `pyret.arr`, which itself runs `ahoy-world.arr`.

```
$ ./src/scripts/phaseC src/arr/compiler/pyret.arr --run src/arr/compiler/pyret.arr - --run examples/ahoy-world.arr
69/69 modules compiled (/home/alex/repos/pyret-lang/src/arr/compiler/server)
Cleaning up and generating standalone...
25/25 modules compiled (base)       
Cleaning up and generating standalone...
Ahoy world!The program didn't define any tests.
```

And, as a sanity check, we can still simply _not_ pass arguments:
```
$ ./src/scripts/phaseB examples/ahoy-world.arr                             
Ahoy world!The program didn't define any tests.
```