### PR TITLE
roughnum fractions recognized, except for 0 denominator

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -2034,7 +2034,8 @@ define("pyret-base/js/js-numbers", function() {
 
     aMatch = x.match(roughnumRatRegexp);
     if (aMatch) {
-      return Rational.makeInstance(fromString(aMatch[1]), fromString(aMatch[2])).toRoughnum();
+      return toRoughnum(Rational.makeInstance(fromString(aMatch[1]), fromString(aMatch[2])),
+        errbacks);
     }
 
     aMatch = x.match(roughnumDecRegexp);

--- a/src/js/base/pyret-tokenizer.js
+++ b/src/js/base/pyret-tokenizer.js
@@ -121,9 +121,11 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
 
   const badNumber = new RegExp("^~?[+-]?\\.[0-9]+(?:[eE][-+]?[0-9]+)?", STICKY_REGEXP);
 
-  const roughnum = new RegExp("^~[-+]?"  + "(?:" + unsigned_rational_part + "|" + unsigned_decimal_part + ")", STICKY_REGEXP);
+  const roughnum = new RegExp("^~[-+]?"  + unsigned_decimal_part, STICKY_REGEXP);
 
   const rational = new RegExp("^[-+]?" + unsigned_rational_part, STICKY_REGEXP);
+
+  const roughrational = new RegExp("^~[-+]?" + unsigned_rational_part, STICKY_REGEXP);
 
   const parenparen = new RegExp("^\\((?=\\()", STICKY_REGEXP); // NOTE: Don't include the following paren
   const spaceparen = new RegExp("^\\s+\\(", STICKY_REGEXP);
@@ -295,6 +297,7 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
     {name: "BAR", val: bar, parenIsForExp: true},
 
     {name: "RATIONAL", val: rational},
+    {name: "RATIONAL", val: roughrational},
     {name: "NUMBER", val: number},
     {name: "NUMBER", val: roughnum},
     {name: "LONG_STRING", val: tquot_str},

--- a/tests/evaluator/well-formed.js
+++ b/tests/evaluator/well-formed.js
@@ -315,6 +315,10 @@ define(["js/runtime-anf", "./eval-matchers"], function(rtLib, e) {
         P.checkCompileErrorMsg("100/0", err);
         P.checkCompileErrorMsg("0/0", err);
         P.checkCompileErrorMsg("0/00000", err);
+        P.checkCompileErrorMsg("~1/0", err);
+        P.checkCompileErrorMsg("~100/0", err);
+        P.checkCompileErrorMsg("~0/0", err);
+        P.checkCompileErrorMsg("~0/00000", err);
         P.wait(done);
       });
       xit("special imports", function(done) {

--- a/tests/pyret/tests/test-numbers.arr
+++ b/tests/pyret/tests/test-numbers.arr
@@ -276,3 +276,12 @@ check "floor/ceiling/round of bigrats":
   num-ceiling(+123123123123123123123123124.5) is 123123123123123123123123125
   num-ceiling(-123123123123123123123123124.5) is -123123123123123123123123124
 end
+
+check "rough fractions -- proper, improper, integral -- recognized, provided denr != 0":
+  num-is-roughnum(~1/2) is true
+  ~1/2 is%(within(0.01)) ~0.5
+  num-is-roughnum(~3/2) is true
+  ~3/2 is%(within(0.01)) ~1.5
+  num-is-roughnum(~10/2) is true
+  ~10/2 is%(within(0.1)) ~5
+end

--- a/tests/pyret/tests/test-numbers.arr
+++ b/tests/pyret/tests/test-numbers.arr
@@ -284,4 +284,18 @@ check "rough fractions -- proper, improper, integral -- recognized, provided den
   ~3/2 is%(within(0.01)) ~1.5
   num-is-roughnum(~10/2) is true
   ~10/2 is%(within(0.1)) ~5
+  #
+  num-is-roughnum(~+1/2) is true
+  ~+1/2 is%(within(0.01)) ~+0.5
+  num-is-roughnum(~+3/2) is true
+  ~+3/2 is%(within(0.01)) ~+1.5
+  num-is-roughnum(~+10/2) is true
+  ~+10/2 is%(within(0.1)) ~+5
+  #
+  num-is-roughnum(~-1/2) is true
+  ~-1/2 is%(within(0.01)) ~-0.5
+  num-is-roughnum(~-3/2) is true
+  ~-3/2 is%(within(0.01)) ~-1.5
+  num-is-roughnum(~-10/2) is true
+  ~-10/2 is%(within(0.1)) ~-5
 end


### PR DESCRIPTION
This supersedes PR #1047 (replacing parsing error with well-formedness error). Fixes issue #1046.

- Well-formed "rough rationals", `~p/q` are recognized correctly, whether they reduce to integers, or proper or improper fractions. Test in `test-numbers.js`.

- Denominator zero in `~p/q` triggers a well-formedness-error. Test in `well-formed.js`.