### PR TITLE
[Emacs] Autoload pyret-mode on .arr files.

### DIFF
--- a/tools/emacs/pyret.el
+++ b/tools/emacs/pyret.el
@@ -1832,6 +1832,8 @@ in (nil if we're not in a string).")
 
 ;; Automatically enable pyret-mode on .arr files.
 (add-to-list 'auto-mode-alist '("\\.arr\\'" . pyret-mode))
+;; Pyret files are UTF-8.
+(add-to-list 'file-coding-system-alist '("\\.arr\\'" . utf-8-unix))
 
 (provide 'pyret)
 

--- a/tools/emacs/pyret.el
+++ b/tools/emacs/pyret.el
@@ -1830,5 +1830,8 @@ in (nil if we're not in a string).")
 
 (add-hook 'pyret-mode-startup-hook 'pyret-smartparens-setup)
 
+;; Automatically enable pyret-mode on .arr files.
+(add-to-list 'auto-mode-alist '("\\.arr\\'" . pyret-mode))
+
 (provide 'pyret)
 


### PR DESCRIPTION
Added autoloading of pyret-mode to .arr files to the emacs mode. It's a small change, but is convenient.