### PR TITLE
Memo jsast fast mode with sourcemaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PHASEB           = build/phaseB
 PHASEC           = build/phaseC
 RELEASE_DIR      = build/release
 
-FLATNESS_THRESHOLD = 5
+FLATNESS_THRESHOLD = -1
 
 # CUSTOMIZE THESE IF NECESSARY
 PARSERS         := $(patsubst src/js/base/%-grammar.bnf,src/js/%-parser.js,$(wildcard src/$(JSBASE)/*-grammar.bnf))
@@ -209,7 +209,8 @@ TEST_BUILD=$(NODE) $(PYRET_TEST_PHASE)/pyret.jarr \
 	  --builtin-js-dir src/js/trove/ \
 		--builtin-arr-dir src/arr/trove/ \
 		--require-config $(PYRET_TEST_CONFIG) \
-		--compiled-dir tests/compiled/
+		--compiled-dir tests/compiled/ \
+		--flatness-threshold $(FLATNESS_THRESHOLD)
 
 .PHONY : old-test
 old-test: runtime-test evaluator-test compiler-test pyret-test regression-test type-check-test lib-test
@@ -244,8 +245,7 @@ tests/pyret/all.jarr: phaseA $(TEST_FILES) $(TYPE_TEST_FILES) $(REG_TEST_FILES) 
 	$(TEST_BUILD) \
 		--build-runnable tests/all.arr \
     --outfile tests/pyret/all.jarr \
-		-check-all \
-		--flatness-threshold $(FLATNESS_THRESHOLD)
+		-check-all
 
 .PHONY : all-pyret-test
 all-pyret-test: tests/pyret/all.jarr parse-test

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ tests/pyret/all.jarr: phaseA $(TEST_FILES) $(TYPE_TEST_FILES) $(REG_TEST_FILES) 
 		--build-runnable tests/all.arr \
     --outfile tests/pyret/all.jarr \
 		-check-all
+		--flatness-threshold 5
 
 .PHONY : all-pyret-test
 all-pyret-test: tests/pyret/all.jarr parse-test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYRET_COMP0      = build/phase0/pyret.jarr
 CLOSURE          = java -jar deps/closure-compiler/compiler.jar
-NODE             = node -max-old-space-size=8192
+NODE             = node -max-old-space-size=8192 --stack-size=8192
 SWEETJS          = node_modules/sweet.js/bin/sjs --readable-names --module ./src/js/macros.js
 JS               = js
 JSBASE           = $(JS)/base

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYRET_COMP0      = build/phase0/pyret.jarr
 CLOSURE          = java -jar deps/closure-compiler/compiler.jar
-NODE             = node -max-old-space-size=8192 --stack-size=8192
+NODE             = node -max-old-space-size=8192 --stack-size=16384
 SWEETJS          = node_modules/sweet.js/bin/sjs --readable-names --module ./src/js/macros.js
 JS               = js
 JSBASE           = $(JS)/base
@@ -16,6 +16,12 @@ PHASEC           = build/phaseC
 RELEASE_DIR      = build/release
 
 FLATNESS_THRESHOLD = -1
+ifeq ($(FLATNESS_THRESHOLD),-1)
+  # If we allow infinite flatness, then get rid of the system stack
+  # limit for node
+  TMPNODE:=$(NODE)
+  NODE=ulimit -s unlimited; $(TMPNODE)
+endif
 
 # CUSTOMIZE THESE IF NECESSARY
 PARSERS         := $(patsubst src/js/base/%-grammar.bnf,src/js/%-parser.js,$(wildcard src/$(JSBASE)/*-grammar.bnf))

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ PHASEB           = build/phaseB
 PHASEC           = build/phaseC
 RELEASE_DIR      = build/release
 
+FLATNESS_THRESHOLD = 5
+
 # CUSTOMIZE THESE IF NECESSARY
 PARSERS         := $(patsubst src/js/base/%-grammar.bnf,src/js/%-parser.js,$(wildcard src/$(JSBASE)/*-grammar.bnf))
 COPY_JS          = $(patsubst src/js/base/%.js,src/js/%.js,$(wildcard src/$(JSBASE)/*.js)) \
@@ -106,8 +108,8 @@ $(PHASEB)/pyret.jarr: $(PHASEA)/pyret.jarr $(PHASEB_ALL_DEPS) $(patsubst src/%,$
                       --builtin-arr-dir src/arr/trove/ \
                       --compiled-dir build/phaseB/compiled/ \
                       -no-check-mode $(EF) \
-                      --require-config src/scripts/standalone-configB.json
-
+                      --require-config src/scripts/standalone-configB.json \
+                      --flatness-threshold $(FLATNESS_THRESHOLD)
 
 .PHONY : phaseC
 phaseC: $(PHASEC)/pyret.jarr
@@ -119,7 +121,8 @@ $(PHASEC)/pyret.jarr: $(PHASEB)/pyret.jarr $(PHASEC_ALL_DEPS) $(patsubst src/%,$
                       --builtin-arr-dir src/arr/trove/ \
                       --compiled-dir build/phaseC/compiled/ \
                       -no-check-mode $(EF) \
-                      --require-config src/scripts/standalone-configC.json
+                      --require-config src/scripts/standalone-configC.json \
+                      --flatness-threshold $(FLATNESS_THRESHOLD)
 
 .PHONY : show-comp
 show-comp: build/show-compilation.jarr
@@ -241,8 +244,8 @@ tests/pyret/all.jarr: phaseA $(TEST_FILES) $(TYPE_TEST_FILES) $(REG_TEST_FILES) 
 	$(TEST_BUILD) \
 		--build-runnable tests/all.arr \
     --outfile tests/pyret/all.jarr \
-		-check-all
-		--flatness-threshold 5
+		-check-all \
+		--flatness-threshold $(FLATNESS_THRESHOLD)
 
 .PHONY : all-pyret-test
 all-pyret-test: tests/pyret/all.jarr parse-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PHASEB           = build/phaseB
 PHASEC           = build/phaseC
 RELEASE_DIR      = build/release
 
-FLATNESS_THRESHOLD = -1
+FLATNESS_THRESHOLD = 10
 ifeq ($(FLATNESS_THRESHOLD),-1)
   # If we allow infinite flatness, then get rid of the system stack
   # limit for node

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ clean:
 .PHONY : test-clean
 test-clean:
 	$(call RMDIR, tests/compiled)
+	$(call RM, tests/pyret/*.jarr)
 
 # Written this way because cmd.exe complains about && in command lines
 new-bootstrap: no-diff-standalone

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -961,11 +961,11 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-def
     j-block(
       # Update step before the call, so that if it runs out of gas,
       # the resumer goes to the right step
-      cl-sing(j-expr(j-assign(step, after-app-label))) +
+      [clist:
+        j-expr(j-assign(step, after-app-label)),
+        j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l)))] +
       if not(is-definitely-fn):
-        [clist:
-          j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l))),
-          check-fun(l, j-id(compiler.cur-apploc), compiled-f)]
+        cl-sing(check-fun(l, j-id(compiler.cur-apploc), compiled-f))
       else:
         cl-sing(j-expr(j-raw-code("// omitting isFunction check")))
       end +

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -875,58 +875,71 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
   end
 end
 
+fun should-apply-tco(compiler, args, app-info):
+  app-info.is-recursive and
+  app-info.is-tail and
+  compiler.allow-tco and
+  compiler.options.proper-tail-calls and
+  (args.length() == compiler.args.length()) # if it's an arity mismatch, use non-TCO to handle the error
+end
+
+fun compile-tco-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-definitely-fn) block:
+  ans = compiler.cur-ans
+  step = compiler.cur-step
+  compiled-f = f.visit(compiler).exp
+  compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
+  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+
+  c-block(
+    j-block(
+      [clist:
+        j-expr(j-assign(step, j-num(0))),
+        j-expr(j-unop(j-id(compiler.elided-frames), j-incr)),
+        if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
+          j-expr(j-raw-code("// Omitting rungas decrement and check"))
+        else:
+          j-if1(j-binop(j-unop(rt-field("RUNGAS"), j-decr), J.j-leq, j-num(0)),
+            j-block([clist:
+                j-expr(j-dot-assign(RUNTIME, "EXN_STACKHEIGHT", j-num(0))),
+                j-expr(j-assign(ans, rt-method("makeCont", cl-empty)))]))          
+        end
+      ] +
+      CL.map_list2(
+        lam(compiled-arg, arg): j-expr(j-assign(arg, compiled-arg)) end,
+        compiled-args.to-list(),
+        compiler.args) +
+      # CL.map_list2(
+      #   lam(compiled-arg, arg):
+      #     console-log([clist: j-str(tostring(arg)), j-id(arg)])
+      #   end,
+      #   compiled-args.to-list(),
+      #   compiler.args),
+      cl-sing(j-continue)),
+    new-cases)
+end
+
 fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-definitely-fn) block:
   ans = compiler.cur-ans
   step = compiler.cur-step
   compiled-f = f.visit(compiler).exp
   compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
   {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
-  if app-info.is-recursive and
-     app-info.is-tail and
-     compiler.allow-tco and
-     compiler.options.proper-tail-calls and
-     (compiled-args.length() == compiler.args.length()): # if it's an arity mismatch, use non-TCO to handle the error
-    c-block(
-      j-block(
+  c-block(
+    j-block(
+      # Update step before the call, so that if it runs out of gas,
+      # the resumer goes to the right step
+      cl-sing(j-expr(j-assign(step, after-app-label))) +
+      if not(is-definitely-fn):
         [clist:
-          # Update step before the call, so that if it runs out of gas,
-          # the resumer goes to the right step
-          j-expr(j-assign(step, j-num(0))),
-          j-expr(j-unop(j-id(compiler.elided-frames), j-incr)),
-          j-if1(j-binop(j-unop(rt-field("RUNGAS"), j-decr), J.j-leq, j-num(0)),
-            j-block([clist:
-              j-expr(j-dot-assign(RUNTIME, "EXN_STACKHEIGHT", j-num(0))),
-              j-expr(j-assign(ans, rt-method("makeCont", cl-empty)))]))] +
-        CL.map_list2(
-          lam(compiled-arg, arg): j-expr(j-assign(arg, compiled-arg)) end,
-          compiled-args.to-list(),
-          compiler.args) +
-        # CL.map_list2(
-        #   lam(compiled-arg, arg):
-        #     console-log([clist: j-str(tostring(arg)), j-id(arg)])
-        #   end,
-        #   compiled-args.to-list(),
-        #   compiler.args),
-        cl-sing(j-continue)),
-      new-cases)
-  else:
-    c-block(
-      j-block(
-        # Update step before the call, so that if it runs out of gas,
-        # the resumer goes to the right step
-        [clist:
-          j-expr(j-assign(step, after-app-label)),
-          j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l)))] +
-        if not(is-definitely-fn):
-          cl-sing(check-fun(l, j-id(compiler.cur-apploc), compiled-f))
-        else:
-          cl-sing(j-expr(j-raw-code("// omitting isFunction check")))
-        end +
-        [clist:
-          j-expr(j-assign(ans, app(l, compiled-f, compiled-args))),
-          j-break]),
-      new-cases)
-  end
+          j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l))),
+          check-fun(j-id(compiler.cur-apploc), compiled-f)]
+      else:
+        cl-sing(j-expr(j-raw-code("// omitting isFunction check")))
+      end +
+      [clist:
+        j-expr(j-assign(ans, app(compiler.get-loc(l), compiled-f, compiled-args))),
+        j-break]),
+    new-cases)
 end
 
 fun j-block-to-stmt-list(b :: J.JBlock) -> CL.ConcatList<J.JStmt>:
@@ -1177,7 +1190,9 @@ fun compile-a-app(l :: N.Loc, f :: N.AVal, args :: List<N.AVal>,
     app-info :: A.AppInfo):
 
   is-safe-id = N.is-a-id(f) or N.is-a-id-safe-letrec(f)
-  app-compiler = if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
+  app-compiler = if should-apply-tco(compiler, args, app-info):
+    compile-tco-app
+  else if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
     compile-flat-app
   else if is-safe-id and is-function-flat(compiler, f.id.key()):
     compile-flat-app

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -504,6 +504,11 @@ var total-time = 0
 
 show-stack-trace = false
 fun compile-fun-body(l :: Loc, step :: A.Name, fun-name :: A.Name, compiler, args :: List<N.ABind>, opt-arity :: Option<Number>, body :: N.AExpr, should-report-error-frame :: Boolean, is-flat :: Boolean) -> J.JBlock block:
+  shadow is-flat = if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
+    true
+  else:
+    is-flat
+  end
   make-label = make-label-sequence(0)
   ret-label = make-label()
   ans = fresh-id(compiler-name("ans"))
@@ -1148,17 +1153,21 @@ fun compile-split-update(compiler, loc, opt-dest, obj :: N.AVal, fields :: List<
 
 end
 
-fun is-function-flat(flatness-env :: D.StringDict<Option<Number>>, fun-name :: String) -> Boolean:
-  flatness-opt-opt = flatness-env.get(fun-name)
-  flatness-opt = cases (Option) flatness-opt-opt:
-    | some(f-opt) => f-opt
-    | none => none
+fun is-function-flat(compiler, fun-name :: String) -> Boolean:
+  threshold = compiler.options.flatness-threshold
+  if threshold == CS.INFINITE-FLATNESS-VALUE:
+    true
+  else:
+    flatness-opt-opt = compiler.flatness-env.get(fun-name)
+    cases (Option) flatness-opt-opt:
+      | some(f-opt) => is-some(f-opt) and (f-opt.value < threshold)
+      | none => false
+    end
   end
-  is-some(flatness-opt) and (flatness-opt.value <= 5)
 end
 
 fun is-id-fn-name(flatness-env :: D.StringDict<Option<Number>>, name :: String) -> Boolean:
-    is-some(flatness-env.get(name))
+  flatness-env.has-key(name)
 end
 
 fun compile-a-app(l :: N.Loc, f :: N.AVal, args :: List<N.AVal>,
@@ -1168,7 +1177,9 @@ fun compile-a-app(l :: N.Loc, f :: N.AVal, args :: List<N.AVal>,
     app-info :: A.AppInfo):
 
   is-safe-id = N.is-a-id(f) or N.is-a-id-safe-letrec(f)
-  app-compiler = if is-safe-id and is-function-flat(compiler.flatness-env, f.id.key()):
+  app-compiler = if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
+    compile-flat-app
+  else if is-safe-id and is-function-flat(compiler, f.id.key()):
     compile-flat-app
   else:
     compile-split-app
@@ -1181,7 +1192,7 @@ end
 fun compile-a-lam(compiler, l :: Loc, name :: String, args :: List<N.ABind>, ret :: A.Ann, body :: N.AExpr, bind-opt :: Option<BindType>) block:
   is-flat = if is-some(bind-opt) and is-b-let(bind-opt.value):
     bind = bind-opt.value.value
-    is-function-flat(compiler.flatness-env, bind.id.key())
+    is-function-flat(compiler, bind.id.key())
   else:
     false
   end

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -864,12 +864,10 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
             j-str(methname),
             compiler.get-loc(l)],
           compiled-args)))
-    call-code = [clist:
-      j-expr(j-raw-code("// method call optimization")),
-      j-expr(j-assign(ans, call))
-    ]
+    call-code = cl-sing(j-expr(j-assign(ans, call)))
     if compiler.options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE:
-      insert-flat-code(compiler, opt-dest, opt-body, ans, call-code)
+      insert-flat-code(compiler, opt-dest, opt-body, ans,
+        cl-cons(j-expr(j-raw-code("// method call optimization")), call-code))
     else:
       {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
       c-block(j-block(

--- a/src/arr/compiler/cli-module-loader.arr
+++ b/src/arr/compiler/cli-module-loader.arr
@@ -425,16 +425,18 @@ fun build-runnable-standalone(path, require-config-path, outfile, options) block
       end
 
       when options.collect-times: stats.set-now("standalone", time-now()) end
-      ans = MS.make-standalone(program.natives, program.js-ast,
-        JSON.j-obj(config.freeze()).serialize(), options.standalone-file)
-      when options.collect-times block:
-        standalone-end = time-now() - stats.get-value-now("standalone")
-        stats.set-now("standalone", [list: "Outputing JS: " + tostring(standalone-end) + "ms"])
-        for SD.each-key-now(key from stats):
-          print(key + ": \n" + stats.get-value-now(key).join-str(", \n") + "\n")
+
+      callback = lam(_):
+        when options.collect-times block:
+          standalone-end = time-now() - stats.get-value-now("standalone")
+          stats.set-now("standalone", [list: "Outputing JS: " + tostring(standalone-end) + "ms"])
+          for SD.each-key-now(key from stats):
+            print(key + ": \n" + stats.get-value-now(key).join-str(", \n") + "\n")
+          end
         end
       end
-      ans
+      MS.make-standalone(program.natives, program.js-ast,
+        JSON.j-obj(config.freeze()).serialize(), options.standalone-file, callback)
   end
 end
 

--- a/src/arr/compiler/compile-lib.arr
+++ b/src/arr/compiler/compile-lib.arr
@@ -522,6 +522,13 @@ fun make-standalone(wl, compiled, options):
           end
       end
     end)
+
+  runtime-options = J.j-obj(
+    C.concat-singleton(
+      J.j-field("bounceAllowed",
+        if options.flatness-threshold == CS.INFINITE-FLATNESS-VALUE: j-false
+        else: j-true end)))
+
   cases(List) all-compile-problems:
     | link(_, _) => left(all-compile-problems)
     | empty =>
@@ -547,7 +554,8 @@ fun make-standalone(wl, compiled, options):
           j-field("staticModules", static-modules),
           j-field("depMap", depmap),
           j-field("toLoad", to-load),
-          j-field("uris", uris)
+          j-field("uris", uris),
+          j-field("runtimeOptions", runtime-options)
         ])
 
       right({

--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -41,6 +41,9 @@ is-s-block = A.is-s-block
 
 type Loc = SL.Srcloc
 
+DEFAULT-FLATNESS-THRESHOLD = 0
+INFINITE-FLATNESS-VALUE = -1
+
 data Dependency:
   | dependency(protocol :: String, arguments :: List<String>)
     with:
@@ -2301,7 +2304,8 @@ type CompileOptions = {
   standalone-file :: String,
   log :: (String -> Nothing),
   on-compile :: Function, # NOTE: skipping types because the are in compile-lib
-  before-compile :: Function
+  before-compile :: Function,
+  flatness-threshold :: Number
 }
 
 default-compile-options = {
@@ -2331,6 +2335,7 @@ default-compile-options = {
   end,
   method on-compile(_, locator, loadable, _): loadable end,
   method before-compile(_, _): nothing end,
+  flatness-threshold: DEFAULT-FLATNESS-THRESHOLD,
   standalone-file: "src/js/base/handalone.js"
 }
 

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -64,8 +64,10 @@ fun main(args :: List<String>) -> Number:
     "type-check",
       C.flag(C.once, "Type-check the program during compilation"),
     "inline-case-body-limit",
-      C.next-val-default(C.Number, DEFAULT-INLINE-CASE-LIMIT, none, C.once, "Set number of steps that could be inlined in case body")
-  ]
+      C.next-val-default(C.Number, DEFAULT-INLINE-CASE-LIMIT, none, C.once, "Set number of steps that could be inlined in case body"),
+    "flatness-threshold",
+      C.next-val-default(C.Number, CS.DEFAULT-FLATNESS-THRESHOLD, none, C.once, "One plus maximum flatness for a function get the flatness optimization (" + tostring(CS.INFINITE-FLATNESS-VALUE) + " for all functions to be treated as flat)")
+        ]
 
   params-parsed = C.parse-args(options, args)
 
@@ -125,7 +127,8 @@ fun main(args :: List<String>) -> Number:
                 proper-tail-calls: tail-calls,
                 compiled-cache: compiled-dir,
                 display-progress: display-progress,
-                inline-case-body-limit: inline-case-body-limit
+                inline-case-body-limit: inline-case-body-limit,
+                flatness-threshold: r.get-value("flatness-threshold")
               })
           success-code
         else if r.has-key("serve"):

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -7,12 +7,14 @@ require(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], 
   var depMap = program.depMap;
   var toLoad = program.toLoad;
   var uris = program.uris;
+  var runtimeOptions = program.runtimeOptions;
 
   var main = toLoad[toLoad.length - 1];
 
   var runtime = runtimeLib.makeRuntime({
     stdout: function(s) { process.stdout.write(s); },
-    stderr: function(s) { process.stderr.write(s); }
+    stderr: function(s) { process.stderr.write(s); },
+    options: runtimeOptions
   });
 
   var EXIT_SUCCESS = 0;

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -174,7 +174,8 @@ require(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], 
           process.exit(EXIT_ERROR_CHECK_FAILURES);
         }
         else {
-          process.exit(EXIT_SUCCESS);
+          console.log("Process exited succesfully...");
+          //process.exit(EXIT_SUCCESS);
         }
       }
     });
@@ -261,7 +262,8 @@ require(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], 
     if(runtime.isSuccessResult(result)) {
       //console.log("The program completed successfully");
       //console.log(result);
-      process.exit(EXIT_SUCCESS);
+      //process.exit(EXIT_SUCCESS);
+        console.log("Program is done...waiting for event loop to clear");
     }
     else if (runtime.isFailureResult(result)) {
 

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -249,38 +249,37 @@ require(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"], 
     return execRt.ffi.isExit(exn) || execRt.ffi.isExitQuiet(exn);
   }
 
-  function processExit(execRt, exn) {
+  function processSetExitCode(execRt, exn) {
     var exitCode = execRt.getField(exn, "code");
     if (execRt.ffi.isExit(exn)) {
       var message = "Exited with code " + exitCode.toString() + "\n";
       process.stdout.write(message);
     }
-    process.exit(exitCode);
+    process.exitCode = exitCode;
   }
 
   function onComplete(result) {
     if(runtime.isSuccessResult(result)) {
-      //console.log("The program completed successfully");
-      //console.log(result);
-      //process.exit(EXIT_SUCCESS);
-        console.log("Program is done...waiting for event loop to clear");
-    }
-    else if (runtime.isFailureResult(result)) {
-
+      // Don't do anything here. Just wait for event loop to clear
+    } else if (runtime.isFailureResult(result)) {
       if (runtime.isPyretException(result.exn) && isExit(runtime, result)) {
-        processExit(runtime, result.exn.exn);
-      }
-      console.error("The run ended in error:");
-      try {
-        renderErrorMessageAndExit(runtime, result);
-      } catch(e) {
-        console.error("EXCEPTION!", e);
+        processSetExitCode(runtime, result.exn.exn);
+        // Wait for event loop to clear now
+      } else {
+        console.error("The run ended in error:");
+        try {
+          renderErrorMessageAndExit(runtime, result);
+        } catch(e) {
+          console.error("EXCEPTION!", e);
+        }
       }
     } else {
       console.error("The run ended in an unknown error: ", result);
       console.error(result.exn.stack);
       process.exit(EXIT_ERROR_UNKNOWN);
     }
+
+    console.log("Program is done...waiting for event loop to clear");
   }
 
   return runtime.runThunk(function() {

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5916,6 +5916,12 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       thisRuntime.bounceAllowed = theOutsideWorld.options.bounceAllowed;
     }
 
+    if (theOutsideWorld.parentRuntime) {
+      thisRuntime.bounceAllowed &= theOutsideWorld.parentRuntime.bounceAllowed;
+    }
+
+    console.log("New runtime. Is bounce allowed: " + thisRuntime.bounceAllowed);
+
     return thisRuntime;
   }
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3589,9 +3589,9 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         var result;
         try {
           result = f();
-          result = otherRuntime.makeSuccessResult(result, {});
+          result = thisRuntime.makeSuccessResult(result, {});
         } catch (e) {
-          result = otherRuntime.makeFailureResult(e, {});
+          result = thisRuntime.makeFailureResult(e, {});
         }
         return then(result);
       }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5096,7 +5096,10 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
                 });
               });
             } else {
-              /* require() should be synchronous */
+              /**
+                 require() should be synchronous.
+                 In this case we can't load native modules asynchronously.
+              */
               var arr = [];
               for(var i = 0; i < mod.nativeRequires.length; i++) {
                 var val = require(mod.nativeRequires[i]);

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5928,10 +5928,11 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       thisRuntime.bounceAllowed = theOutsideWorld.options.bounceAllowed;
     }
 
-    // In principle it should be possible for a parent runtime to have bouncing off
-    // but a "child runtime" have bouncing on, though it might require some nasty
-    // modifications to the run function. For now we just require that the child runtime
-    // can only allow bounces if the parent runtime can as well
+    // We require that the child runtime can only allow bounces if the parent
+    // runtime can handle them as well. Otherwise, a child runtime bouncing
+    // would clear both the child's stack and the parent's stack, and since
+    // the parent doesn't support bouncing, there would be no way
+    // to resume with its runtime.
     if (theOutsideWorld.parentRuntime) {
       thisRuntime.bounceAllowed &= theOutsideWorld.parentRuntime.bounceAllowed;
     }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3091,7 +3091,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         stackFrame = $ar.args[2];
         $fun_ans = $ar.vars[0];
       }
-      if (thisRuntime.spendGas() || thisRuntime.spendRunGas()) {
+      if (spendGas() || spendRunGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         skipLoop = true;
         $ans = thisRuntime.makeCont();
@@ -3135,7 +3135,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
             i = i + 1;
           }
         }
-        if (thisRuntime.spendGas() || thisRuntime.spendRunGas()) {
+        if (spendGas() || spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           return thisRuntime.makeCont();
         }
@@ -3146,7 +3146,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
 
           if (isContinuation(res)) { return res; }
 
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }  
@@ -3908,14 +3908,14 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         var $step = 0;
       }
       var cleanQuit = true;
