### PR TITLE
Calling a method on by itself error message fix

### DIFF
--- a/src/arr/compiler/js-of-pyret.arr
+++ b/src/arr/compiler/js-of-pyret.arr
@@ -236,7 +236,7 @@ fun make-expr-flatness-env(
     | a-type-let(_, bind, body) =>
       make-expr-flatness-env(body, sd)
     | a-let(_, bind, val, body) =>
-      val-flatness = if AA.is-a-lam(val) or AA.is-a-method(val) block:
+      val-flatness = if AA.is-a-lam(val) block:
         lam-flatness = make-expr-flatness-env(val.body, sd)
         sd.set-now(bind.id.key(), lam-flatness)
         # flatness of defining this lambda is 0, since we're not actually

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -962,7 +962,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     }
     /* Not stack-safe */
     function setRef(ref, value) {
-      if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["ref-set"], 1, $a); }
+      if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["ref-set"], 2, $a); }
       if(ref.state === UNGRAPHABLE || ref.state === SET) {
         return checkAnn(["references"], ref.anns, value, function(_) {
           ref.value = value;

--- a/tests/pyret/tests/test-errors.arr
+++ b/tests/pyret/tests/test-errors.arr
@@ -125,6 +125,14 @@ check:
     e-non-ctor-app2.loc satisfies S.is-srcloc
   end
 
+  some-method = method(x): x end
+  e-method-app = get-err(lam(): some-method() end)
+  e-method-app satisfies E.is-non-function-app
+  when E.is-non-function-app(e-method-app) block:
+    tostring(e-method-app.non-fun-val) is "<function>"
+    e-method-app.loc satisfies S.is-srcloc
+  end
+
   e12 = get-err(lam(): num-tostring("two", "arguments") end)
   e12 satisfies E.is-arity-mismatch
   when E.is-arity-mismatch(e12) block:


### PR DESCRIPTION
The program:

```
m = method(x): x end
m()
```

Should now produce a reasonable Pyret error message (rather than giving a JS stacktrace).