### PR TITLE
Force defstruct to use vector

### DIFF
--- a/tools/emacs/pyret.el
+++ b/tools/emacs/pyret.el
@@ -767,6 +767,7 @@ the number of quote characters in the match."
    (:constructor pyret-make-indent 
                  (fun cases data shared try except graph parens object 
                   vars fields initial-period block-comment-depth))
+   (:type vector)
    :named)
    fun cases data shared try except graph parens object vars fields initial-period block-comment-depth)
 (defun pyret-map-indent (f total delta)


### PR DESCRIPTION
Our code assumes that the structure defined by defstruct is a vector.
However, this is not true in Emacs 26 as it switches to use a record instead
(see https://lists.gnu.org/archive/html/emacs-diffs/2017-03/msg00245.html),
so our code doesn't work in Emacs 26.

This commit forces the structure used by defstruct to be vector again.
It does nothing prior Emacs 26 since the default structure is a vector already

Fixes #1355 