### PR TITLE
1 == ~1 (like ~1 == 1) should raise error

### DIFF
--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -2282,7 +2282,9 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     // JS function from Pyret values to Pyret booleans (or throws)
     function equalAlways(v1, v2) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["equal-always"], 2, $a, false); }
-      if(typeof v1 === "number" || typeof v1 === "string" || typeof v1 === "boolean") {
+      if (typeof v1 === 'number'  && typeof v2 === 'number' ||
+          typeof v1 === 'string'  && typeof v2 === 'string' ||
+          typeof v1 === 'boolean' && typeof v2 === 'boolean') {
         return v1 === v2;
       }
       return safeCall(function() {

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -2282,9 +2282,9 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     // JS function from Pyret values to Pyret booleans (or throws)
     function equalAlways(v1, v2) {
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["equal-always"], 2, $a, false); }
-      if (typeof v1 === 'number'  && typeof v2 === 'number' ||
-          typeof v1 === 'string'  && typeof v2 === 'string' ||
-          typeof v1 === 'boolean' && typeof v2 === 'boolean') {
+      if (((typeof v1 === 'number')  && (typeof v2 === 'number')) ||
+          ((typeof v1 === 'string')  && (typeof v2 === 'string')) ||
+          ((typeof v1 === 'boolean') && (typeof v2 === 'boolean'))) {
         return v1 === v2;
       }
       return safeCall(function() {

--- a/tests/pyret/tests/test-equality.arr
+++ b/tests/pyret/tests/test-equality.arr
@@ -139,14 +139,22 @@ check "eq-none is equal nothing never always":
   eq-none is-not== eq-all
 end
 
-check "error on bare fun and meth":
+check "error on bare fun and meth and roughnum":
   identical(f, f) raises f-func-err
   equal-always(f, f) raises f-func-err
   equal-now(f, f) raises f-func-err
 
   identical(m, m) raises f-meth-err
-  equal-always(f, f) raises f-func-err
-  equal-now(f, f) raises f-func-err
+  equal-always(m, m) raises f-meth-err
+  equal-now(m, m) raises f-meth-err
+
+  identical(1, ~1) is false
+  equal-always(1, ~1) raises "Roughnum"
+  equal-now(1, ~1) raises "Roughnum"
+
+  identical(~1, 1) is false
+  equal-always(~1, 1) raises "Roughnum"
+  equal-now(~1, 1) raises "Roughnum"
 end
 
 check "error (and non-error) on nested fun and meth":


### PR DESCRIPTION
This is a fix for #1301.

`equalAlways()` (in `runtime.js`) was checking `typeof` of its first arg only to decide if it wanted to do a plain JS equality check. This fix disallows this if first arg is `number` but second is not.  (In general, I've made `equalAlways()` attempt a basic JS equality only if both args are of the same primitive JS type. When not,  `equal3` takes over as usual, raising an exception as needed.)

Added tests to `test-equality.arr`. (Also fixed typo in test that was supposed to try equality between methods.)