### PR TITLE
Lift case dispatch object to the top level

### DIFF
--- a/src/arr/compiler/concat-lists.arr
+++ b/src/arr/compiler/concat-lists.arr
@@ -115,7 +115,8 @@ sharing:
   end,
   method to-list(self): self.to-list-acc(empty) end,
   method map-to-list-left(self, f): revmap-to-list-acc(self, f, empty).reverse() end,
-  method map-to-list(self, f): self.map-to-list-acc(f, empty) end
+  method map-to-list(self, f): self.map-to-list-acc(f, empty) end,
+  method find(self, f): find(f, self) end
 where:
   ce = concat-empty
   co = concat-singleton
@@ -152,6 +153,30 @@ fun revmap-to-list-acc(self, f, revhead):
   else if is-concat-snoc(self):
     newhead = revmap-to-list-acc(self.head, f, revhead)
     link(f(self.last), newhead) # order of operations matters
+  end
+end
+
+rec shadow find = lam<a>(f :: (a -> Boolean), l :: ConcatList<a>) -> Option<a>:
+  doc: "Takes a predicate and returns on option containing either the first item in this list that passes the predicate, or none"
+
+  cases (ConcatList) l:
+    | concat-empty => none
+    | concat-singleton(e) => if f(e): some(e) else: none end
+    | concat-append(l1, l2) =>
+      result-left = find(f, l1)
+      if is-none(result-left):
+        find(f, l2)
+      else:
+        result-left
+      end
+    | concat-cons(e, r) => if f(e): some(e) else: find(f, r) end
+    | concat-snoc(r, e) =>
+      result-left = find(f, r)
+      if is-none(result-left):
+        if f(e): some(e) else: none end
+      else:
+        result-left
+      end
   end
 end
 

--- a/src/arr/compiler/js-dag-utils.arr
+++ b/src/arr/compiler/js-dag-utils.arr
@@ -94,7 +94,7 @@ fun-decl-vars :: D.MutableStringDict<NameSet> = D.make-mutable-string-dict()
 fun-used-vars :: D.MutableStringDict<NameSet> = D.make-mutable-string-dict()
 var from-hit = 0
 var from-miss = 0
-  
+
 fun used-vars-jblock(b :: J.JBlock, so-far :: NameSet) -> NameSet block:
   cases(J.JBlock) b block:
     | j-block1(s) => used-vars-jstmt(s, so-far)
@@ -121,11 +121,11 @@ fun declared-vars-jstmt(s :: J.JStmt, so-far :: NameSet) -> NameSet:
       so-far.set-now(name.key(), name)
       so-far
     | j-if1(cond, consq) => declared-vars-jblock(consq, so-far)
-    | j-if(cond, consq, alt) => 
+    | j-if(cond, consq, alt) =>
       shadow so-far = declared-vars-jblock(consq, so-far)
       declared-vars-jblock(alt, so-far)
     | j-return(expr) => so-far
-    | j-try-catch(body, exn, catch) => 
+    | j-try-catch(body, exn, catch) =>
       shadow so-far = declared-vars-jblock(body, so-far)
       declared-vars-jblock(catch, so-far)
     | j-throw(exp) => so-far
@@ -149,11 +149,11 @@ fun declared-vars-jstmt(s :: J.JStmt, so-far :: NameSet) -> NameSet:
 end
 fun used-vars-jstmt(s :: J.JStmt, so-far :: NameSet) -> NameSet:
   cases(J.JStmt) s block:
-    | j-var(name, rhs) => 
+    | j-var(name, rhs) =>
       shadow so-far = used-vars-jexpr(rhs, so-far)
       so-far.remove-now(name.key())
       so-far
-    | j-if1(cond, consq) => 
+    | j-if1(cond, consq) =>
       shadow so-far = used-vars-jexpr(cond, so-far)
       used-vars-jblock(consq, so-far)
     | j-if(cond, consq, alt) =>
@@ -194,7 +194,7 @@ fun used-vars-jexpr(e :: J.JExpr, so-far :: NameSet) -> NameSet:
     | j-sourcenode(_, _, expr) => used-vars-jexpr(expr, so-far)
     | j-parens(exp) => used-vars-jexpr(exp, so-far)
     | j-unop(exp, op) => used-vars-jexpr(exp, so-far)
-    | j-binop(left, op, right) => 
+    | j-binop(left, op, right) =>
       shadow so-far = used-vars-jexpr(left, so-far)
       used-vars-jexpr(right, so-far)
     | j-fun(id, _, args, body) =>
