### PR TITLE
Sourcemaps stacktrace tests

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -256,9 +256,11 @@ fun app(l, f, args):
   end
 end
 
-fun check-fun(l, f):
+fun check-fun(sourcemap-loc, variable-loc, f):
   j-if1(j-unop(j-parens(rt-method("isFunction", [clist: f])), j-not),
-    j-block1(j-expr(j-method(rt-field("ffi"), "throwNonFunApp", [clist: l, f]))))
+    j-block1(j-expr(
+        J.j-sourcenode(sourcemap-loc, sourcemap-loc.source,
+        j-method(rt-field("ffi"), "throwNonFunApp", [clist: variable-loc, f])))))
 end
 
 c-exp = DAG.c-exp
@@ -839,7 +841,7 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
                         cl-cons(obj-id, compiled-args))))
                 ]),
               j-block([clist:
-                  check-fun(compiler.get-loc(l), colon-field-id),
+                  check-fun(l, compiler.get-loc(l), colon-field-id),
                   j-expr(j-assign(ans, app(l, colon-field-id, compiled-args)))
                 ])),
             # If the answer is a cont, jump to the end of the current function
@@ -892,7 +894,7 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-def
           j-expr(j-assign(step, after-app-label)),
           j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l)))] +
         if not(is-definitely-fn):
-          cl-sing(check-fun(j-id(compiler.cur-apploc), compiled-f))
+          cl-sing(check-fun(l, j-id(compiler.cur-apploc), compiled-f))
         else:
           cl-sing(j-expr(j-raw-code("// omitting isFunction check")))
         end +

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -217,6 +217,14 @@ fun obj-of-loc(l):
   end
 end
 
+fun wrap-with-srcnode(l, expr :: J.JExpr):
+  cases(Loc) l:
+    | builtin(name) => expr
+    | srcloc(source, _, _, _, _, _, _) =>
+      J.j-sourcenode(l, source, expr)
+  end
+end
+
 fun get-dict-field(obj, field):
   j-bracket(j-dot(obj, "dict"), field)
 end
@@ -229,7 +237,7 @@ end
 # When the field may not exist, add source mapping so if we can't find it
 # we get a useful stacktrace
 fun get-field-safe(l, obj :: J.JExpr, field :: J.JExpr, loc-expr :: J.JExpr):
-  J.j-sourcenode(l, l.source, get-field-unsafe(obj, field, loc-expr))
+  wrap-with-srcnode(l, get-field-unsafe(obj, field, loc-expr))
 end
 
 fun get-field-ref(obj :: J.JExpr, field :: J.JExpr, loc :: J.JExpr):

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -826,11 +826,15 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
   # num-args = args.length()
 
   if J.is-j-id(compiled-obj):
