### PR TITLE
Change error when split-at given non-integer input to 'Invalid index'

### DIFF
--- a/src/arr/trove/lists.arr
+++ b/src/arr/trove/lists.arr
@@ -515,7 +515,7 @@ end
 
 fun split-at<a>(n :: Number, lst :: List<a>) -> { prefix :: List<a>, suffix :: List<a> } block:
   doc: "Splits the list into two lists, one containing the first n elements, and the other containing the rest"
-  when n < 0:
+  when (n < 0) or not(num-is-integer(n)):
     raise("Invalid index")
   end
   var prefix = empty

--- a/tests/pyret/tests/test-lists.arr
+++ b/tests/pyret/tests/test-lists.arr
@@ -75,6 +75,7 @@ check "split-at where: block":
   split-at(4, one-four) is { prefix: one-four, suffix: empty }
   split-at(2, one-four) is { prefix: link(1, link(2, empty)), suffix: link(3, link(4, empty)) }
   split-at(-1, one-four) raises "Invalid index"
+  split-at(1.35, one-four) raises "Invalid index"
   split-at(5, one-four) raises "Index too large"
 end
 


### PR DESCRIPTION
Fixes #1190. (forgot to add tests the first time around!)