### PR TITLE
Adding update and extend type support for data types

### DIFF
--- a/tests/type-check/bad/data-as-object-extend-missing.arr
+++ b/tests/type-check/bad/data-as-object-extend-missing.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{a: "a"}

--- a/tests/type-check/bad/data-as-object-extend-ref.arr
+++ b/tests/type-check/bad/data-as-object-extend-ref.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{c: "a"}

--- a/tests/type-check/bad/data-as-object-extend-wrong-type.arr
+++ b/tests/type-check/bad/data-as-object-extend-wrong-type.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{b: "b"}

--- a/tests/type-check/bad/data-as-object-update-missing.arr
+++ b/tests/type-check/bad/data-as-object-update-missing.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{b: 3}

--- a/tests/type-check/bad/data-as-object-update-non-ref.arr
+++ b/tests/type-check/bad/data-as-object-update-non-ref.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{c: 3}

--- a/tests/type-check/bad/data-as-object-update-wrong.arr
+++ b/tests/type-check/bad/data-as-object-update-wrong.arr
@@ -1,0 +1,5 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{b: 3}

--- a/tests/type-check/good/data-as-object.arr
+++ b/tests/type-check/good/data-as-object.arr
@@ -1,0 +1,6 @@
+data Foo:
+  | bar(a :: Number, ref b :: String)
+end
+
+bar(1, "a").{a: 3}
+bar(1, "b")!{b: "a"}


### PR DESCRIPTION
Allows extend and update syntax to be used on data types.
Errors if the fields do not occur in the data type, e.g.
```
data Foo:
  | bar(a :: Number)
end

bar(1).{b: 3}
```