### PR TITLE
Fix error that occurs when using implicit version of `spy` with `var`

### DIFF
--- a/src/arr/compiler/desugar.arr
+++ b/src/arr/compiler/desugar.arr
@@ -925,8 +925,12 @@ fun desugar-expr(expr :: A.Expr):
       end
       ds-contents-list = for map(spy-exp from contents):
         cases(A.SpyField) spy-exp:
-          | s-spy-name(l2, name) => {A.s-srcloc(l2, l2); A.s-str(l2, name.id.toname()); desugar-expr(name)}
-          | s-spy-expr(l2, name, value) => {A.s-srcloc(l2, l2); A.s-str(l2, name); desugar-expr(value)}
+          | s-spy-expr(l2, name, value, implicit-label) =>
+            if implicit-label:
+              {A.s-srcloc(l2, l2); A.s-str(l2, value.id.toname()); desugar-expr(value)}
+            else:
+              {A.s-srcloc(l2, l2); A.s-str(l2, name); desugar-expr(value)}
+            end
         end
       end
       ds-contents = for L.foldr(acc from {empty; empty; empty}, ds-content from ds-contents-list):

--- a/src/arr/compiler/desugar.arr
+++ b/src/arr/compiler/desugar.arr
@@ -925,12 +925,8 @@ fun desugar-expr(expr :: A.Expr):
       end
       ds-contents-list = for map(spy-exp from contents):
         cases(A.SpyField) spy-exp:
-          | s-spy-expr(l2, name, value, implicit-label) =>
-            if implicit-label:
-              {A.s-srcloc(l2, l2); A.s-str(l2, value.id.toname()); desugar-expr(value)}
-            else:
-              {A.s-srcloc(l2, l2); A.s-str(l2, name); desugar-expr(value)}
-            end
+          | s-spy-expr(l2, name, value, _) =>
+            {A.s-srcloc(l2, l2); A.s-str(l2, name); desugar-expr(value)}
         end
       end
       ds-contents = for L.foldr(acc from {empty; empty; empty}, ds-content from ds-contents-list):

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -239,11 +239,11 @@
         },
         'spy-field': function(node) {
           if (node.kids.length === 1) {
-            return RUNTIME.getField(ast, 's-spy-name')
-              .app(pos(node.pos), tr(node.kids[0]));
+            return RUNTIME.getField(ast, 's-spy-expr')
+              .app(pos(node.pos), RUNTIME.makeString(""), tr(node.kids[0]), RUNTIME.makeBoolean(true));
           } else {
             return RUNTIME.getField(ast, 's-spy-expr')
-              .app(pos(node.pos), symbol(node.kids[0]), tr(node.kids[2]));
+              .app(pos(node.pos), symbol(node.kids[0]), tr(node.kids[2]), RUNTIME.makeBoolean(false));
           }
         },
         'data-with': function(node) {

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -240,7 +240,7 @@
         'spy-field': function(node) {
           if (node.kids.length === 1) {
             return RUNTIME.getField(ast, 's-spy-expr')
-              .app(pos(node.pos), RUNTIME.makeString(""), tr(node.kids[0]), RUNTIME.makeBoolean(true));
+              .app(pos(node.pos), symbol(node.kids[0].kids[0]), tr(node.kids[0]), RUNTIME.makeBoolean(true));
           } else {
             return RUNTIME.getField(ast, 's-spy-expr')
               .app(pos(node.pos), symbol(node.kids[0]), tr(node.kids[2]), RUNTIME.makeBoolean(false));

--- a/tests/pyret/regression/using-spy-with-var.arr
+++ b/tests/pyret/regression/using-spy-with-var.arr
@@ -1,0 +1,6 @@
+check "https://github.com/brownplt/pyret-lang/issues/1342":
+  # if this parses, the test is fine
+  var x = 1
+  spy: x end
+  spy: some-name: x end
+end


### PR DESCRIPTION
Fixes #1342.

In regards to the updated constructor for `s-spy-expr`, I wasn't sure what the `name` of something that used to fall under the `s-spy-name` case should be (since for those cases, the `name` in the new constructor is now a String instead of an Expr), so I took a guess and in parse-pyret.js set the `name` for things that used to be `s-spy-name` to the empty string and used `value` in places where it was necessary.