### PR TITLE
Filtering and Ignoring Tokens

### DIFF
--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -81,7 +81,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
               if (this.skippedTokens === undefined) {
                 this.skippedTokens = t.pos;
               } else {
-                this.skippedTokens.combine(t.pos);
+                this.skippedTokens = this.skippedTokens.combine(t.pos);
               }
               break;
             }
@@ -98,7 +98,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
     if (p === undefined) {
       p = this.skippedTokens;
     } else if (this.skippedTokens !== undefined) {
-        p.combine(this.skippedTokens);
+      p = p.combine(this.skippedTokens);
     }
 
     return p;

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -71,8 +71,6 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
             else
               this.skippedWhitespace = this.skippedWhitespace.combine(newWS);
             break;
-          } else if (tok_type === "__IGNORE") {
-            break;
           }
           var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
           this.curTok = t;

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -1,9 +1,10 @@
 define("jglr/jglr", ["jglr/rnglr"], function(E) {
   const SrcLoc = E.SrcLoc
 
-  function Tokenizer(ignore_ws, Tokens) {
+  function Tokenizer(ignore_ws, Tokens, Whitelist) {
     this.ignore_ws = ignore_ws;
     this.Tokens = Tokens;
+    this.Whitelist = Whitelist;
   }
   Tokenizer.prototype.isEOF = function(tok) { return tok === E.EOF; }
   Tokenizer.prototype.tokenizeFrom = function(str) {
@@ -38,6 +39,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
   Tokenizer.prototype.unshiftToken = function(prev_tok) { this.curTok = prev_tok; }
   Tokenizer.prototype.next = function() {
     delete this.skippedWhitespace;
+    delete this.skippedTokens;
     while (this.hasNext()) { // Surround the tokenizer loop...
       if (this.pos == this.len) { 
         this.pos++; 
@@ -73,11 +75,33 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
             break;
           }
           var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
+          if (this.Whitelist !== undefined) {
+            // Tokenizer was supplied a whitelist
+            if (this.Whitelist.includes(tok_type) === false) {
+              if (this.skippedTokens === undefined) {
+                this.skippedTokens = t.pos;
+              } else {
+                this.skippedTokens.combine(t.pos);
+              }
+              break;
+            }
+          }
           this.curTok = t;
           return t;
         }
       }
     }
+  }
+
+  Tokenizer.prototype.skippedCode = function() {
+    var p = this.skippedWhitespace;
+    if (p === undefined) {
+      p = this.skippedTokens;
+    } else if (this.skippedTokens !== undefined) {
+        p.combine(this.skippedTokens);
+    }
+
+    return p;
   }
 
   return {

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -71,6 +71,8 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
             else
               this.skippedWhitespace = this.skippedWhitespace.combine(newWS);
             break;
+          } else if (tok_type === "__IGNORE") {
+            break;
           }
           var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
           this.curTok = t;

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -1,9 +1,10 @@
 define("jglr/jglr", ["jglr/rnglr"], function(E) {
   const SrcLoc = E.SrcLoc
 
-  function Tokenizer(ignore_ws, Tokens) {
+  function Tokenizer(ignore_ws, Tokens, filter) {
     this.ignore_ws = ignore_ws;
     this.Tokens = Tokens;
+    this.Filter = (filter === undefined) ? baseFilter : filter;
   }
   Tokenizer.prototype.isEOF = function(tok) { return tok === E.EOF; }
   Tokenizer.prototype.tokenizeFrom = function(str) {
@@ -34,16 +35,6 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
     t.pos = pos;
     return t;
   }
-  Tokenizer.prototype.baseFilter = function(tok_type) {
-    // True - pass token
-    // False - ignore token
-    return !(this.ignore_ws && (tok_type === "WS" || tok_type === "COMMENT")) && this.filter(tok_type);
-  }
-  Tokenizer.prototype.filter = function(tok_type) { 
-    // True - pass token
-    // False - ignore token
-    return true;
-  };
   Tokenizer.prototype.postProcessMatch = function(tok, match, str) { return tok.name; }
   Tokenizer.prototype.unshiftToken = function(prev_tok) { this.curTok = prev_tok; }
   Tokenizer.prototype.next = function() {
@@ -76,7 +67,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
           else
             this.curCol = s.length - s.lastIndexOf("\n") - 1;
 
-          if (this.baseFilter(tok_type)) {
+          if (this.Filter(tok_type)) {
             // Passed filter
             var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
             this.curTok = t;
@@ -94,6 +85,12 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
         }
       }
     }
+  }
+
+  function baseFilter(tokenType) {
+    // True:  Allow token
+    // False: Ignore token
+    return !(this.ignore_ws && (tokenType === "WS" || tokenType === "COMMENT"));
   }
 
   return {

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -75,9 +75,11 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
             break;
           }
           var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
+
           if (this.Whitelist !== undefined) {
-            // Tokenizer was supplied a whitelist
-            if (this.Whitelist.includes(tok_type) === false) {
+            // Whitelist of ACCEPTED tokens
+            if (this.Whitelist[tok_type] === undefined) {
+              // Token not on the whitelist
               if (this.skippedTokens === undefined) {
                 this.skippedTokens = t.pos;
               } else {
@@ -86,6 +88,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
               break;
             }
           }
+
           this.curTok = t;
           return t;
         }

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -1,10 +1,9 @@
 define("jglr/jglr", ["jglr/rnglr"], function(E) {
   const SrcLoc = E.SrcLoc
 
-  function Tokenizer(ignore_ws, Tokens, Whitelist) {
+  function Tokenizer(ignore_ws, Tokens) {
     this.ignore_ws = ignore_ws;
     this.Tokens = Tokens;
-    this.Whitelist = Whitelist;
   }
   Tokenizer.prototype.isEOF = function(tok) { return tok === E.EOF; }
   Tokenizer.prototype.tokenizeFrom = function(str) {
@@ -35,6 +34,16 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
     t.pos = pos;
     return t;
   }
+  Tokenizer.prototype.baseFilter = function(tok_type) {
+    // True - pass token
+    // False - ignore token
+    return !(this.ignore_ws && (tok_type === "WS" || tok_type === "COMMENT")) && this.filter(tok_type);
+  }
+  Tokenizer.prototype.filter = function(tok_type) { 
+    // True - pass token
+    // False - ignore token
+    return true;
+  };
   Tokenizer.prototype.postProcessMatch = function(tok, match, str) { return tok.name; }
   Tokenizer.prototype.unshiftToken = function(prev_tok) { this.curTok = prev_tok; }
   Tokenizer.prototype.next = function() {
@@ -47,7 +56,9 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
         this.curTok = E.EOF;
         return E.EOF; 
       }
+
       for (var i = 0; i < this.Tokens.length; i++) {
+
         var tok = this.Tokens[i];
         this.positionTokenRegexp(tok);
         var match = tok.val.exec(this.str);
@@ -65,32 +76,22 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
             this.curCol += s.length;
           else
             this.curCol = s.length - s.lastIndexOf("\n") - 1;
-          if (this.ignore_ws && (tok_type === "WS" || tok_type === "COMMENT")) {
-            // ... in case we're ignoring whitespace
-            var newWS = SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos);
-            if (this.skippedWhitespace === undefined)
-              this.skippedWhitespace = newWS;
-            else
-              this.skippedWhitespace = this.skippedWhitespace.combine(newWS);
-            break;
-          }
-          var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
 
-          if (this.Whitelist !== undefined) {
-            // Whitelist of ACCEPTED tokens
-            if (this.Whitelist[tok_type] === undefined) {
-              // Token not on the whitelist
-              if (this.skippedTokens === undefined) {
-                this.skippedTokens = t.pos;
+          if (this.baseFilter(tok_type)) {
+            // Passed filter
+            var t = this.makeToken(tok_type, s, SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos));
+            this.curTok = t;
+            return t;
+          } else {
+            // Rejected by filter
+            var skipped = SrcLoc.make(l, c, p, this.curLine, this.curCol, this.pos);
+            if (this.skippedTokens === undefined) {
+                this.skippedTokens = skipped;
               } else {
-                this.skippedTokens = this.skippedTokens.combine(t.pos);
-              }
-              break;
+                this.skippedTokens = this.skippedTokens.combine(skipped);
             }
-          }
-
-          this.curTok = t;
-          return t;
+            break;
+          } 
         }
       }
     }

--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -47,7 +47,6 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
   Tokenizer.prototype.postProcessMatch = function(tok, match, str) { return tok.name; }
   Tokenizer.prototype.unshiftToken = function(prev_tok) { this.curTok = prev_tok; }
   Tokenizer.prototype.next = function() {
-    delete this.skippedWhitespace;
     delete this.skippedTokens;
     while (this.hasNext()) { // Surround the tokenizer loop...
       if (this.pos == this.len) { 
@@ -95,17 +94,6 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
         }
       }
     }
-  }
-
-  Tokenizer.prototype.skippedCode = function() {
-    var p = this.skippedWhitespace;
-    if (p === undefined) {
-      p = this.skippedTokens;
-    } else if (this.skippedTokens !== undefined) {
-      p = p.combine(this.skippedTokens);
-    }
-
-    return p;
   }
 
   return {

--- a/lib/jglr/rnglr.js
+++ b/lib/jglr/rnglr.js
@@ -1313,7 +1313,7 @@ define("jglr/rnglr", ["jglr/cyclicJSON"], function(cycle) {
       return ret;
     },
 
-    reducer: function(U, R, Q, N, i, cur_tok, skipped_WS_loc) {
+    reducer: function(U, R, Q, N, i, cur_tok, skipped_loc) {
       // cur_tok = token #i+1: i starts at index 0, and tokens start at index 1
       // U is an array of sets of GSS nodes
       // R is the worklist of pending reductions
@@ -1351,8 +1351,8 @@ define("jglr/rnglr", ["jglr/cyclicJSON"], function(cycle) {
             z = nodes_X[c];
             if (z === undefined) {
               var pos;
-              if (skipped_WS_loc !== undefined) {
-                pos = skipped_WS_loc.posAtStart();
+              if (skipped_loc !== undefined) {
+                pos = skipped_loc.posAtStart();
               } else {
                 pos = cur_tok.pos;
               }
@@ -1421,7 +1421,7 @@ define("jglr/rnglr", ["jglr/cyclicJSON"], function(cycle) {
           if (m !== 0) {
             var labels = p.labels.slice(0);
             labels.push(y_m);
-            thiz.addChildren(item.rule, z, labels, f, skipped_WS_loc !== undefined ? skipped_WS_loc.posAtStart() : cur_tok.pos.posAtStart());
+            thiz.addChildren(item.rule, z, labels, f, skipped_loc !== undefined ? skipped_loc.posAtStart() : cur_tok.pos.posAtStart());
           }
         }
       });
@@ -1694,7 +1694,7 @@ define("jglr/rnglr", ["jglr/cyclicJSON"], function(cycle) {
             var N = new Queue([]);
             // console.log("Phase 1: reducing due to token #" + i + ": " + cur_tok.toString(true));
             while (R.length > 0) {
-              this.reducer(this.U, R, Q, N, i, cur_tok, token_source.skippedWhitespace);
+              this.reducer(this.U, R, Q, N, i, cur_tok, token_source.skippedCode());
             }
             hasNext = token_source.hasNext();
             var next_tok = token_source.next();

--- a/lib/jglr/rnglr.js
+++ b/lib/jglr/rnglr.js
@@ -1694,7 +1694,7 @@ define("jglr/rnglr", ["jglr/cyclicJSON"], function(cycle) {
             var N = new Queue([]);
             // console.log("Phase 1: reducing due to token #" + i + ": " + cur_tok.toString(true));
             while (R.length > 0) {
-              this.reducer(this.U, R, Q, N, i, cur_tok, token_source.skippedCode());
+              this.reducer(this.U, R, Q, N, i, cur_tok, token_source.skippedTokens);
             }
             hasNext = token_source.hasNext();
             var next_tok = token_source.next();


### PR DESCRIPTION
While writing specific grammars (i.e. for 'balanced' blocks) for error analysis, I've found that I can ignore most of the data besides a few important tokens (keywords, parentheses, etc). 

**New Proposal**:
Treat the tokenizer as an iterator. Use a "filter" function which chooses what tokens are ignored or passed to the parser. If the filter function is not provided, a default filter is used.

**Original proposal**: Add special "__IGNORE" metatoken handling

Provide a way to discard tokens during tokenization. This pull requests integrates a filter for tokens with type "__IGNORE" (a metatype) which will NOT be passed to the parser while still passing over the string data.


Some alternatives:
1. Change token types and pass "__IGNORE" tokens to the grammar. However, I would like the error analysis grammars to be relatively simple.
2. Integrate productions from the full grammar. Again, I would like to keep the grammars simple, and it kind of defeats the purpose of the finer-grained grammars.
3. Write custom procedures to filter out unnecessary data. Prone to mistakes and may not match up with the expected output.
