### PR TITLE
Node repl load definitions file

### DIFF
--- a/src/arr/compiler/cli-repl.arr
+++ b/src/arr/compiler/cli-repl.arr
@@ -1,6 +1,8 @@
 import runtime-lib as RT
 import load-lib as L
 import string-dict as SD
+import file as F
+import cmdline-lib as CL
 
 import js-file("./cli-repl") as CR
 
@@ -20,8 +22,14 @@ fun run-interaction(src):
   repl.run-interaction(i)
 end
 
+all-cmdline-params = CL.command-line-arguments()
+file-name = all-cmdline-params.first
+other-args = all-cmdline-params.rest
+
+input-file = F.file-to-string(other-args.first)
 
 CR.start({
   restart-interactions: restart-interactions,
-  run-interaction: run-interaction
+  run-interaction: run-interaction,
+  definitions: input-file
 })

--- a/src/arr/compiler/cli-repl.arr
+++ b/src/arr/compiler/cli-repl.arr
@@ -26,7 +26,10 @@ all-cmdline-params = CL.command-line-arguments()
 file-name = all-cmdline-params.first
 other-args = all-cmdline-params.rest
 
-input-file = F.file-to-string(other-args.first)
+input-file =  cases(List) other-args:
+                | empty => ""
+                | link(first, rest) => F.file-to-string(first)
+              end
 
 CR.start({
   restart-interactions: restart-interactions,

--- a/src/arr/compiler/cli-repl.js
+++ b/src/arr/compiler/cli-repl.js
@@ -7,7 +7,7 @@
       var runInteractions = runtime.getField(pyretRepl, "run-interaction");
       function runUsingPyretRepl(src, context, filename, callback) {
         return runtime.runThunk(function() {
-            return runInteractions.app(src); 
+            return runInteractions.app(src);
           },
           function(result) {
             if(runtime.isSuccessResult(result)) {
@@ -20,7 +20,9 @@
       }
       var restartInteractions = runtime.getField(pyretRepl, "restart-interactions");
       return runtime.safeCall(function() {
-          return restartInteractions.app("");
+          // need to convert definitions to JS string?
+          var definitions = runtime.getField(pyretRepl, "definitions");
+          return restartInteractions.app(definitions);
         },
         function(ans) {
           var replServer = nativeRepl.start({eval: runUsingPyretRepl});


### PR DESCRIPTION
After 
`make src/arr/compiler/cli-repl.jarr`,  
run 
`node src/arr/compiler/cli-repl.jarr ./definitions.arr` 
to load the file `./definitions.arr` into the REPL session. 

It would be nice if we could feed the remaining command line arguments to the definitions file, but I wasn't able to see a simple way to do it. I assume that the plumbing for doing such a thing hasn't been set up because it hasn't been needed for the CPO repl.