### PR TITLE
fix #1230

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -919,15 +919,18 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-def
               j-expr(j-dot-assign(RUNTIME, "EXN_STACKHEIGHT", j-num(0))),
               j-expr(j-assign(ans, rt-method("makeCont", cl-empty)))]))] +
         CL.map_list2(
-          lam(compiled-arg, arg): j-expr(j-assign(arg, compiled-arg)) end,
+          lam(compiled-arg, arg): j-expr(j-assign(compiler-name(arg.toname()), compiled-arg)) end,
           compiled-args.to-list(),
+          compiler.args) +
+        CL.map_list(
+          lam(arg): j-expr(j-assign(arg, j-id(compiler-name(arg.toname())))) end,
           compiler.args) +
         # CL.map_list2(
         #   lam(compiled-arg, arg):
         #     console-log([clist: j-str(tostring(arg)), j-id(arg)])
         #   end,
         #   compiled-args.to-list(),
-        #   compiler.args),
+        #   compiler.args) +
         cl-sing(j-continue)),
       new-cases)
   else:

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -937,7 +937,7 @@ fun get-assignments(lst :: List<J.JExpr>, limit :: Number) -> {List<J.JExpr>; Li
           if limit == 0:
             tmp-arg = fresh-id(compiler-name('tmp_asgn'))
             {pre; post} = get-assignments(rest, rest.length())
-            {link(j-assign(tmp-arg, actual), pre); link(j-assign(formal, j-id(tmp-arg)), post)}
+            {link(j-var(tmp-arg, actual), pre); link(j-assign(formal, j-id(tmp-arg)), post)}
           else:
             occurs-any = for any(next-asgn :: J.JExpr%(is-j-assign) from rest):
               is-id-occurs(formal, next-asgn.rhs)

--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -100,6 +100,7 @@ j-continue = J.j-continue
 j-while = J.j-while
 j-for = J.j-for
 j-raw-code = J.j-raw-code
+is-j-assign = J.is-j-assign
 make-label-sequence = J.make-label-sequence
 
 fun console-log(lst :: CL.ConcatList) -> J.JStmt:
@@ -909,9 +910,7 @@ fun is-id-occurs(target :: A.Name, e :: J.JExpr) block:
   found
 end
 
-type Asgn = {A.Name; J.JExpr}
-
-fun get-assignments(lst :: List<Asgn>, limit :: Number) -> {List<Asgn>; List<Asgn>}:
+fun get-assignments(lst :: List<J.JExpr>, limit :: Number) -> {List<J.JExpr>; List<J.JExpr>}:
   doc: ```
        Find an order of assignment statements in `lst` that avoid new variables
        where `limit` is the number of round-robin attempts allowed.
@@ -919,31 +918,37 @@ fun get-assignments(lst :: List<Asgn>, limit :: Number) -> {List<Asgn>; List<Asg
        When the dependency graph is acyclic, this algorithm degenerates to
        finding a topological order.
 
-       If the RHS of assignment statements have at most one one identifier,
+       If the RHS of assignment statements have at most one identifier,
        it's possible that the corresponding dependency graph will have cycles,
        but there can be at most one cycle per connected component. Thus, this
        algorithm degenerates to finding topological order at most twice per
        component (one for ordering non-cycle parts, then we break the cycle
-       and then another one is for the ordering the rest). It guarantees that
+       and then another one for the ordering the rest). It guarantees that
        it will reach limit = 0 at most once per each component.
 
-       The output is a pair of `pre` and `post` where they are lists of
+       The output is a pair of `pre` and `post` which are lists of
        assignments. The order of `post` doesn't matter.
        ```
   cases (List) lst:
     | empty => {empty; empty}
-    | link({formal; actual}, rest) =>
-      if limit == 0:
-        tmp-arg = fresh-id(compiler-name('tmp_asgn'))
-        {pre; post} = get-assignments(rest, rest.length())
-        {link({tmp-arg; actual}, pre); link({formal; j-id(tmp-arg)}, post)}
-      else:
-        if for any({_; e} from rest): is-id-occurs(formal, e) end:
-          get-assignments(rest + [list: {formal; actual}], limit - 1)
-        else:
-          {pre; post} = get-assignments(rest, rest.length())
-          {link({formal; actual}, pre); post}
-        end
+    | link(asgn, rest) =>
+      cases (J.JExpr) asgn:
+        | j-assign(formal, actual) =>
+          if limit == 0:
+            tmp-arg = fresh-id(compiler-name('tmp_asgn'))
+            {pre; post} = get-assignments(rest, rest.length())
+            {link(j-assign(tmp-arg, actual), pre); link(j-assign(formal, j-id(tmp-arg)), post)}
+          else:
+            occurs-any = for any(next-asgn :: J.JExpr%(is-j-assign) from rest):
+              is-id-occurs(formal, next-asgn.rhs)
+            end
+            if occurs-any:
+              get-assignments(rest + [list: asgn], limit - 1)
+            else:
+              {pre; post} = get-assignments(rest, rest.length())
+              {link(asgn, pre); post}
+            end
+          end
       end
   end
 end
@@ -960,9 +965,7 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-def
      compiler.options.proper-tail-calls and
      (compiled-args.length() == compiler.args.length()):
      # if it's an arity mismatch, use non-TCO to handle the error
-    args-list = for map2(formal from compiler.args, actual from compiled-args.to-list()):
-      {formal; actual}
-    end
+    args-list = map2(j-assign, compiler.args, compiled-args.to-list())
     {pre; post} = get-assignments(args-list, args-list.length())
     c-block(
       j-block(
@@ -975,7 +978,7 @@ fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-def
             j-block([clist:
               j-expr(j-dot-assign(RUNTIME, "EXN_STACKHEIGHT", j-num(0))),
               j-expr(j-assign(ans, rt-method("makeCont", cl-empty)))]))] +
-        CL.map_list({({name; e}): j-expr(j-assign(name, e))}, pre + post) +
+        CL.map_list(j-expr, pre + post) +
         # CL.map_list2(
         #   lam(compiled-arg, arg):
         #     console-log([clist: j-str(tostring(arg)), j-id(arg)])

--- a/tests/pyret/regression.arr
+++ b/tests/pyret/regression.arr
@@ -19,3 +19,4 @@ import file("./regression/proto-fields.arr") as _
 import file("./regression/toplevel-data.arr") as _
 import file("./regression/bogus-global-type-name.arr") as _
 import file("./regression/duplicate-check-block-report.arr") as _
+import file("./regression/tail-recursion-arg-order.arr") as _

--- a/tests/pyret/regression/tail-recursion-arg-order.arr
+++ b/tests/pyret/regression/tail-recursion-arg-order.arr
@@ -1,11 +1,10 @@
+# https://github.com/brownplt/pyret-lang/issues/1230
 fun iter(a, b, k):
   if k == 0:
     b
   else:
     iter(a + b, a, k - 1)
   end
-end
-
-check "https://github.com/brownplt/pyret-lang/issues/1230":
+where:
   iter(1, 0, 10) is 55
 end

--- a/tests/pyret/regression/tail-recursion-arg-order.arr
+++ b/tests/pyret/regression/tail-recursion-arg-order.arr
@@ -1,0 +1,11 @@
+fun iter(a, b, k):
+  if k == 0:
+    b
+  else:
+    iter(a + b, a, k - 1)
+  end
+end
+
+check "https://github.com/brownplt/pyret-lang/issues/1230":
+  iter(1, 0, 10) is 55
+end

--- a/tests/pyret/regression/tail-recursion-arg-order.arr
+++ b/tests/pyret/regression/tail-recursion-arg-order.arr
@@ -1,4 +1,5 @@
 # https://github.com/brownplt/pyret-lang/issues/1230
+
 fun iter(a, b, k):
   if k == 0:
     b
@@ -7,4 +8,15 @@ fun iter(a, b, k):
   end
 where:
   iter(1, 0, 10) is 55
+end
+
+fun oops(a, b):
+  if a == 1: b else: oops(1, a) end
+end
+fun working(a, b):
+  if a == 1: b else: working(1, a) + 0 end
+end
+
+examples:
+  oops(4, 5) is working(4, 5)
 end


### PR DESCRIPTION
Fix the bug by assigning the values to a temporary variable before assigning it again to the real variable, avoiding the dependency issue.

Note that the temporary variable `compiler-name(arg.toname())` is in scope at the beginning of the function, but is effectively useless (no more reference to the variable) at the point where we assign the value to the variable. That's why I decide to use it for as a temporary variable. But if anyone objects, I can also change it to other names.