### PR TITLE
string-to-number arg, if roughnum, should be well-formed

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -1928,7 +1928,7 @@ define(function() {
   var flonumRegexp = new RegExp("^([-+]?)(\\d+\)((?:\\.\\d*)?)((?:[Ee][-+]?\\d+)?)$");
 
 
-  var roughnumDecRegexp = new RegExp("^~([-+]?\\d*(?:\\.\\d*)?(?:[Ee][-+]?\\d+)?)$");
+  var roughnumDecRegexp = new RegExp("^~([-+]?\\d+(?:\\.\\d+)?(?:[Ee][-+]?\\d+)?)$");
 
   var roughnumRatRegexp = new RegExp("^~([+-]?\\d+)/(\\d+)$");
 


### PR DESCRIPTION
Fix for #708. `string-to-number` of `~.1`, `~`, `~.`, `~-` should all return `none`.