### PR TITLE
Adding simple function-entry/function-exit profiling information

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -201,6 +201,8 @@ rt-name-map = [D.string-dict:
   "makeTupleAnn", "mTA",
   "makeVariantConstructor", "mVC",
   "namedBrander", "nB",
+  "profileEnter", "pEn",
+  "profileExit", "pEx",
   "traceEnter", "tEn",
   "traceErrExit", "tErEx",
   "traceExit", "tEx",
@@ -585,6 +587,11 @@ fun compile-fun-body(l :: Loc, step :: A.Name, fun-name :: A.Name, compiler, arg
         else:
           cl-sing(j-expr(j-unop(rt-field("GAS"), j-incr)))
         end +
+        if local-compiler.options.should-profile:
+          cl-sing(j-expr(rt-method("profileExit", [clist: local-compiler.get-loc(l)])))
+        else:
+          cl-empty
+        end +
         cl-sing(j-return(j-id(local-compiler.cur-ans))))))
   ^ cl-snoc(_, j-default(j-block1(
         j-expr(j-method(rt-field("ffi"), "throwSpinnakerError", [clist: local-compiler.get-loc(l), j-id(step)])))))
@@ -640,16 +647,22 @@ fun compile-fun-body(l :: Loc, step :: A.Name, fun-name :: A.Name, compiler, arg
   end
 
   is-activation-record-call = rt-method("isActivationRecord", [clist: j-id(first-arg)])
-  preamble-stmts = if is-flat:
-    first-entry-stmts
-  else:
-    if-check = if first-entry-stmts.is-empty():
-      j-if1(is-activation-record-call, restorer)
+  preamble-stmts =
+    if local-compiler.options.should-profile:
+      cl-sing(j-expr(rt-method("profileEnter", [clist: local-compiler.get-loc(l)])))
     else:
-      j-if(is-activation-record-call, restorer, j-block(first-entry-stmts))
+      cl-empty
+    end +
+    if is-flat:
+      first-entry-stmts
+    else:
+      if-check = if first-entry-stmts.is-empty():
+        j-if1(is-activation-record-call, restorer)
+      else:
+        j-if(is-activation-record-call, restorer, j-block(first-entry-stmts))
+      end
+      cl-sing(if-check)
     end
-    cl-sing(if-check)
-  end
 
   stack-attach-guard =
     if compiler.options.proper-tail-calls:
@@ -1092,7 +1105,7 @@ fun compile-cases-branch(compiler, compiled-val, branch :: N.ACasesBranch, cases
       j-list(false, cl-empty)
     end
     compiled-branch-fun =
-      compile-fun-body(branch.body.l, step, temp-branch, compiler.{allow-tco: false}, branch-args, none, branch.body, true, false, false)
+      compile-fun-body(branch.body.l, step, temp-branch, compiler.{allow-tco: false, options: compiler.options.{should-profile: false}}, branch-args, none, branch.body, true, false, false)
     preamble = cases-preamble(compiler, compiled-val, branch, cases-loc)
     deref-fields = j-expr(j-assign(compiler.cur-ans, j-method(compiled-val, "$app_fields", [clist: j-id(temp-branch), ref-binds-mask])))
     actual-app =

--- a/src/arr/compiler/cli-module-loader.arr
+++ b/src/arr/compiler/cli-module-loader.arr
@@ -368,6 +368,9 @@ fun build-program(path, options, stats) block:
   cached-modules = starter-modules.count-now()
   var num-compiled = cached-modules
   shadow options = options.{
+    method should-profile(_, locator):
+      options.add-profiling and (locator.uri() == base.locator.uri())
+    end,
     method before-compile(_, locator) block:
       num-compiled := num-compiled + 1
       clear-and-print("Compiling " + num-to-string(num-compiled) + "/" + num-to-string(total-modules)

--- a/src/arr/compiler/compile-lib.arr
+++ b/src/arr/compiler/compile-lib.arr
@@ -419,6 +419,7 @@ fun compile-module(locator :: Locator, provide-map :: SD.StringDict<CS.Provides>
               end
             desugared := nothing
             add-phase("Type Checked", type-checked)
+            shadow options = options.{should-profile: options.should-profile(locator)}
             cases(CS.CompileResult) type-checked block:
               | ok(_) =>
                 var tc-ast = type-checked.code

--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -2480,6 +2480,7 @@ default-compile-options = {
   module-eval: true,
   compiled-cache: "compiled",
   display-progress: true,
+  should-profile: method(_, locator): false end,
   log: lam(s, to-clear):
     cases(Option) to-clear block:
       | none => print(s)

--- a/src/arr/compiler/js-of-pyret.arr
+++ b/src/arr/compiler/js-of-pyret.arr
@@ -492,18 +492,3 @@ fun trace-make-compiled-pyret(add-phase, program-ast, env, bindings, provides, o
   compiled = anfed.visit(AL.splitting-compiler(env, add-phase, flatness-env, flat-provides, options))
   {flat-provides; add-phase("Generated JS", C.ok(ccp-dict(compiled)))}
 end
-
-fun println(s) block:
-  print(s + "\n")
-end
-
-fun make-compiled-pyret(program-ast, env, bindings, provides, options) -> { C.Provides; CompiledCodePrinter} block:
-#  each(println, program-ast.tosource().pretty(80))
-  anfed = N.anf-program(program-ast)
-  #each(println, anfed.tosource().pretty(80))
-  flatness-env = make-prog-flatness-env(anfed, bindings, env)
-  flat-provides = get-flat-provides(provides, flatness-env, anfed)
-  compiled = anfed.visit(AL.splitting-compiler(env, flatness-env, flat-provides, options))
-  {flat-provides; ccp-dict(compiled)}
-end
-

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -26,7 +26,7 @@ fun main(args :: List<String>) -> Number block:
     "serve",
       C.flag(C.once, "Start the Pyret server"),
     "port",
-      C.next-val-default(C.String, "1701", none, C.once, "Port to serve on (default 1701)"),
+      C.next-val-default(C.Number, "1701", none, C.once, "Port to serve on"),
     "build-standalone",
       C.next-val(C.String, C.once, "Main Pyret (.arr) file to build as a standalone"),
     "build-runnable",
@@ -55,6 +55,8 @@ fun main(args :: List<String>) -> Number block:
       C.flag(C.once, "Don't auto-import basics like list, option, etc."),
     "module-load-dir",
       C.next-val-default(C.String, ".", none, C.once, "Base directory to search for modules"),
+    "profile",
+      C.flag(C.once, "Add profiling information to the main file"),
     "check-all",
       C.flag(C.once, "Run checks all modules (not just the main module)"),
     "no-check-mode",
@@ -100,6 +102,7 @@ fun main(args :: List<String>) -> Number block:
       tail-calls = not(r.has-key("improper-tail-calls"))
       compiled-dir = r.get-value("compiled-dir")
       standalone-file = r.get-value("standalone-file")
+      add-profiling = r.has-key("profile")
       display-progress = not(r.has-key("no-display-progress"))
       html-file = if r.has-key("html-file"):
             some(r.get-value("html-file"))
@@ -136,6 +139,7 @@ fun main(args :: List<String>) -> Number block:
                 check-mode : check-mode,
                 type-check : type-check,
                 allow-shadowed : allow-shadowed,
+                add-profiling : add-profiling,
                 collect-all: false,
                 collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
                 ignore-unbound: false,

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -34,6 +34,10 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/post-load-hooks", "pyret-base
 
   var postLoadHooks = loadHooksLib.makeDefaultPostLoadHooks(runtime, {main: main, checkAll: true});
   postLoadHooks[main] = function(answer) {
+    var profile = runtime.getProfile();
+    if (profile.length > 0) {
+      profile.forEach(function(entry) { process.stderr.write(JSON.stringify(entry) + "\n"); });
+    }
     var checkerLib = runtime.modules["builtin://checker"];
     var checker = runtime.getField(runtime.getField(checkerLib, "provide-plus-types"), "values");
     var getStack = function(err) {

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3580,6 +3580,15 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     var TRACE_DEPTH = 0;
     var SHOW_TRACE = true;
     var TOTAL_VARS = 0;
+    var PROFILE = [];
+    const getTime = ((typeof process !== "undefined") && process.hrtime) ? process.hrtime
+          : (((typeof performance !== "undefined") && performance.now) ? performance.now : Date.now);
+    function profileEnter(loc) {
+      PROFILE.push([loc, true, getTime()]);
+    }
+    function profileExit(loc) {
+      PROFILE.push([loc, false, getTime()]);
+    }
     function traceEnter(name, vars) {
       if (!SHOW_TRACE) return;
       TRACE_DEPTH++;
@@ -5618,6 +5627,9 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'spy': spy,
 
 
+      'profileEnter' : profileEnter,
+      'profileExit' : profileExit,
+      'getProfile' : function() { return PROFILE; },
       'traceEnter': traceEnter,
       'traceExit': traceExit,
       'traceErrExit': traceErrExit,
@@ -6020,6 +6032,8 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         'makeTupleAnn': 'mTA',
         'makeVariantConstructor': 'mVC',
         'namedBrander': 'nB',
+        'profileEnter': 'pEn',
+        'profileExit': 'pEx',
         'traceEnter': 'tEn',
         'traceErrExit': 'tErEx',
         'traceExit': 'tEx',


### PR DESCRIPTION
* Using the `-profile` command-line argument will instruct the compiler to add profiling information to the main module.  (This is easily generalized: the `should-profile` method added to `build-program` in cli-module-loader.arr could easily return true always, or for some subset of modules, etc.)
* The profiling information consists of a triple, [srcloc, boolean, timestamp]:
  - The srcloc is in raw form (i.e. a 7-tuple JS array).
  - Boolean true means function entry; false means function exit.
  - The timestamp is the highest-resolution we can get per platform, meaning process.hrtime, falling back to performance.now, with Date.now as last resort.  (The process.hrtime output is a pair of integers meaning seconds and nanoseconds; the performance.now output is a double meaning milliseconds, and Date.now is an integer meaning milliseconds.)
* Any profiling output is printed to process.stderr (at least for now; this could easily be changed in handalone.js), one line per profile entry, in JSON format.
* This commit doesn't add any interpretation of the output (in particular, it does no runtime processing of the hrtime output, so that no time is wasted during actual running of the program -- save that for postprocessing).  Separate scripts could easily be written to analyze the data and produce interesting statistics...