### PR TITLE
string-to-number: valid number with decimal point must have digit after point

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -2013,7 +2013,7 @@ define("pyret-base/js/js-numbers", function() {
 
   var rationalRegexp = new RegExp("^([+-]?\\d+)/(\\d+)$");
   var digitRegexp = new RegExp("^[+-]?\\d+$");
-  var flonumRegexp = new RegExp("^([-+]?)(\\d+\)((?:\\.\\d*)?)((?:[Ee][-+]?\\d+)?)$");
+  var flonumRegexp = new RegExp("^([-+]?)(\\d+\)((?:\\.\\d+)?)((?:[Ee][-+]?\\d+)?)$");
 
 
   var roughnumDecRegexp = new RegExp("^~([-+]?\\d+(?:\\.\\d+)?(?:[Ee][-+]?\\d+)?)$");

--- a/tests/pyret/tests/test-s-exp.arr
+++ b/tests/pyret/tests/test-s-exp.arr
@@ -50,7 +50,7 @@ check:
 
   p("-5") is s-num(-5)
   p("-4.4") is s-num(-4.4)
-  p("-3.") is s-num(-3.0)
+  p("-3.0") is s-num(-3.0)
   # Make sure bignums parse correctly
   p(num-tostring(num-expt(100, 100))) is
     s-num(num-expt(100, 100))


### PR DESCRIPTION
Fix for #708.  (This is for non-rough numbers with decimal point. A test in `test-s-exp.arr` expected `"-3."` to parse as `-3`. Changed it.)