### PR TITLE
Add 'checks' CLI option for specifying which checks (all, none, or main) to execute

### DIFF
--- a/src/arr/compiler/cli-module-loader.arr
+++ b/src/arr/compiler/cli-module-loader.arr
@@ -128,7 +128,7 @@ fun get-cached(basedir, uri, name, cache-type):
       # F.file-times(static-path + ".js").mtime
     end,
     method get-options(self, options):
-      options.{ check-mode: false }
+      options.{ checks: "none" }
     end,
     method get-module(_):
       raise("Should never fetch source for builtin module " + static-path)
@@ -318,7 +318,7 @@ fun module-finder(ctxt :: CLIContext, dep :: CS.Dependency):
         l = get-builtin-test-locator(ctxt.cache-base-dir, args.first)
         force-check-mode = l.{
           method get-options(self, options):
-            options.{ check-mode: true, type-check: false }
+            options.{ checks: "all", type-check: false }
           end
         }
         CL.located(force-check-mode, ctxt)

--- a/src/arr/compiler/compile-lib.arr
+++ b/src/arr/compiler/compile-lib.arr
@@ -369,7 +369,7 @@ fun compile-module(locator :: Locator, provide-map :: SD.StringDict<CS.Provides>
       var wf = W.check-well-formed(ast-ended)
       ast-ended := nothing
       add-phase("Checked well-formedness", wf)
-      checker = if options.check-mode and not(is-builtin-module(locator.uri())):
+      checker = if not(options.checks == "none") and not(is-builtin-module(locator.uri())):
         CH.desugar-check
       else:
         CH.desugar-no-checks
@@ -380,7 +380,7 @@ fun compile-module(locator :: Locator, provide-map :: SD.StringDict<CS.Provides>
           wf := nothing
           var checked = checker(wf-ast)
           wf-ast := nothing
-          add-phase(if options.check-mode: "Desugared (with checks)" else: "Desugared (skipping checks)" end, checked)
+          add-phase(if not(options.checks == "none"): "Desugared (with checks)" else: "Desugared (skipping checks)" end, checked)
           var imported = AU.wrap-extra-imports(checked, libs)
           checked := nothing
           add-phase("Added imports", imported)
@@ -541,14 +541,9 @@ fun make-standalone(wl, compiled, options):
 
   runtime-options = J.j-obj(
     [C.clist:
+      J.j-field("checks", j-str(options.checks)),
       J.j-field("disableAnnotationChecks",
         if options.runtime-annotations:
-          j-false
-        else:
-          j-true
-        end),
-      J.j-field("disableCheckMode",
-        if options.check-mode:
           j-false
         else:
           j-true

--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -2472,6 +2472,7 @@ default-compile-options = {
   this-pyret-dir: ".",
   check-mode : true,
   check-all : true,
+  checks: "all",
   type-check : false,
   allow-shadowed : false,
   collect-all: false,

--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -128,115 +128,117 @@ fun main(args :: List<String>) -> Number block:
       when r.has-key("allow-builtin-overrides"):
         B.set-allow-builtin-overrides(r.get-value("allow-builtin-overrides"))
       end
-      when r.has-key("checks") and r.has-key("no-check-mode") and not(r.get-value("checks") == "none") block:
+      if r.has-key("checks") and r.has-key("no-check-mode") and not(r.get-value("checks") == "none") block:
         print-error("Can't use --checks " + r.get-value("checks") + " with -no-check-mode\n")
         failure-code
-      end
-      when r.has-key("checks") and r.has-key("check-all") and not(r.get-value("checks") == "all") block:
-        print-error("Can't use --checks " + r.get-value("checks") + " with -check-all\n")
-        failure-code
-      end
-      if not(is-empty(rest)) block:
-        print-error("No longer supported\n")
-        failure-code
       else:
-        if r.has-key("build-runnable") block:
-          outfile = if r.has-key("outfile"):
-            r.get-value("outfile")
-          else:
-            r.get-value("build-runnable") + ".jarr"
-          end
-          compile-opts = CS.make-default-compile-options(this-pyret-dir)
-          CLI.build-runnable-standalone(
-              r.get-value("build-runnable"),
-              r.get("require-config").or-else(P.resolve(P.join(this-pyret-dir, "config.json"))),
-              outfile,
-              compile-opts.{
-                this-pyret-dir: this-pyret-dir,
-                standalone-file: standalone-file,
-                checks : checks,
-                type-check : type-check,
-                allow-shadowed : allow-shadowed,
-                collect-all: false,
-                collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
-                ignore-unbound: false,
-                proper-tail-calls: tail-calls,
-                compiled-cache: compiled-dir,
-                compiled-read-only: r.get("compiled-read-only-dir").or-else(empty),
-                display-progress: display-progress,
-                inline-case-body-limit: inline-case-body-limit,
-                deps-file: r.get("deps-file").or-else(compile-opts.deps-file),
-                html-file: html-file,
-                module-eval: module-eval,
-                user-annotations: user-annotations,
-                runtime-annotations: runtime-annotations
-              })
-          success-code
-        else if r.has-key("serve"):
-          port = r.get-value("port")
-          S.serve(port, this-pyret-dir)
-          success-code
-        else if r.has-key("build-standalone"):
-          print-error("Use build-runnable instead of build-standalone\n")
+        if r.has-key("checks") and r.has-key("check-all") and not(r.get-value("checks") == "all") block:
+          print-error("Can't use --checks " + r.get-value("checks") + " with -check-all\n")
           failure-code
-          #|
-          CLI.build-require-standalone(r.get-value("build-standalone"),
-              CS.default-compile-options.{
-                checks : checks,
-                type-check : type-check,
-                allow-shadowed : allow-shadowed,
-                collect-all: false,
-                collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
-                ignore-unbound: false,
-                proper-tail-calls: tail-calls,
-                compiled-cache: compiled-dir,
-                display-progress: display-progress
-              })
-           |#
-        else if r.has-key("build"):
-          result = CLI.compile(r.get-value("build"),
-            CS.default-compile-options.{
-              checks : checks,
-              type-check : type-check,
-              allow-shadowed : allow-shadowed,
-              collect-all: false,
-              ignore-unbound: false,
-              proper-tail-calls: tail-calls,
-              compile-module: false,
-              display-progress: display-progress
-            })
-          failures = filter(CS.is-err, result.loadables)
-          if is-link(failures) block:
-            for each(f from failures) block:
-              for lists.each(e from f.errors) block:
-                print-error(tostring(e))
-                print-error("\n")
-              end
-              print-error("There were compilation errors\n")
-            end
+        else:
+          if not(is-empty(rest)) block:
+            print-error("No longer supported\n")
             failure-code
           else:
-            success-code
-          end
-        else if r.has-key("run"):
-          run-args =
-            if is-empty(rest):
-              empty
+            if r.has-key("build-runnable") block:
+              outfile = if r.has-key("outfile"):
+                r.get-value("outfile")
+              else:
+                r.get-value("build-runnable") + ".jarr"
+              end
+              compile-opts = CS.make-default-compile-options(this-pyret-dir)
+              CLI.build-runnable-standalone(
+                  r.get-value("build-runnable"),
+                  r.get("require-config").or-else(P.resolve(P.join(this-pyret-dir, "config.json"))),
+                  outfile,
+                  compile-opts.{
+                    this-pyret-dir: this-pyret-dir,
+                    standalone-file: standalone-file,
+                    checks : checks,
+                    type-check : type-check,
+                    allow-shadowed : allow-shadowed,
+                    collect-all: false,
+                    collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
+                    ignore-unbound: false,
+                    proper-tail-calls: tail-calls,
+                    compiled-cache: compiled-dir,
+                    compiled-read-only: r.get("compiled-read-only-dir").or-else(empty),
+                    display-progress: display-progress,
+                    inline-case-body-limit: inline-case-body-limit,
+                    deps-file: r.get("deps-file").or-else(compile-opts.deps-file),
+                    html-file: html-file,
+                    module-eval: module-eval,
+                    user-annotations: user-annotations,
+                    runtime-annotations: runtime-annotations
+                  })
+              success-code
+            else if r.has-key("serve"):
+              port = r.get-value("port")
+              S.serve(port, this-pyret-dir)
+              success-code
+            else if r.has-key("build-standalone"):
+              print-error("Use build-runnable instead of build-standalone\n")
+              failure-code
+              #|
+              CLI.build-require-standalone(r.get-value("build-standalone"),
+                  CS.default-compile-options.{
+                    checks : checks,
+                    type-check : type-check,
+                    allow-shadowed : allow-shadowed,
+                    collect-all: false,
+                    collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
+                    ignore-unbound: false,
+                    proper-tail-calls: tail-calls,
+                    compiled-cache: compiled-dir,
+                    display-progress: display-progress
+                  })
+               |#
+            else if r.has-key("build"):
+              result = CLI.compile(r.get-value("build"),
+                CS.default-compile-options.{
+                  checks : checks,
+                  type-check : type-check,
+                  allow-shadowed : allow-shadowed,
+                  collect-all: false,
+                  ignore-unbound: false,
+                  proper-tail-calls: tail-calls,
+                  compile-module: false,
+                  display-progress: display-progress
+                })
+              failures = filter(CS.is-err, result.loadables)
+              if is-link(failures) block:
+                for each(f from failures) block:
+                  for lists.each(e from f.errors) block:
+                    print-error(tostring(e))
+                    print-error("\n")
+                  end
+                  print-error("There were compilation errors\n")
+                end
+                failure-code
+              else:
+                success-code
+              end
+            else if r.has-key("run"):
+              run-args =
+                if is-empty(rest):
+                  empty
+                else:
+                  rest.rest
+                end
+              result = CLI.run(r.get-value("run"), CS.default-compile-options.{
+                  standalone-file: standalone-file,
+                  display-progress: display-progress,
+                  checks: checks
+                }, run-args)
+              _ = print(result.message + "\n")
+              result.exit-code
             else:
-              rest.rest
+              block:
+                print-error(C.usage-info(options).join-str("\n"))
+                print-error("Unknown command line options\n")
+                failure-code
+              end
             end
-          result = CLI.run(r.get-value("run"), CS.default-compile-options.{
-              standalone-file: standalone-file,
-              display-progress: display-progress,
-              checks: checks
-            }, run-args)
-          _ = print(result.message + "\n")
-          result.exit-code
-        else:
-          block:
-            print-error(C.usage-info(options).join-str("\n"))
-            print-error("Unknown command line options\n")
-            failure-code
           end
         end
       end

--- a/src/arr/compiler/server.arr
+++ b/src/arr/compiler/server.arr
@@ -32,6 +32,7 @@ fun compile(options):
       compiled-cache: options.get("compiled-dir").or-else("./compiled"),
       compiled-read-only: options.get("compiled-read-only").or-else(empty),
       standalone-file: options.get("standalone-file").or-else(compile-opts.standalone-file),
+      checks: options.get-value("checks"),
       display-progress: options.get("display-progress").or-else(true),
       log: options.get("log").or-else(compile-opts.log),
       log-error: options.get("log-error").or-else(compile-opts.log-error),

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -169,7 +169,7 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"]
       checker = runtime.getField(runtime.getField(checker, "provide-plus-types"), "values");
       var checks = checkFlag("checks");
       if(checks && checks !== "none") {
-        var currentChecker = runtime.getField(checker, "make-check-context").app(runtime.makeString(main), flag === "all");
+        var currentChecker = runtime.getField(checker, "make-check-context").app(runtime.makeString(main), checks === "all");
         runtime.setParam("current-checker", currentChecker);
       }
     }

--- a/src/js/base/handalone.js
+++ b/src/js/base/handalone.js
@@ -167,15 +167,16 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/exn-stack-parser", "program"]
     },
     "builtin://checker": function(checker) {
       checker = runtime.getField(runtime.getField(checker, "provide-plus-types"), "values");
-      // NOTE(joe): This is the place to add checkAll
-      if(!checkFlag("disableCheckMode")) {
-        var currentChecker = runtime.getField(checker, "make-check-context").app(runtime.makeString(main), true);
+      var checks = checkFlag("checks");
+      if(checks && checks !== "none") {
+        var currentChecker = runtime.getField(checker, "make-check-context").app(runtime.makeString(main), flag === "all");
         runtime.setParam("current-checker", currentChecker);
       }
     }
   };
   postLoadHooks[main] = function(answer) {
-    if(checkFlag("disableCheckMode")) { process.exit(EXIT_SUCCESS); }
+    var checks = checkFlag("checks");
+    if(checks && checks === "none") { process.exit(EXIT_SUCCESS); }
     var checkerLib = runtime.modules["builtin://checker"];
     var checker = runtime.getField(runtime.getField(checkerLib, "provide-plus-types"), "values");
     var getStack = function(err) {

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -158,7 +158,9 @@
     }
     function getModuleResultChecks(mr) {
       checkSuccess(mr, "checks");
-      return mr.val.runtime.getField(mr.val.result.result, "checks");
+      var checks = mr.val.runtime.getField(mr.val.result.result, "checks");
+      if(mr.val.runtime.ffi.isList(checks)) { return checks; }
+      else { return mr.val.runtime.ffi.makeList([]); }
     }
     function getModuleResultExn(mr) {
       checkExn(mr);

--- a/src/js/trove/load-lib.js
+++ b/src/js/trove/load-lib.js
@@ -289,7 +289,7 @@
     /* ProgramString is a staticModules/depMap/toLoad tuple as a string */
     // TODO(joe): this should take natives as an argument, as well, and requirejs them
     function runProgram(otherRuntimeObj, realmObj, programString, options, commandLineArguments) {
-      var checkAll = runtime.getField(options, "check-all");
+      var checks = runtime.getField(options, "checks");
       var otherRuntime = runtime.getField(otherRuntimeObj, "runtime").val;
       otherRuntime.setParam("command-line-arguments", runtime.ffi.toArray(commandLineArguments));
       var realm = Object.create(runtime.getField(realmObj, "realm").val);
@@ -303,10 +303,12 @@
       runtime.setParam("currentMainURL", main);
 
       if(realm["builtin://checker"]) {
-        var checker = otherRuntime.getField(otherRuntime.getField(realm["builtin://checker"], "provide-plus-types"), "values");
         // NOTE(joe): This is the place to add checkAll
-        var currentChecker = otherRuntime.getField(checker, "make-check-context").app(otherRuntime.makeString(main), checkAll);
-        otherRuntime.setParam("current-checker", currentChecker);
+        if (checks !== "none") {
+          var checker = otherRuntime.getField(otherRuntime.getField(realm["builtin://checker"], "provide-plus-types"), "values");
+          var currentChecker = otherRuntime.getField(checker, "make-check-context").app(otherRuntime.makeString(main), checks === "all");
+          otherRuntime.setParam("current-checker", currentChecker);
+        }
       }
 
       var postLoadHooks = {
@@ -329,10 +331,12 @@
           otherRuntime["checkEQ"] = otherRuntime.makeCheckType(ffi.isEqualityResult, "EqualityResult");
         },
         "builtin://checker": function(checker) {
-          var checker = otherRuntime.getField(otherRuntime.getField(checker, "provide-plus-types"), "values");
           // NOTE(joe): This is the place to add checkAll
-          var currentChecker = otherRuntime.getField(checker, "make-check-context").app(otherRuntime.makeString(main), checkAll);
-          otherRuntime.setParam("current-checker", currentChecker);
+          if (checks !== "none") {
+            var checker = otherRuntime.getField(otherRuntime.getField(checker, "provide-plus-types"), "values");
+            var currentChecker = otherRuntime.getField(checker, "make-check-context").app(otherRuntime.makeString(main), checks === "all");
+            otherRuntime.setParam("current-checker", currentChecker);
+          }
         },
         "builtin://table": function(table) {
           table = table.jsmod;

--- a/src/server/client.js
+++ b/src/server/client.js
@@ -14,6 +14,7 @@ const optionDefinitions = [
   { name: 'require-config', type: String, group: "pyret-options" },
   { name: 'builtin-js-dir', type: String, group: "pyret-options" },
   { name: 'builtin-arr-dir', type: String, group: "pyret-options" },
+  { name: 'checks', alias: 'e', type: String, group: "pyret-options" },
   { name: 'no-check-mode', type: Boolean, group: "pyret-options", defaultValue: false },
   { name: 'compiled-dir', type: String, group: "pyret-options" },
   { name: 'standalone-file', type: String, group: "pyret-options" }

--- a/src/server/pyret.js
+++ b/src/server/pyret.js
@@ -94,6 +94,11 @@ const usages = [
         description: "Turn on the type-checker, and report errors found by the type checker as compilation errors."
       },
       {
+        name: 'checks',
+        alias: 'e',
+        description: "Specify which checks to execute (all, none, or main) (default all)"
+      }
+      {
         name: 'no-check-mode',
         alias: 'k',
         description: "Omit check blocks during compilation, and generate a standalone program that doesn't print testing information at all."
@@ -220,6 +225,7 @@ const optionDefinitions = [
   { name: 'builtin-js-dir', type: String, multiple: true, group: "pyret-options" },
   { name: 'builtin-arr-dir', type: String, multiple: true, group: "pyret-options" },
   { name: 'allow-builtin-overrides', type: Boolean, group: "pyret-options", defaultValue: false },
+  { name: 'checks', alias: 'e', type: String, group: "pyret-options" },
   { name: 'no-check-mode', alias: 'k', type: Boolean, group: "pyret-options", defaultValue: false },
   { name: 'compiled-dir', type: String, group: "pyret-options" },
   { name: 'standalone-file', type: String, group: "pyret-options" },

--- a/src/server/pyret.js
+++ b/src/server/pyret.js
@@ -97,7 +97,7 @@ const usages = [
         name: 'checks',
         alias: 'e',
         description: "Specify which checks to execute (all, none, or main) (default all)"
-      }
+      },
       {
         name: 'no-check-mode',
         alias: 'k',
@@ -225,7 +225,7 @@ const optionDefinitions = [
   { name: 'builtin-js-dir', type: String, multiple: true, group: "pyret-options" },
   { name: 'builtin-arr-dir', type: String, multiple: true, group: "pyret-options" },
   { name: 'allow-builtin-overrides', type: Boolean, group: "pyret-options", defaultValue: false },
-  { name: 'checks', alias: 'e', type: String, group: "pyret-options" },
+  { name: 'checks', defaultValue: 'all', alias: 'e', type: String, group: "pyret-options" },
   { name: 'no-check-mode', alias: 'k', type: Boolean, group: "pyret-options", defaultValue: false },
   { name: 'compiled-dir', type: String, group: "pyret-options" },
   { name: 'standalone-file', type: String, group: "pyret-options" },


### PR DESCRIPTION
Addresses #1228.

**Heads up:** this commit introduces an issue. I wanted to make the PR anyway so there's a relevant place to discuss the changes.

Preliminary testing done via `node build/phaseA/pyret.jarr --checks [all|none|main] --run test.arr`. With the changes so far (in this PR), `main` and `all` work as expected, and almost all the current behavior is unchanged (`-check-all` continues to work as normal, and not providing any flags at the command line runs all checks).

`--checks none` and `-no-check-mode` don't work, though -- both cause the `There was an exception while formatting the check results` error. I suspect this is because of [this change](https://github.com/purag/pyret-lang/blob/2b79e23840beb0211a8ded6cd0f2514836d41e67/src/js/trove/load-lib.js#L307-L310) in `load-lib.js` (and the [corresponding change](https://github.com/purag/pyret-lang/blob/2b79e23840beb0211a8ded6cd0f2514836d41e67/src/js/trove/load-lib.js#L335-L339) on lines 335-339).

My intuition says I need to actually set `current-checker` to some no-op, but I wasn't quite sure how to do it. Or maybe I need to add something to `renderCheckResults`. Any ideas?