@@ -250,7 +250,7 @@ fun used-vars-jexpr(e :: J.JExpr, so-far :: NameSet) -> NameSet:
       shadow so-far = used-vars-jexpr(test, so-far)
       shadow so-far = used-vars-jexpr(consq, so-far)
       used-vars-jexpr(altern, so-far)
-    | j-assign(name, rhs) => 
+    | j-assign(name, rhs) =>
       shadow so-far = used-vars-jexpr(rhs, so-far)
       so-far.set-now(name.key(), name)
       so-far
@@ -262,7 +262,7 @@ fun used-vars-jexpr(e :: J.JExpr, so-far :: NameSet) -> NameSet:
       shadow so-far = used-vars-jexpr(obj, so-far)
       used-vars-jexpr(rhs, so-far)
     | j-dot(obj, field) => used-vars-jexpr(obj, so-far)
-    | j-bracket(obj, field) => 
+    | j-bracket(obj, field) =>
       shadow so-far = used-vars-jexpr(obj, so-far)
       used-vars-jexpr(field, so-far)
     | j-list(_, elts) =>
@@ -296,7 +296,7 @@ fun declared-vars-jcase(c :: J.JCase, so-far :: NameSet) -> NameSet:
 end
 fun used-vars-jcase(c :: J.JCase, so-far :: NameSet) -> NameSet:
   cases(J.JCase) c block:
-    | j-case(exp, body) => 
+    | j-case(exp, body) =>
       shadow so-far = used-vars-jexpr(exp, so-far)
       used-vars-jblock(body, so-far)
     | j-default(body) => used-vars-jblock(body, so-far)
@@ -339,25 +339,16 @@ fun stmts-of(blk :: J.JBlock):
   end
 end
 
-fun find-steps-to(stmts :: ConcatList<J.JStmt>, step :: A.Name, acc :: D.MutableStringDict<J.Label>) -> D.MutableStringDict<J.Label>:
+fun find-steps-to(stmts :: ConcatList<J.JStmt>, step :: A.Name, acc :: D.MutableStringDict<J.Label>, cases-dispatches :: ConcatList<J.JStmt>) -> D.MutableStringDict<J.Label>:
   var looking-for = none
   for CL.foldr(shadow acc from acc, stmt from stmts):
     cases(J.JStmt) stmt:
-      | j-var(name, rhs) =>
-        if is-some(looking-for) and (looking-for.value == name) block:
-          looking-for := none
-          for CL.foldl(shadow acc from acc, field from rhs.fields) block:
-            acc.set-now(tostring(field.value.label.get()), field.value.label)
-            acc
-          end
-        else:
-          acc
-        end
-      | j-if1(cond, consq) => find-steps-to(stmts-of(consq), step, acc)
+      | j-var(name, rhs) => acc
+      | j-if1(cond, consq) => find-steps-to(stmts-of(consq), step, acc, cases-dispatches)
       | j-if(cond, consq, alt) =>
         acc
-          ^ find-steps-to(stmts-of(consq), step, _)
-          ^ find-steps-to(stmts-of(alt), step, _)
+          ^ find-steps-to(stmts-of(consq), step, _, cases-dispatches)
+          ^ find-steps-to(stmts-of(alt), step, _, cases-dispatches)
       | j-return(expr) => acc
       | j-try-catch(body, exn, catch) => acc # ignoring for now, because we know we don't use these
       | j-throw(exp) => acc