-      if (thisRuntime.spendGas()) {
+      if (spendGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         cleanQuit = false;
         $ans = thisRuntime.makeCont();
       }
       
       while (cleanQuit && (curIdx < len)) {
-        if (thisRuntime.spendRunGas()) {
+        if (spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           cleanQuit = false;
           $ans = thisRuntime.makeCont();
@@ -3966,14 +3966,14 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         var $step = 0;
       }
       var cleanQuit = true;
-      if (thisRuntime.spendGas()) {
+      if (spendGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         $ans = thisRuntime.makeCont();
         cleanQuit = false;
       }
       
       while (cleanQuit && curIdx < len) {
-        if (thisRuntime.spendRunGas()) {
+        if (spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           $ans = thisRuntime.makeCont();
           cleanQuit = false;
@@ -4083,7 +4083,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var length = arr.length;
       function foldHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4120,7 +4120,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4156,7 +4156,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var length = arr.length;
       function eachHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4189,7 +4189,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4226,7 +4226,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4269,7 +4269,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4307,7 +4307,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4349,7 +4349,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array();
       function filterHelp() {
         while(currentIndex < (length - 1)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4391,7 +4391,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentLst = lst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if (thisRuntime.spendRunGas()) {
+          if (spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3524,7 +3524,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       if (thisRuntime.bounceAllowed) {
         return thisRuntime.pauseStack(resumer);
       } else {
-        return resumer();
+        return resumer(new DummyPausePackage());
       }
     }
 
@@ -5606,6 +5606,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'isPause'     : isPause,
 
       'pauseStack'  : pauseStack,
+      'maybePauseStack' : maybePauseStack,
       'schedulePause'  : schedulePause,
       'breakAll' : breakAll,
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5911,8 +5911,10 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         thisRuntime[nameMap[longName]] = thisRuntime[longName];
     }
 
-    // FIXME: figure out how to set this in pyret code
-    thisRuntime.bounceAllowed = true;
+    thisRuntime.bounceAllowed = true; // Default
+    if (theOutsideWorld.options) {
+      thisRuntime.bounceAllowed = theOutsideWorld.options.bounceAllowed;
+    }
 
     return thisRuntime;
   }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3043,6 +3043,15 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       return stackStr;
     }
 
+    /* Decrement gas or rungas and return whether or not it's time to return a continuation */
+    function spendGas() {
+      return thisRuntime.bounceAllowed && (--thisRuntime.GAS <= 0);
+    }
+
+    function spendRunGas() {
+      return thisRuntime.bounceAllowed && (--thisRuntime.RUNGAS <= 0);
+    }
+
     function Pause(stack, pause, resumer) {
       this.stack = stack;
       this.pause = pause;
@@ -3082,7 +3091,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         stackFrame = $ar.args[2];
         $fun_ans = $ar.vars[0];
       }
-      if (thisRuntime.bounceAllowed && (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0)) {
+      if (thisRuntime.spendGas() || thisRuntime.spendRunGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         skipLoop = true;
         $ans = thisRuntime.makeCont();
@@ -3126,7 +3135,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
             i = i + 1;
           }
         }
-        if (thisRuntime.bounceAllowed && (--thisRuntime.GAS <= 0 || --thisRuntime.RUNGAS <= 0)) {
+        if (thisRuntime.spendGas() || thisRuntime.spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           return thisRuntime.makeCont();
         }
@@ -3137,7 +3146,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
 
           if (isContinuation(res)) { return res; }
 
-          if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }  
@@ -3860,14 +3869,14 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         var $step = 0;
       }
       var cleanQuit = true;
-      if (thisRuntime.bounceAllowed && --thisRuntime.GAS <= 0) {
+      if (thisRuntime.spendGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         cleanQuit = false;
         $ans = thisRuntime.makeCont();
       }
       
       while (cleanQuit && (curIdx < len)) {
-        if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+        if (thisRuntime.spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           cleanQuit = false;
           $ans = thisRuntime.makeCont();
@@ -3918,14 +3927,14 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         var $step = 0;
       }
       var cleanQuit = true;
-      if (thisRuntime.bounceAllowed && --thisRuntime.GAS <= 0) {
+      if (thisRuntime.spendGas()) {
         thisRuntime.EXN_STACKHEIGHT = 0;
         $ans = thisRuntime.makeCont();
         cleanQuit = false;
       }
       
       while (cleanQuit && curIdx < len) {
-        if (thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+        if (thisRuntime.spendRunGas()) {
           thisRuntime.EXN_STACKHEIGHT = 0;
           $ans = thisRuntime.makeCont();
           cleanQuit = false;
@@ -4035,7 +4044,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var length = arr.length;
       function foldHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4072,7 +4081,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4108,7 +4117,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var length = arr.length;
       function eachHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4141,7 +4150,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4178,7 +4187,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4221,7 +4230,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array(length);
       function mapHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4259,7 +4268,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentFst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4301,7 +4310,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var newArray = new Array();
       function filterHelp() {
         while(currentIndex < (length - 1)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }
@@ -4343,7 +4352,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       var currentLst = lst;
       function foldHelp() {
         while(thisRuntime.ffi.isLink(currentLst)) {
-          if(thisRuntime.bounceAllowed && --thisRuntime.RUNGAS <= 0) {
+          if (thisRuntime.spendRunGas()) {
             thisRuntime.EXN_STACKHEIGHT = 0;
             return thisRuntime.makeCont();
           }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5920,8 +5920,6 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       thisRuntime.bounceAllowed &= theOutsideWorld.parentRuntime.bounceAllowed;
     }
 
-    console.log("New runtime. Is bounce allowed: " + thisRuntime.bounceAllowed);
-
     return thisRuntime;
   }
 

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3061,6 +3061,33 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     function isPause(v) { return v instanceof Pause; }
     Pause.prototype = Object.create(Cont.prototype);
 
+    function makeTimerObj() {
+      return {};
+    }
+
+    function startTimer(timerObj) {
+      if (typeof window !== "undefined" && window.performance) {
+        timerObj.startTime = window.performance.now();
+      } else if (typeof process !== "undefined" && process.hrtime) {
+        timerObj.startTime = process.hrtime();
+      }
+    }
+
+    function endTimer(timerObj) {
+      if (typeof window !== "undefined" && window.performance) {
+        timerObj.elapsed = window.performance.now() - timerObj.startTime;
+      } else if (typeof process !== "undefined" && process.hrtime) {
+        timerObj.elapsed = process.hrtime(timerObj.startTime);
+      }
+      return timerObj.elapsed;
+    }
+
+    function makeStatsObj(bounces, tos, time) {
+      var stats = {"bounces": bounces, "tos": tos, "time": time};
+      return stats;
+    }
+
+
     function safeTail(fun) {
       return fun();
     }
@@ -3174,23 +3201,9 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         return;
       }
       RUN_ACTIVE = true;
-      var start;
-      function startTimer() {
-        if (typeof window !== "undefined" && window.performance) {
-          start = window.performance.now();
-        } else if (typeof process !== "undefined" && process.hrtime) {
-          start = process.hrtime();
-        }
-      }
-      function endTimer() {
-        if (typeof window !== "undefined" && window.performance) {
-          return window.performance.now() - start;
-        } else if (typeof process !== "undefined" && process.hrtime) {
-          return process.hrtime(start);
-        }
-      }
+      var timerObj = makeTimerObj();
       function getStats() {
-        return { bounces: BOUNCES, tos: TOS, time: endTimer() };
+        return makeStatsObj(BOUNCES, TOS, endTimer(timerObj));
       }
       function finishFailure(exn) {
         RUN_ACTIVE = false;
@@ -3203,7 +3216,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         onDone(new SuccessResult(answer, getStats()));
       }
 
-      startTimer();
+      startTimer(timerObj);
       var that = this;
       var theOneTrueStackTop = ["top-of-stack"]
       var kickoff = makeActivationRecord(
@@ -3633,14 +3646,19 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       if (thisRuntime.bounceAllowed) {
         return thisRuntime.run(f, thisRuntime.namespace, {}, then);
       } else {
+        var timerObj = makeTimerObj();
         // Just run it on this stack and use a try/catch handler
-        var result;
+        var fnResult;
+        var resultCtor;
         try {
-          result = f();
-          result = thisRuntime.makeSuccessResult(result, {});
+          fnResult = f();
+          resultCtor = thisRuntime.makeSuccessResult;
         } catch (e) {
-          result = thisRuntime.makeFailureResult(e, {});
+          fnResult = e;
+          resultCtor = thisRuntime.makeFailureResult;
         }
+        var statsObj = makeStatsObj(0, 0, endTimer(timerObj));
+        result = resultCtor(fnResult, statsObj);
         return then(result);
       }
     }

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5916,6 +5916,10 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       thisRuntime.bounceAllowed = theOutsideWorld.options.bounceAllowed;
     }
 
+    // In principle it should be possible for a parent runtime to have bouncing off
+    // but a "child runtime" have bouncing on, though it might require some nasty
+    // modifications to the run function. For now we just require that the child runtime
+    // can only allow bounces if the parent runtime can as well
     if (theOutsideWorld.parentRuntime) {
       thisRuntime.bounceAllowed &= theOutsideWorld.parentRuntime.bounceAllowed;
     }

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -323,6 +323,10 @@
       var main = toLoad[toLoad.length - 1];
       runtime.setParam("currentMainURL", main);
 
+      if (otherRuntime.bounceAllowed != runtime.bounceAllowed) {
+        throw new Error("bounceAllowed mismatch.");
+      }
+
       if(realm["builtin://checker"]) {
         var checker = otherRuntime.getField(otherRuntime.getField(realm["builtin://checker"], "provide-plus-types"), "values");
         // NOTE(joe): This is the place to add checkAll

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -222,25 +222,17 @@
             'exit-code': runtime.makeNumber(resumeWith["exit-code"])
           });
 
-          if (runtime.bounceAllowed) {
-            restarter.resume(result);
-          } else {
-            return result;
-          }
-        }
+          return restarter.resumeOrReturn(result);
+        };
         return execRt.runThunk(thunk, thenFn);
-      }
+      };
 
-      if (runtime.bounceAllowed) {
-        return runtime.pauseStack(pauseFn);
-      } else {
-        return pauseFn();
-      }
+      return runtime.maybePauseStack(pauseFn);
     }
     function renderErrorMessage(mr) {
       var res = getModuleResultResult(mr);
       var execRt = mr.val.runtime;
-      var pauseStackFn = function(restarter) {
+      var pauseFn = function(restarter) {
         // TODO(joe): This works because it's a builtin and already loaded on execRt.
         // In what situations may this not work?
         var rendererrorMod = execRt.modules["builtin://render-error-display"];
@@ -287,21 +279,13 @@
             });
           }
 
-          if (execRt.bounceAllowed) {
-            restarter.resume(resultObj);
-          } else {
-            return resultObj;
-          }
+          return restarter.resumeOrReturn(resultObj);
         };
 
         return execRt.runThunk(renderFn, thenFn);
       };
 
-      if (execRt.bounceAllowed) {
-        return runtime.pauseStack(pauseStackFn);
-      } else {
-        return pauseStackFn();
-      }
+      return runtime.maybePauseStack(pauseFn);
     }
     function getModuleResultAnswer(mr) {
       checkSuccess(mr, "answer");
@@ -388,21 +372,13 @@
             retVal = makeModuleResult(otherRuntime, finalResult, makeRealm(realm), runtime.nothing);
           }
 
-          if (runtime.bounceAllowed) {
-            restarter.resume(retVal);
-          } else {
-            return retVal;
-          }
+          return restarter.resumeOrReturn(retVal);
         };
 
         return otherRuntime.runThunk(thunk, then);
       };
 
-      if (runtime.bounceAllowed) {
-        return runtime.pauseStack(pauseFunction);
-      } else {
-        return pauseFunction();
-      }
+      return runtime.maybePauseStack(pauseFunction);
     }
     var vals = {
       "run-program": runtime.makeFunction(runProgram, "run-program"),

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -194,7 +194,6 @@
         };
         var getStackP = execRt.makeFunction(getStack, "get-stack");
         var checks = getModuleResultChecks(mr);
