### PR TITLE
fix error-rendering error for lookup-non-object

### DIFF
--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -608,7 +608,7 @@ data RuntimeError:
         [ED.error:
           ed-simple-intro("field lookup", self.loc),
           [ED.para: ED.text("It was given a non-object value:")],
-           ED.embed(self.obj)]
+           ED.embed(self.non-obj)]
       else if src-available(self.loc):
         cases(O.Option) maybe-ast(self.loc):
           | some(ast) =>
@@ -636,14 +636,14 @@ data RuntimeError:
         [ED.error:
           ed-simple-intro("field lookup", self.loc),
           [ED.para: ED.text("The left side was not an object:")],
-          ED.embed(self.obj)]
+          ED.embed(self.non-obj)]
       end
     end,
     method render-reason(self):
       [ED.error:
         ed-simple-intro("object lookup", self.loc),
         [ED.para: ED.text("The left side was not an object:")],
-        ED.embed(self.obj)]
+        ED.embed(self.non-obj)]
     end
   | extend-non-object(loc, non-obj) with:
     method render-fancy-reason(self, maybe-stack-loc, src-available, maybe-ast):


### PR DESCRIPTION
Because code.pyret.org's configuration skips these code paths, it is
necessary to use the command-line / node.js environment to test this.

To reproduce:
- create a file `tmp.arr` with just `"hello world".length()`
- `make tmp.jarr`
- `node tmp.jarr`