@@ -370,8 +361,12 @@ fun find-steps-to(stmts :: ConcatList<J.JStmt>, step :: A.Name, acc :: D.Mutable
           else if J.is-j-binop(expr.rhs) and (expr.rhs.op == J.j-or):
             # $step gets a cases dispatch
             # ASSUMES that the dispatch table is assigned two statements before this one
-            looking-for := some(expr.rhs.left.obj.id)
             acc.set-now(tostring(expr.rhs.right.label.get()), expr.rhs.right.label)
+            now-looking = cases-dispatches.find({(elt :: J.JStmt): elt.name == expr.rhs.left.obj.id}).value.rhs
+            for CL.foldl(shadow acc from acc, field from now-looking.fields) block:
+              acc.set-now(tostring(field.value.label.get()), field.value.label)
+              acc
+            end
             acc
           else if J.is-j-num(expr.rhs):
             acc
@@ -498,7 +493,7 @@ var step-4-total = 0
 #   ranges
 # end
 
-fun simplify(add-phase, body-cases :: ConcatList<J.JCase>, step :: A.Name) -> RegisterAllocation block:
+fun simplify(add-phase, body-cases :: ConcatList<J.JCase>, step :: A.Name, cases-dispatches :: ConcatList<J.JStmt>) -> RegisterAllocation block:
   start = time-now()
   from-hit := 0
   from-miss := 0
@@ -510,8 +505,8 @@ fun simplify(add-phase, body-cases :: ConcatList<J.JCase>, step :: A.Name) -> Re
       acc-dag.set-now(label,
         node(label,
           cases(J.JBlock) body-case.body:
-            | j-block1(s) => find-steps-to(cl-sing(s), step, ns-empty())
-            | j-block(stmts) => find-steps-to(stmts, step, ns-empty())
+            | j-block1(s) => find-steps-to(cl-sing(s), step, ns-empty(), cases-dispatches)
+            | j-block(stmts) => find-steps-to(stmts, step, ns-empty(), cases-dispatches)
           end, body-case,
           ns-empty(), ns-empty(), ns-empty(), none, none, none, none))
     end

--- a/src/arr/compiler/js-dag-utils.arr
+++ b/src/arr/compiler/js-dag-utils.arr
@@ -340,7 +340,6 @@ fun stmts-of(blk :: J.JBlock):
 end
 
 fun find-steps-to(stmts :: ConcatList<J.JStmt>, step :: A.Name, acc :: D.MutableStringDict<J.Label>, cases-dispatches :: ConcatList<J.JStmt>) -> D.MutableStringDict<J.Label>:
-  var looking-for = none
   for CL.foldr(shadow acc from acc, stmt from stmts):
     cases(J.JStmt) stmt:
       | j-var(name, rhs) => acc
@@ -360,7 +359,8 @@ fun find-steps-to(stmts :: ConcatList<J.JStmt>, step :: A.Name, acc :: D.Mutable
             acc
           else if J.is-j-binop(expr.rhs) and (expr.rhs.op == J.j-or):
             # $step gets a cases dispatch
-            # ASSUMES that the dispatch table is assigned two statements before this one
+            # ASSUMES that the dispatch table is assigned before toplevel is defined.
+            # (see cases-dispatches in anf-loop-compiler.arr)
             acc.set-now(tostring(expr.rhs.right.label.get()), expr.rhs.right.label)
             now-looking = cases-dispatches.find({(elt :: J.JStmt): elt.name == expr.rhs.left.obj.id}).value.rhs
             for CL.foldl(shadow acc from acc, field from now-looking.fields) block:


### PR DESCRIPTION
For example:

```
data Test:
  | test-a(x)
  | test-b(x)
end

cases (Test) test-a(123):
  | test-a(x) => x + 5
  | test-b(x) => x - 5
end ^ print
```

Prior this PR, this compiles to:

```
var $toplevel28 =
  function($$resumer34) {
    var $step27 = 0;
    ...
    while(!R.isContinuation($ans30)) {
      switch($step27) {
      case 0:
        ...
      case 1:
        var $cases_dispatch76 = { "test-a": 2, "test-b": 3 };
        $al31 = L[9];
        $step27 = $cases_dispatch76[cases62.$name] || 4;
        break;
      case 2:
        ...
      case 3:
        ...
      case 4:
        ...
      case 5:
        ...
      case 6:
        ...
      case 7:
        ...
      case 8:
        ...
      case 9:
      ...
    case 10:
      ...
    default: R.ffi.throwSpinnakerError(L[13], $step27);
    }
  }
  ...
  return $ans30;
};
```

With this PR, it compiles to:

```
var $cases_dispatch76 = { "test-a": 2, "test-b": 3 };
var $toplevel28 =
  function($$resumer34) {
    var $step27 = 0;
    ...
    while(!R.isContinuation($ans30)) {
      switch($step27) {
      case 0:
        ...
      case 1:
        $al31 = L[9];
        $step27 = $cases_dispatch76[cases62.$name] || 4;
        break;
      case 2:
        ...
      case 3:
        ...
      case 4:
        ...
      case 5:
        ...
      case 6:
        ...
      case 7:
        ...
      case 8:
        ...
      case 9:
      ...
    case 10:
      ...
    default: R.ffi.throwSpinnakerError(L[13], $step27);
    }
  }
  ...
  return $ans30;
};
```

The sole purpose of doing this is to avoid case dispatch object allocation,
especially in recursive functions.

This transformation preserves the semantics of the program because the case
dispatch objects do not refer to any other variable, and all identifiers
associated with case dispatch objects are fresh (so it's impossible to
get accidentally captured).