-    call = rt-method("maybeMethodCall",
-      cl-append([clist: compiled-obj, j-str(methname), compiler.get-loc(l)], compiled-args))
+    call = wrap-with-srcnode(l,
+      rt-method("maybeMethodCall",
+        cl-append([clist: compiled-obj,
+            j-str(methname),
+            compiler.get-loc(l)],
+          compiled-args)))
     {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
     c-block(j-block([clist:
-      j-expr(j-assign(step,  after-app-label)),
+      j-expr(j-assign(step, after-app-label)),
       j-expr(j-assign(ans, call)),
       j-break
     ]), new-cases)

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -1,7 +1,7 @@
 if(typeof window === 'undefined') {
 var require = require("requirejs");
 }
-require(["source-map", "pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], function(sourceMap, runtimeLib, stackLib, program) {
+require(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], function(runtimeLib, stackLib, program) {
 
   var staticModules = program.staticModules;
   var depMap = program.depMap;
@@ -187,30 +187,7 @@ require(["source-map", "pyret-base/js/runtime", "pyret-base/js/exn-stack-parser"
       var gf = execRt.getField;
       var exnStack = res.exn.stack;
 
-      var parsedStack = stackLib.parseStack(res.exn.stack);
-
-
-
-      var pyretStack = parsedStack.map(function(frame) {
-        var uri = program.uris[frame.hashedURI];        
-        console.log("The URI for ", frame.hashedURI, " is ", uri);
-        var moduleSourceMap = staticModules[uri].theMap;
-        var consumer = new sourceMap.SourceMapConsumer(moduleSourceMap);
-        consumer.computeColumnSpans();
-        var original = consumer.originalPositionFor({
-            source: uri,
-            line: Number(frame.startLine),
-            column: Number(frame.startCol) },
-          sourceMap.SourceMapConsumer.LEAST_UPPER_BOUND);
-        console.log(original);
-        var posForPyret = original.name.split(",");
-        for(var i = 1; i < posForPyret.length; i += 1) {
-          posForPyret[i] = Number(posForPyret[i]);
-        }
-        return posForPyret;
-      });
-
-      res.exn.pyretStack = pyretStack.concat(res.exn.pyretStack);
+      res.exn.pyretStack = stackLib.convertExceptionToPyretStackTrace(res.exn, program);
       debugger;
       
 

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -210,7 +210,7 @@ require(["source-map", "pyret-base/js/runtime", "pyret-base/js/exn-stack-parser"
         return posForPyret;
       });
 
-      res.exn.pyretStack = pyretStack;
+      res.exn.pyretStack = pyretStack.concat(res.exn.pyretStack);
       debugger;
       
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -7,6 +7,7 @@ define("pyret-base/js/runtime",
    "pyret-base/js/secure-loader",
    "seedrandom"],
 function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom) {
+  Error.stackTraceLimit = Infinity;
 
   if(util.isBrowser()) {
     var require = requirejs;
@@ -3272,6 +3273,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       // This function should not return anything meaningful, as state
       // and fallthrough are carefully managed.
       function iter() {
+        console.log("In iter, gas is " + thisRuntime.GAS);
         // CONSOLE.log("In run2::iter, GAS is ", thisRuntime.GAS);
         // If the thread is dead, return has already been processed
         if (threadIsDead) {
@@ -3398,6 +3400,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
             }
 
             else if(isPyretException(e)) {
+              console.log("caught pyret exn");
               while(theOneTrueStackHeight > 0) {
                 var next = theOneTrueStack[--theOneTrueStackHeight];
                 theOneTrueStack[theOneTrueStackHeight] = "sentinel";

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3273,7 +3273,6 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       // This function should not return anything meaningful, as state
       // and fallthrough are carefully managed.
       function iter() {
-        console.log("In iter, gas is " + thisRuntime.GAS);
         // CONSOLE.log("In run2::iter, GAS is ", thisRuntime.GAS);
         // If the thread is dead, return has already been processed
         if (threadIsDead) {
@@ -3400,7 +3399,6 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
             }
 
             else if(isPyretException(e)) {
-              console.log("caught pyret exn");
               while(theOneTrueStackHeight > 0) {
                 var next = theOneTrueStack[--theOneTrueStackHeight];
                 theOneTrueStack[theOneTrueStackHeight] = "sentinel";

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -362,7 +362,7 @@
               return posForPyret;
             });
 
-            result.exn.pyretStack = pyretStack;
+            result.exn.pyretStack = pyretStack.concat(result.exn.pyretStack);
 
             restarter.resume(makeModuleResult(otherRuntime, result, makeRealm(realm), runtime.nothing));
           }

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -2,9 +2,9 @@
   requires: [
     { "import-type": "builtin", name: "runtime-lib" }
   ],
-  nativeRequires: ["source-map", "pyret-base/js/exn-stack-parser", "pyret-base/js/secure-loader"],
+  nativeRequires: ["pyret-base/js/exn-stack-parser", "pyret-base/js/secure-loader"],
   provides: {},
-  theModule: function(runtime, namespace, uri, runtimeLib, sourceMap, stackLib, loader) {
+  theModule: function(runtime, namespace, uri, runtimeLib, stackLib, loader) {
     var EXIT_SUCCESS = 0;
     var EXIT_ERROR = 1;
     var EXIT_ERROR_RENDERING_ERROR = 2;
@@ -341,28 +341,7 @@
           if(!mainReached) {
             // NOTE(joe): we should only reach here if there was an error earlier
             // on in the chain of loading that stopped main from running
-            var parsedStack = stackLib.parseStack(result.exn.stack);
-
-            var pyretStack = parsedStack.map(function(frame) {
-              var uri = program.uris[frame.hashedURI];        
-              console.log("The URI for ", frame.hashedURI, " is ", uri);
-              var moduleSourceMap = staticModules[uri].theMap;
-              var consumer = new sourceMap.SourceMapConsumer(moduleSourceMap);
-              consumer.computeColumnSpans();
-              var original = consumer.originalPositionFor({
-                  source: uri,
-                  line: Number(frame.startLine),
-                  column: Number(frame.startCol) },
-                sourceMap.SourceMapConsumer.LEAST_UPPER_BOUND);
-              console.log(original);
-              var posForPyret = original.name.split(",");
-              for(var i = 1; i < posForPyret.length; i += 1) {
-                posForPyret[i] = Number(posForPyret[i]);
-              }
-              return posForPyret;
-            });
-
-            result.exn.pyretStack = pyretStack.concat(result.exn.pyretStack);
+            result.exn.pyretStack = stackLib.convertExceptionToPyretStackTrace(result.exn, program);
 
             restarter.resume(makeModuleResult(otherRuntime, result, makeRealm(realm), runtime.nothing));
           }

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -105,7 +105,12 @@
 
       var res = getModuleResultResult(mr);
       var stackString = runtime.printPyretStack(res.exn.pyretStack);
-      return runtime.makeString(stackString);
+      var stackFrames = stackString.split("\n");
+      var pyretStackFrames = stackFrames.map(function(frameString){
+        return runtime.makeString(frameString.trim());
+      });
+
+      return runtime.makeArray(pyretStackFrames);
     }
     function getModuleResultRuntime(mr) {
       return mr.val.runtime;

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -97,6 +97,18 @@
     function getResultProvides(mr) {
       return mr.val.provides;
     }
+    function getResultStackTrace(mr) {
+      var runtime = mr.val.runtime;
+      if (!runtime.isFailureResult(mr.val.result)) {
+        runtime.ffi.throwMessageException("Tried to get stacktrace of non-failing module result.");
+      }
+
+      var res = getModuleResultResult(mr);
+      console.log(JSON.stringify(res));
+      var stackString = runtime.printPyretStack(res.exn.pyretStack);
+      console.log("ST is :\n" + stackString);
+      return runtime.makeString(stackString);
+    }
     function getModuleResultRuntime(mr) {
       return mr.val.runtime;
     }
@@ -367,6 +379,7 @@
       "get-result-answer": runtime.makeFunction(getAnswerForPyret, "get-result-answer"),
       "get-result-realm": runtime.makeFunction(getRealm, "get-result-realm"),
       "get-result-compile-result": runtime.makeFunction(getResultCompileResult, "get-result-compile-result"),
+      "get-result-stacktrace": runtime.makeFunction(getResultStackTrace, "get-result-stacktrace"),
       "render-check-results": runtime.makeFunction(renderCheckResults, "render-check-results"),
       "render-error-message": runtime.makeFunction(renderErrorMessage, "render-error-message"),
       "empty-realm": runtime.makeFunction(emptyRealm, "empty-realm"),

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -104,9 +104,7 @@
       }
 
       var res = getModuleResultResult(mr);
-      console.log(JSON.stringify(res));
       var stackString = runtime.printPyretStack(res.exn.pyretStack);
-      console.log("ST is :\n" + stackString);
       return runtime.makeString(stackString);
     }
     function getModuleResultRuntime(mr) {

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -1,6 +1,6 @@
 const R = require("requirejs");
 var build = process.env["PHASE"] || "build/phaseA";
-R(["../../../" + build + "/js/pyret-tokenizer", "../../../" + build + "/js/pyret-parser", "fs"], function(T, G, fs) {
+R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], function(T, G, fs) {
   _ = require("jasmine-node");
   function parse(str) {
     const toks = T.Tokenizer;

--- a/tests/parse/require-test-runner/all-spec.js
+++ b/tests/parse/require-test-runner/all-spec.js
@@ -5,10 +5,11 @@ var build = process.env["PHASE"] || "build/phaseA";
 r.config({
   waitSeconds: 15000,
   paths: {
-    trove: "../../../" + build + "/trove",
-    js: "../../../" + build + "/js",
-    compiler: "../../../" + build + "/arr/compiler",
-    jglr: "../../../lib/jglr"
+    "trove": "../../../" + build + "/trove",
+    "js": "../../../" + build + "/js",
+    "compiler": "../../../" + build + "/arr/compiler",
+    "jglr": "../../../lib/jglr",
+    "pyret-base": "../../../" + build
   }
 });
 

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -25,20 +25,6 @@ end
 val = lam(str): L.get-result-answer(get-run-answer(str)) end
 msg = lam(str): L.render-error-message(get-run-answer(str)) end
 
-fun startswith(hay, needle):
-  needle-len = string-length(needle)
-  hay-len = string-length(hay)
-  (needle-len <= hay-len) and
-  string-equal(string-substring(hay, 0, needle-len), needle)
-end
-
-fun endswith(hay, needle):
-  needle-len = string-length(needle)
-  hay-len = string-length(hay)
-  (needle-len <= hay-len) and
-  string-equal(string-substring(hay, hay-len - needle-len, hay-len), needle)
-end
-
 check:
   r = RT.make-runtime()
 
@@ -157,10 +143,11 @@ check:
   result35 = next-interaction("fun g(): f() end")
   result36 = next-interaction("g()")
   result36.v satisfies L.is-failure-result
-  L.get-result-stacktrace(result36.v) is
-  "  definitions://: line 1, column 9\n" +
-  "  interactions://1: line 1, column 9\n" +
-  "  interactions://2: line 1, column 0"
+  L.get-result-stacktrace(result36.v) is=~
+  [raw-array:
+    "definitions://: line 1, column 9",
+    "interactions://1: line 1, column 9",
+    "interactions://2: line 1, column 0"]
 
   # Call a bunch of flat functions
   result37 = restart("fun f(o): o.x end\n" +
@@ -169,11 +156,12 @@ check:
                      "fun j(): string-append(g(), h()) end", false)
   result38 = next-interaction("j()")
   result38.v satisfies L.is-failure-result
-  L.get-result-stacktrace(result38.v) is
-  "  definitions://: line 1, column 10\n" +
-  "  definitions://: line 2, column 9\n" +
-  "  definitions://: line 4, column 23\n" +
-  "  interactions://1: line 1, column 0"
+  L.get-result-stacktrace(result38.v) is=~
+  [raw-array:
+    "definitions://: line 1, column 10",
+    "definitions://: line 2, column 9",
+    "definitions://: line 4, column 23",
+    "interactions://1: line 1, column 0"]
 
   #Call a tail-recursive function that has an error at the deepest level
   result39 = restart("fun len(l, acc):\n" +
@@ -189,29 +177,29 @@ check:
   # Due to tail call optimization, the stack trace may not have any of the
   # "middle" frames, though it should definitely have the topmost and bottom
   # most frames.
-  topframe = "  definitions://: line 3, column 15\n"
-  startswith(stacktrace, topframe) is true
-
-  bottomframe = "  interactions://1: line 1, column 0"
-  endswith(stacktrace, bottomframe) is true
+  raw-array-get(stacktrace, 0) is "definitions://: line 3, column 15"
+  raw-array-get(stacktrace,
+    raw-array-length(stacktrace) - 1) is "interactions://1: line 1, column 0"
 
   result41 = restart("fun f(o): o.x end\n" +
                      "fun g(): f(5)\n end", false)
   result42 = next-interaction("g()")
   result42.v satisfies L.is-failure-result
-  L.get-result-stacktrace(result42.v) is
-  "  definitions://: line 1, column 10\n" +
-  "  definitions://: line 2, column 9\n" +
-  "  interactions://1: line 1, column 0"
+  L.get-result-stacktrace(result42.v) is=~
+  [raw-array:
+    "definitions://: line 1, column 10",
+    "definitions://: line 2, column 9",
+    "interactions://1: line 1, column 0"]
 
   #Method call test
   result43 = restart("fun f(o): o.x() end\n" +
                      "fun g(): f({x: 5})\n end", false)
   result44 = next-interaction("g()")
   result44.v satisfies L.is-failure-result
-  L.get-result-stacktrace(result44.v) is
-  "  definitions://: line 1, column 10\n" +
-  "  definitions://: line 2, column 9\n" +
-  "  interactions://1: line 1, column 0"
+  L.get-result-stacktrace(result44.v) is=~
+  [raw-array:
+    "definitions://: line 1, column 10",
+    "definitions://: line 2, column 9",
+    "interactions://1: line 1, column 0"]
 
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -204,5 +204,14 @@ check:
   "  definitions://: line 2, column 9\n" +
   "  interactions://1: line 1, column 0"
 
+  #Method call test
+  result43 = restart("fun f(o): o.x() end\n" +
+                     "fun g(): f({x: 5})\n end", false)
+  result44 = next-interaction("g()")
+  result44.v satisfies L.is-failure-result
+  L.get-result-stacktrace(result44.v) is
+  "  definitions://: line 1, column 10\n" +
+  "  definitions://: line 2, column 9\n" +
+  "  interactions://1: line 1, column 0"
 
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -218,11 +218,13 @@ check:
   result46.v satisfies L.is-failure-result
   stacktrace46 = L.get-result-stacktrace(result46.v)
 
+  raw-array-length(stacktrace46) is 5
   raw-array-get(stacktrace46, 0) is "definitions://: line 2, column 12"
   # Don't check the actual line number in the builtin:lists
   startswith(raw-array-get(stacktrace46, 1), "builtin://lists:")
-  raw-array-get(stacktrace46, 2) is "definitions://: line 3, column 0"
-  raw-array-get(stacktrace46, 3) is "interactions://1: line 1, column 0"
+  startswith(raw-array-get(stacktrace46, 2), "builtin://lists:")
+  raw-array-get(stacktrace46, 3) is "definitions://: line 3, column 0"
+  raw-array-get(stacktrace46, 4) is "interactions://1: line 1, column 0"
 
   # stacktrace through builtin raw-list-map
   result47 = restart("fun f():\n" +

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -138,6 +138,51 @@ check:
   result33 = next-interaction("f()")
   val(result33) is some(22)
 
+  # Make sure a stack 3 levels deep works
+  result34 = restart("fun f(): 9() end", false)
+  result35 = next-interaction("fun g(): f() end")
+  result36 = next-interaction("g()")
+  result36.v satisfies L.is-failure-result
+  L.get-result-stacktrace(result36.v) is
+  "  definitions://: line 1, column 9\n" +
+  "  interactions://1: line 1, column 9\n" +
+  "  interactions://2: line 1, column 0"
+
+  # Call a bunch of flat functions
+  result37 = restart("fun f(o): o.x end\n" +
+                     "fun g(): f({}) end\n" +
+                     "fun h(): f({x: \"a\"}) end\n" +
+                     "fun j(): string-append(g(), h()) end", false)
+  result38 = next-interaction("j()")
+  result38.v satisfies L.is-failure-result
+  L.get-result-stacktrace(result38.v) is
+  "  definitions://: line 1, column 10\n" +
+  "  definitions://: line 2, column 9\n" +
+  "  definitions://: line 4, column 23\n" +
+  "  interactions://1: line 1, column 0"
+
+  # Call a tail-recursive function that has an error at the deepest level
+  result39 = restart("fun len(l, acc):\n" +
+  "  cases (List) l:\n" +
+  "    | empty => l.notafield\n" +
+  "    | link(_, r) => len(r, 1 + acc)\n" +
+  "  end\n" +
+  "end",
+  false)
+  result40 = next-interaction("len(range(0, 10), 0)")
+  L.get-result-stacktrace(result40.v)
+  "  definitions://: line 3, column 15\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  definitions://: line 4, column 20\n" +
+  "  interactions://1: line 1, column 0"
+
 
 end
-

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -162,26 +162,36 @@ check:
   "  interactions://1: line 1, column 0"
 
   # Call a tail-recursive function that has an error at the deepest level
-  result39 = restart("fun len(l, acc):\n" +
-  "  cases (List) l:\n" +
-  "    | empty => l.notafield\n" +
-  "    | link(_, r) => len(r, 1 + acc)\n" +
-  "  end\n" +
-  "end",
-  false)
-  result40 = next-interaction("len(range(0, 10), 0)")
-  L.get-result-stacktrace(result40.v) is
-  "  definitions://: line 3, column 15\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
-  "  definitions://: line 4, column 20\n" +
+  # result39 = restart("fun len(l, acc):\n" +
+  # "  cases (List) l:\n" +
+  # "    | empty => l.notafield\n" +
+  # "    | link(_, r) => len(r, 1 + acc)\n" +
+  # "  end\n" +
+  # "end",
+  # false)
+  # result40 = next-interaction("len(range(0, 10), 0)")
+  # L.get-result-stacktrace(result40.v) is
+  # "  definitions://: line 3, column 15\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  definitions://: line 4, column 20\n" +
+  # "  interactions://1: line 1, column 0"
+
+  result41 = restart("fun f(o): o.x end\n" +
+                     "fun g(): f(5)\n end", false)
+  result42 = next-interaction("g()")
+  result42.v satisfies L.is-failure-result
+  L.get-result-stacktrace(result42.v) is
+  "  definitions://: line 1, column 10\n" +
+  "  definitions://: line 2, column 9\n" +
   "  interactions://1: line 1, column 0"
+
 
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -25,6 +25,13 @@ end
 val = lam(str): L.get-result-answer(get-run-answer(str)) end
 msg = lam(str): L.render-error-message(get-run-answer(str)) end
 
+fun startswith(hay, needle):
+  needle-len = string-length(needle)
+  hay-len = string-length(hay)
+  (needle-len <= hay-len) and
+  string-equal(string-substring(hay, 0, needle-len), needle)
+end
+
 check:
   r = RT.make-runtime()
 
@@ -201,5 +208,20 @@ check:
     "definitions://: line 1, column 10",
     "definitions://: line 2, column 9",
     "interactions://1: line 1, column 0"]
+
+  # stacktrace through list.map()
+  result45 = restart("fun f():\n" +
+    "h = lam(x): 9() end\n" +
+    "[list: 1, 2, 3].map(h)\n" +
+    "end", false)
+  result46 = next-interaction("f()")
+  result46.v satisfies L.is-failure-result
+  stacktrace46 = L.get-result-stacktrace(result46.v)
+
+  raw-array-get(stacktrace46, 0) is "definitions://: line 2, column 12"
+  # Don't check the actual line number in the builtin:lists
+  startswith(raw-array-get(stacktrace46, 1), "builtin://lists:")
+  raw-array-get(stacktrace46, 2) is "definitions://: line 3, column 0"
+  raw-array-get(stacktrace46, 3) is "interactions://1: line 1, column 0"
 
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -224,4 +224,18 @@ check:
   raw-array-get(stacktrace46, 2) is "definitions://: line 3, column 0"
   raw-array-get(stacktrace46, 3) is "interactions://1: line 1, column 0"
 
+  # stacktrace through builtin raw-list-map
+  result47 = restart("fun f():\n" +
+    "h = lam(x): x.somefield end\n" +
+    "builtins.raw-list-map(h, [list: 1, 2, 3])\n" +
+    "end", false)
+  result48 = next-interaction("f()")
+  result48.v satisfies L.is-failure-result
+  L.get-result-stacktrace(result48.v) is=~
+  [raw-array:
+    "definitions://: line 2, column 12",
+    "definitions://: line 3, column 0",
+    "interactions://1: line 1, column 0"]
+
+
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -238,4 +238,23 @@ check:
     "interactions://1: line 1, column 0"]
 
 
+  result49 = restart("fun sum(x):\n" +
+    "if x == 0:\n" +
+    "  9()\n" +
+    "else:\n" +
+    "  x + sum(x - 1)\n" +
+    "end\n" +
+  "end", false)
+
+  # Should be plenty enough to bounce
+  ncalls = 1000
+  result50 = next-interaction("sum(" + tostring(ncalls) + ")")
+  result50.v satisfies L.is-failure-result
+  stacktrace50-list = raw-array-to-list(L.get-result-stacktrace(result50.v))
+
+  stacktrace50-list is
+  [list: "definitions://: line 3, column 2"] +
+  repeat(ncalls, "definitions://: line 5, column 6") +
+  [list: "interactions://1: line 1, column 0"]
+
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -170,7 +170,7 @@ check:
   "end",
   false)
   result40 = next-interaction("len(range(0, 10), 0)")
-  L.get-result-stacktrace(result40.v)
+  L.get-result-stacktrace(result40.v) is
   "  definitions://: line 3, column 15\n" +
   "  definitions://: line 4, column 20\n" +
   "  definitions://: line 4, column 20\n" +
@@ -183,6 +183,5 @@ check:
   "  definitions://: line 4, column 20\n" +
   "  definitions://: line 4, column 20\n" +
   "  interactions://1: line 1, column 0"
-
 
 end

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -25,6 +25,20 @@ end
 val = lam(str): L.get-result-answer(get-run-answer(str)) end
 msg = lam(str): L.render-error-message(get-run-answer(str)) end
 
+fun startswith(hay, needle):
+  needle-len = string-length(needle)
+  hay-len = string-length(hay)
+  (needle-len <= hay-len) and
+  string-equal(string-substring(hay, 0, needle-len), needle)
+end
+
+fun endswith(hay, needle):
+  needle-len = string-length(needle)
+  hay-len = string-length(hay)
+  (needle-len <= hay-len) and
+  string-equal(string-substring(hay, hay-len - needle-len, hay-len), needle)
+end
+
 check:
   r = RT.make-runtime()
 
@@ -161,28 +175,25 @@ check:
   "  definitions://: line 4, column 23\n" +
   "  interactions://1: line 1, column 0"
 
-  # Call a tail-recursive function that has an error at the deepest level
-  # result39 = restart("fun len(l, acc):\n" +
-  # "  cases (List) l:\n" +
-  # "    | empty => l.notafield\n" +
-  # "    | link(_, r) => len(r, 1 + acc)\n" +
-  # "  end\n" +
-  # "end",
-  # false)
-  # result40 = next-interaction("len(range(0, 10), 0)")
-  # L.get-result-stacktrace(result40.v) is
-  # "  definitions://: line 3, column 15\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  definitions://: line 4, column 20\n" +
-  # "  interactions://1: line 1, column 0"
+  #Call a tail-recursive function that has an error at the deepest level
+  result39 = restart("fun len(l, acc):\n" +
+  "  cases (List) l:\n" +
+  "    | empty => l.notafield\n" +
+  "    | link(_, r) => len(r, 1 + acc)\n" +
+  "  end\n" +
+  "end",
+  false)
+  result40 = next-interaction("len(range(0, 10), 0)")
+  stacktrace = L.get-result-stacktrace(result40.v)
+
+  # Due to tail call optimization, the stack trace may not have any of the
+  # "middle" frames, though it should definitely have the topmost and bottom
+  # most frames.
+  topframe = "  definitions://: line 3, column 15\n"
+  startswith(stacktrace, topframe) is true
+
+  bottomframe = "  interactions://1: line 1, column 0"
+  endswith(stacktrace, bottomframe) is true
 
   result41 = restart("fun f(o): o.x end\n" +
                      "fun g(): f(5)\n end", false)


### PR DESCRIPTION
I added a few tests for sourcemaps. Most of them are pretty simple, testing calling a non function or non method, or accessing a field that doesn't exist. It also tests errors from within flat functions, to be sure that we get complete stack traces.

When testing the stack trace of a function that's tail recursive, we only check that the top and bottom frames are correct, since the middle "frames" are omitted by the optimization. This might be controversial so any thoughts are welcome.

I also made some changes in anf-loop-compiler. There are a few places where code that might throw an exception was not sourcemapped and so the stack trace would be wrong or incomplete. I added a few j-sourcenodes in places that I thought could use them.
