### PR TITLE
Fixes #1233

### DIFF
--- a/src/arr/compiler/type-check.arr
+++ b/src/arr/compiler/type-check.arr
@@ -11,7 +11,6 @@ import file("ast-util.arr") as AU
 import file("type-structs.arr") as TS
 import file("type-check-structs.arr") as TCS
 import file("compile-structs.arr") as C
-import file("type-defaults.arr") as TD
 
 type Type = TS.Type
 type TypeMembers = TS.TypeMembers
@@ -2416,7 +2415,7 @@ fun synthesis-s-check-test(e :: Expr, loc :: Loc, op :: A.CheckOp, refinement ::
       | some(shadow right) =>
         synthesis(left, false, context).bind(lam(_, left-type, shadow context):
           synthesis(right, false, context).bind(lam(_, pred-type, shadow context):
-            shadow context = context.add-constraint(pred-type, t-arrow([list: TD.t-runtime-error], t-boolean(loc), l, false))
+            shadow context = context.add-constraint(pred-type, t-arrow([list: t-top(l, false)], t-boolean(loc), l, false))
             create-result(context)
           end)
         end)

--- a/tests/type-check/bad/test-is.arr
+++ b/tests/type-check/bad/test-is.arr
@@ -1,0 +1,5 @@
+fun func() -> Number:
+  0
+where:
+  func() is false
+end

--- a/tests/type-check/bad/test-raises.arr
+++ b/tests/type-check/bad/test-raises.arr
@@ -1,0 +1,5 @@
+fun func() -> Number:
+  0
+where:
+  func() raises 1
+end

--- a/tests/type-check/bad/test-refinement.arr
+++ b/tests/type-check/bad/test-refinement.arr
@@ -1,0 +1,5 @@
+fun func() -> Number:
+  0
+where:
+  func() is%({(x :: Number): false}) 0
+end

--- a/tests/type-check/good/tests.arr
+++ b/tests/type-check/good/tests.arr
@@ -1,0 +1,28 @@
+import is-field-not-found from error
+
+fun func() -> Number: 0
+where:
+  fun pred-fun(a :: Number, b :: Number):
+    a == 4
+  end
+
+  func() is 0
+  func() is-roughly 0.0000000000001
+  func() is-not 10
+  func() is%(pred-fun) 4
+  func() is-not%(pred-fun) 5
+  func() is== 0
+  func() is-not== 5
+  func() is=~ 0
+  func() is-not=~ 5
+  func() is<=> 0
+  func() is-not<=> 5
+  func() satisfies {(x): true}
+  func() violates {(x): false}
+  1 / 0 raises "zero"
+  1 / 0 raises-other-than "field"
+  func() does-not-raise
+  # o = {}
+  # o.x raises-satisfies is-field-not-found
+  # 1 / 0 raises-violates is-field-not-found
+end

--- a/tests/type-check/good/tests.arr
+++ b/tests/type-check/good/tests.arr
@@ -1,4 +1,4 @@
-import is-field-not-found from error
+import is-invalid-array-index from error
 
 fun func() -> Number: 0
 where:
@@ -22,7 +22,6 @@ where:
   1 / 0 raises "zero"
   1 / 0 raises-other-than "field"
   func() does-not-raise
-  # o = {}
-  # o.x raises-satisfies is-field-not-found
-  # 1 / 0 raises-violates is-field-not-found
+  raw-array-get([raw-array: 1, 2], 4) raises-satisfies is-invalid-array-index
+  1 / 0 raises-violates is-invalid-array-index
 end


### PR DESCRIPTION
Adds type-checker support for almost all of the test comparisons. Doesn't yet handle `s-op-raises-satisfies` or `s-op-raises-violates`.