-        //      <<<<<<< b7f9c9016754ed2a86e852980708822e67ff1fed
         var thunk = function() { return toCall.app(checks, getStackP); };
         var thenFn = function(renderedCheckResults) {
           var resumeWith = {

--- a/src/js/trove/make-standalone.js
+++ b/src/js/trove/make-standalone.js
@@ -16,8 +16,8 @@
       returns: The string produced by resolving dependencies with requirejs
 
     */
-    function makeStandalone(deps, body, configJSON, standaloneFile) {
-      runtime.checkArity(4, arguments, ["make-standalone"]);
+    function makeStandalone(deps, body, configJSON, standaloneFile, callback) {
+      runtime.checkArity(5, arguments, ["make-standalone"]);
       runtime.checkList(deps);
       runtime.checkString(configJSON);
 
@@ -67,36 +67,33 @@
         });
       }
       else {
-        return runtime.pauseStack(function(restarter) {
-          requirejs.optimize(config, function(result) {
-            var programWithDeps = fs.readFileSync(config.out, {encoding: 'utf8'});
-            // Browser/node check based on window below
-            fs.open(realOut, "w", function(err, outFile) {
-              if (err) throw err;
-              fs.writeSync(outFile, "if(typeof window === 'undefined') {\n");
-              fs.writeSync(outFile, "var requirejs = require(\"requirejs\");\n");
-              fs.writeSync(outFile, "var define = requirejs.define;\n}\n");
-              fs.writeSync(outFile, programWithDeps);
-              fs.writeSync(outFile, "define(\"program\", " + depsLine + ", function() {\nreturn ");
-              var writeRealOut = function(str) { 
-                fs.writeSync(outFile, str, {encoding: 'utf8'}); 
-                return runtime.nothing; 
-              };
-              runtime.runThunk(function() { 
-                return runtime.getField(body, "print-ugly-source").app(runtime.makeFunction(writeRealOut, "write-real-out"));
-              }, function(_) {
-                fs.writeSync(outFile, "\n});\n");
-                fs.writeSync(outFile, handalone);
-                fs.fsyncSync(outFile);
-                fs.closeSync(outFile);
-                restarter.resume(true);
-              });
-            });
-          }, function(err) {
-            console.error("Error while using requirejs optimizer: ", err); 
-            restarter.error(runtime.ffi.makeMessageException("Error while using requirejs optimizer: ", String(err)));
+        requirejs.optimize(config, function(result) {
+          var programWithDeps = fs.readFileSync(config.out, {encoding: 'utf8'});
+          // Browser/node check based on window below
+          fs.open(realOut, "w", function(err, outFile) {
+            if (err) throw err;
+            fs.writeSync(outFile, "if(typeof window === 'undefined') {\n");
+            fs.writeSync(outFile, "var requirejs = require(\"requirejs\");\n");
+            fs.writeSync(outFile, "var define = requirejs.define;\n}\n");
+            fs.writeSync(outFile, programWithDeps);
+            fs.writeSync(outFile, "define(\"program\", " + depsLine + ", function() {\nreturn ");
+            var writeRealOut = function(str) { 
+              fs.writeSync(outFile, str, {encoding: 'utf8'}); 
+              return runtime.nothing; 
+            };
+            runtime.getField(body, "print-ugly-source").app(runtime.makeFunction(writeRealOut, "write-real-out"));
+            fs.writeSync(outFile, "\n});\n");
+            fs.writeSync(outFile, handalone);
+            fs.fsyncSync(outFile);
+            fs.closeSync(outFile);
+            callback.app(runtime.makeNothing());
           });
+        }, function(err) {
+          console.error("Error while using requirejs optimizer: ", err); 
+          callback(runtime.ffi.makeMessageException("Error while using requirejs optimizer: ", String(err)));
         });
+
+        return runtime.makeNothing();
       }
     }
     return runtime.makeModuleReturn({

--- a/src/js/trove/runtime-lib.js
+++ b/src/js/trove/runtime-lib.js
@@ -16,7 +16,8 @@
       return applyBrand(brandRuntime, runtime.makeObject({
         "runtime": runtime.makeOpaque(runtimeLib.makeRuntime({
           stdout: runtime.stdout,
-          stderr: runtime.stderr
+          stderr: runtime.stderr,
+          parentRuntime: runtime
         }))
       }));
     }

--- a/tests/pyret/tests/test-errors.arr
+++ b/tests/pyret/tests/test-errors.arr
@@ -98,18 +98,14 @@ check:
 #    e5.typ is "Number"
 
   e10 = get-err(lam(): 5() end)
-  e10 satisfies E.is-RuntimeError
-  # TODO: Test should only be relaxed in unsafe mode
-  #e10 satisfies E.is-non-function-app
+  e10 satisfies E.is-non-function-app
   when E.is-non-function-app(e10) block:
     e10.non-fun-val is 5
     e10.loc satisfies S.is-srcloc
   end
 
   e11 = get-err(lam(): 5(6, 7 + 8) end)
-  e11 satisfies E.is-RuntimeError
-  # TODO: Test should only be relaxed in unsafe mode
-  #e11 satisfies E.is-non-function-app
+  e11 satisfies E.is-non-function-app
   when E.is-non-function-app(e11) block:
     e11.non-fun-val is 5
     e11.loc satisfies S.is-srcloc

--- a/tests/pyret/tests/test-errors.arr
+++ b/tests/pyret/tests/test-errors.arr
@@ -98,14 +98,18 @@ check:
 #    e5.typ is "Number"
 
   e10 = get-err(lam(): 5() end)
-  e10 satisfies E.is-non-function-app
+  e10 satisfies E.is-RuntimeError
+  # TODO: Test should only be relaxed in unsafe mode
+  #e10 satisfies E.is-non-function-app
   when E.is-non-function-app(e10) block:
     e10.non-fun-val is 5
     e10.loc satisfies S.is-srcloc
   end
 
   e11 = get-err(lam(): 5(6, 7 + 8) end)
-  e11 satisfies E.is-non-function-app
+  e11 satisfies E.is-RuntimeError
+  # TODO: Test should only be relaxed in unsafe mode
+  #e11 satisfies E.is-non-function-app
   when E.is-non-function-app(e11) block:
     e11.non-fun-val is 5
     e11.loc satisfies S.is-srcloc


### PR DESCRIPTION
Rebased fast-mode onto sourcemaps.

Most changes from fast-mode are the same, except we're no longer forced to relax tests in test-errors.arr. See discussion at #1020. There were quite a few changes from merge conflicts but the tests seem to pass still.