### PR TITLE
Changing the desugaring of bracket expressions to become a *non-flat*…

### DIFF
--- a/src/arr/compiler/anf-loop-compiler.arr
+++ b/src/arr/compiler/anf-loop-compiler.arr
@@ -179,6 +179,7 @@ rt-name-map = [D.string-dict:
   "getDotAnn", "gDA",
   "getField", "gF",
   "getFieldRef", "gFR",
+  "getBracket", "gB",
   "hasBrand", "hB",
   "isActivationRecord", "isAR",
   "isCont", "isC",
@@ -247,10 +248,18 @@ fun get-field-unsafe(obj :: J.JExpr, field :: J.JExpr, loc-expr :: J.JExpr):
   j-app(get-field-loc, [clist: obj, field, loc-expr])
 end
 
+fun get-bracket-unsafe(obj :: J.JExpr, field :: J.JExpr, loc-expr :: J.JExpr):
+  rt-method("getBracket", [clist: obj, field, loc-expr])
+end
+
 # When the field may not exist, add source mapping so if we can't find it
 # we get a useful stacktrace
 fun get-field-safe(l, obj :: J.JExpr, field :: J.JExpr, loc-expr :: J.JExpr):
   wrap-with-srcnode(l, get-field-unsafe(obj, field, loc-expr))
+end
+
+fun get-bracket-safe(l, obj :: J.JExpr, field :: J.JExpr, loc-expr :: J.JExpr):
+  wrap-with-srcnode(l, get-bracket-unsafe(obj, field, loc-expr))
 end
 
 fun get-field-ref(obj :: J.JExpr, field :: J.JExpr, loc :: J.JExpr):
@@ -1357,8 +1366,75 @@ fun compile-a-lam(compiler, l :: Loc, name :: String, args :: List<N.ABind>, ret
           compile-fun-body(l, new-step, temp, compiler.{allow-tco: true}, effective-args, some(len), body, true, is-flat, false)))])
 end
 
+
+fun compile-split-prim-app(l, compiler, opt-dest, f, args, opt-body):
+  ans = compiler.cur-ans
+  step = compiler.cur-step
+  compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
+  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+  c-block(
+    j-block(
+      # Update step before the call, so that if it runs out of gas,
+      # the resumer goes to the right step
+      [clist:
+        j-expr(j-assign(step, after-app-label)),
+        j-expr(j-assign(compiler.cur-apploc, compiler.get-loc(l)))] +
+      [clist:
+        j-expr(wrap-with-srcnode(l, j-assign(ans, rt-method(f, compiled-args)))),
+        j-break]),
+    new-cases)
+end
+
+
+fun compile-flat-prim-app(l, compiler, opt-dest, f, args, opt-body):
+  ans = compiler.cur-ans
+  compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
+
+  # Generate the code for calling the function
+  call-code = j-expr(wrap-with-srcnode(l, j-assign(ans, rt-method(f, compiled-args))))
+
+  # Compile the body of the let. We split it into two portions:
+  # 1) the code that can be in the same "block" (or case region) and
+  # 2) the rest of the case statements
+  {remaining-code; new-cases} = cases (Option) opt-body:
+    | some(body) =>
+      get-remaining-code(compiler, opt-dest, body, ans)
+    | none =>
+      # Special case: there is no more code after this so just jump to the
+      # special last block in the function
+      body = j-block([clist:
+          j-expr(j-assign(compiler.cur-step, compiler.cur-target)),
+          j-break
+        ])
+      {body; cl-empty}
+  end
+
+  # Now merge the code for calling the function with the next block
+  # (this is basically our optimization, since we're not starting a new case
+  # for the next block)
+  c-block(
+    j-block(cl-cons(call-code, j-block-to-stmt-list(remaining-code))),
+    new-cases)
+end
+
+fun compile-a-prim-app(l :: N.Loc, f :: String, args :: List<N.AVal>,
+    compiler,
+    b :: Option<BindType>,
+    opt-body :: Option<N.AExpr>,
+    app-info :: A.PrimAppInfo):
+
+  app-compiler = if app-info.needs-step:
+    compile-split-prim-app
+  else:
+    compile-flat-prim-app
+  end
+  app-compiler(l, compiler, b, f, args, opt-body)
+end
+
 fun compile-lettable(compiler, b :: Option<BindType>, e :: N.ALettable, opt-body :: Option<N.AExpr>, else-case :: (DAG.CaseResults -> DAG.CaseResults)):
   cases(N.ALettable) e:
+    | a-prim-app(l2, f, args, app-info) =>
+      compile-a-prim-app(l2, f, args, compiler, b, opt-body, app-info)
     | a-app(l2, f, args, app-info) =>
       compile-a-app(l2, f, args, compiler, b, opt-body, app-info)
     | a-method-app(l2, obj, m, args) =>
@@ -1513,7 +1589,7 @@ compiler-visitor = {
   method a-app(self, l :: Loc, f :: N.AVal, args :: List<N.AVal>):
     raise("Impossible: a-app directly in compiler-visitor should never happen")
   end,
-  method a-prim-app(self, l :: Loc, f :: String, args :: List<N.AVal>):
+  method a-prim-app(self, l :: Loc, f :: String, args :: List<N.AVal>, app-info :: A.PrimAppInfo):
     visit-args = args.map(_.visit(self))
     set-loc = [clist:
       j-expr(j-assign(self.cur-apploc, self.get-loc(l)))

--- a/src/arr/compiler/anf.arr
+++ b/src/arr/compiler/anf.arr
@@ -15,6 +15,7 @@ type ANFCont = (N.ALettable -> N.AExpr)
 fun get-value(o): o.value end
 
 names = A.global-names
+flat-prim-app = A.prim-app-info-c(false)
 
 fun mk-id(loc, base):
   t = names.make-atom(base)
@@ -341,7 +342,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
       N.a-let(
         l,
         bind(l, array-id),
-        N.a-prim-app(l, "makeArrayN", [list: N.a-num(l, values.length())]),
+        N.a-prim-app(l, "makeArrayN", [list: N.a-num(l, values.length())], flat-prim-app),
         anf-name-arr-rec(values, array-id, 0, lam():
           k(N.a-val(l, N.a-id(l, array-id)))
         end))
@@ -388,9 +389,9 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
             end)
       end
 
-    | s-prim-app(l, f, args) =>
+    | s-prim-app(l, f, args, app-info) =>
       anf-name-rec(args, "anf_arg", lam(vs):
-          k(N.a-prim-app(l, f, vs))
+          k(N.a-prim-app(l, f, vs, app-info))
         end)
 
     | s-instantiate(_, body, _) =>
@@ -400,11 +401,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
       anf-name(obj, "anf_bracket", lam(t-obj): k(N.a-dot(l, t-obj, field)) end)
 
     | s-bracket(l, obj, field) =>
-      fname = cases(A.Expr) field:
-          | s-str(_, s) => s
-          | else => raise("Non-string field: " + torepr(field))
-        end
-      anf-name(obj, "anf_bracket", lam(t-obj): k(N.a-dot(l, t-obj, fname)) end)
+      raise("Impossible")
 
     | s-ref(l, ann) =>
       k(N.a-ref(l, ann))

--- a/src/arr/compiler/ast-util.arr
+++ b/src/arr/compiler/ast-util.arr
@@ -791,8 +791,8 @@ set-tail-visitor = A.default-map-visitor.{
       A.app-info-c(app-info.is-recursive, self.is-tail))
   end,
 
-  method s-prim-app(self, l, _fun, args):
-    A.s-prim-app(l, _fun, args.map(_.visit(self.{is-tail: false})))
+  method s-prim-app(self, l, _fun, args, app-info):
+    A.s-prim-app(l, _fun, args.map(_.visit(self.{is-tail: false})), app-info)
   end,
 
   # skip s-instantiate because all positions which could have s-app-enriched could be in the tail position

--- a/src/arr/compiler/desugar-check.arr
+++ b/src/arr/compiler/desugar-check.arr
@@ -21,8 +21,9 @@ fun ast-lam(ast):
   A.s-lam(ast.l, "", [list: ], [list: ], A.a-blank, "", ast, none, none, true)
 end
 
+flat-prim-app = A.prim-app-info-c(false)
 fun ast-srcloc(l):
-  A.s-prim-app(l, "makeSrcloc", [list: A.s-srcloc(l, l)])
+  A.s-prim-app(l, "makeSrcloc", [list: A.s-srcloc(l, l)], flat-prim-app)
 end
 
 check-stmts-visitor = A.default-map-visitor.{
@@ -126,7 +127,7 @@ fun create-check-block(l, checks):
             A.s-data-field(l2, "name", A.s-str(l2, name)),
             A.s-data-field(l2, "run", check-fun),
             A.s-data-field(l2, "keyword-check", A.s-bool(l2, keyword-check)),
-            A.s-data-field(l2, "location", A.s-prim-app(l2, "makeSrcloc", [list: A.s-srcloc(l2, l2)]))
+            A.s-data-field(l2, "location", A.s-prim-app(l2, "makeSrcloc", [list: A.s-srcloc(l2, l2)], flat-prim-app))
           ])
     end
   end

--- a/src/arr/compiler/desugar-post-tc.arr
+++ b/src/arr/compiler/desugar-post-tc.arr
@@ -8,9 +8,10 @@ import file("compile-structs.arr") as C
 
 mk-id = D.mk-id
 no-branches-exn = D.no-branches-exn
+flat-prim-app = A.prim-app-info-c(false)
 
 fun no-cases-exn(l, val):
-  A.s-prim-app(l, "throwNoCasesMatched", [list: A.s-srcloc(l, l), val])
+  A.s-prim-app(l, "throwNoCasesMatched", [list: A.s-srcloc(l, l), val], flat-prim-app)
 end
 
 desugar-visitor = A.default-map-visitor.{

--- a/src/arr/compiler/flatness.arr
+++ b/src/arr/compiler/flatness.arr
@@ -204,7 +204,7 @@ fun make-lettable-data-env(
       end
     | a-app(_, f, args, _) => default-ret
     | a-method-app(_, obj, meth, args) => default-ret
-    | a-prim-app(_, f, args) => default-ret
+    | a-prim-app(_, f, args, _) => default-ret
     | a-ref(_, ann) => default-ret
     | a-tuple(_, fields) => default-ret
     | a-tuple-get(_, tup, index) => default-ret
@@ -345,7 +345,7 @@ fun make-lettable-flatness-env(lettable :: AA.ALettable, sd :: FEnv, ad :: FEnv)
       none
 
       # TODO: Treat prim-app as flat always? Track depths of prim-anns?
-    | a-prim-app(_, f, args) => get-flatness-for-call(f, sd)
+    | a-prim-app(_, f, args, _) => get-flatness-for-call(f, sd)
 
       # May check unknown annotations, so is nonflat
     | a-update(_, supe, fields) => none

--- a/src/arr/compiler/type-check.arr
+++ b/src/arr/compiler/type-check.arr
@@ -552,7 +552,7 @@ fun _checking(e :: Expr, expect-type :: Type, top-level :: Boolean, context :: C
           raise("checking for s-construct not implemented")
         | s-app(l, _fun, args) =>
           check-synthesis(e, expect-type, top-level, context)
-        | s-prim-app(l, _fun, args) =>
+        | s-prim-app(l, _fun, args, _) =>
           check-synthesis(e, expect-type, top-level, context)
         | s-prim-val(l, name) =>
           raise("checking for s-prim-val not implemented")
@@ -800,9 +800,9 @@ fun _synthesis(e :: Expr, top-level :: Boolean, context :: Context) -> TypingRes
         .typing-bind(lam(fun-type, shadow context):
           synthesis-spine(fun-type, A.s-app(l, _fun, _), args, l, context)
         end)
-    | s-prim-app(l, _fun, args) =>
+    | s-prim-app(l, _fun, args, app-info) =>
       lookup-id(l, _fun, e, context).typing-bind(lam(arrow-type, shadow context):
-        synthesis-spine(arrow-type, A.s-prim-app(l, _fun, _), args, l, context)
+        synthesis-spine(arrow-type, A.s-prim-app(l, _fun, _, app-info), args, l, context)
           .map-type(_.set-loc(l))
       end)
     | s-prim-val(l, name) =>

--- a/src/arr/compiler/well-formed.arr
+++ b/src/arr/compiler/well-formed.arr
@@ -1153,8 +1153,8 @@ top-level-visitor = A.default-iter-visitor.{
       well-formed-visitor.s-app(l, _fun, args)
     end
   end,
-  method s-prim-app(_, l :: Loc, _fun :: String, args :: List<A.Expr>):
-    well-formed-visitor.s-prim-app(l, _fun, args)
+  method s-prim-app(_, l :: Loc, _fun :: String, args :: List<A.Expr>, app-info :: A.PrimAppInfo):
+    well-formed-visitor.s-prim-app(l, _fun, args, app-info)
   end,
   method s-frac(_, l :: Loc, num, den):
     well-formed-visitor.s-frac(l, num, den)

--- a/src/arr/trove/contracts.arr
+++ b/src/arr/trove/contracts.arr
@@ -55,6 +55,40 @@ data FieldFailure:
 end
 
 data FailureReason:
+  | bad-bracket-target(loc, obj) with:
+    method render-fancy-reason(self, loc, from-fail-arg, maybe-stack-loc, src-available, maybe-ast):
+      obj-loc = if src-available(loc):
+        cases(O.Option) maybe-ast(loc):
+          | some(ast) =>
+            if ast.label() == "s-bracket": ast.obj.l
+            else: loc
+            end
+          | none => loc
+        end
+      else: loc
+      end
+      [ED.error:
+        [ED.para:
+          ED.text("A "), ED.highlight(ED.text("bracket expression"), [ED.locs: self.loc], 0),
+          ED.text(" only works with "),
+          ED.code(ED.text("Row")), ED.text("s, "),
+          ED.code(ED.text("StringDict")), ED.text("s, or values that define a "),
+          ED.code(ED.text("get-value")), ED.text(" method.")],
+        ED.cmcode(self.loc),
+        [ED.para: ED.text("The bracket expression's "),
+          ED.highlight(ED.text("target"), [ED.locs: obj-loc], 1), ED.text(" was:")],
+        [ED.para: ED.embed(self.obj)]]
+    end,
+    method render-reason(self, loc, from-fail-arg):
+      [ED.error:
+        [ED.para:
+          ED.text("The bracket expression at "), draw-and-highlight(self.loc),
+          ED.text(" only works with "),
+          ED.code(ED.text("Row")), ED.text("s, "),
+          ED.code(ED.text("StringDict")), ED.text("s, or values that define a "),
+          ED.code(ED.text("get-value")), ED.text(" method.  The value was:")],
+        [ED.para: ED.embed(self.obj)]]
+    end
   | failure-at-arg(loc, index, function-name, args, reason) with:
     method render-fancy-reason(self, loc, from-fail-arg, maybe-stack-loc, src-available, maybe-ast):
       cases(O.Option) maybe-stack-loc(0, true):
@@ -62,16 +96,23 @@ data FailureReason:
           if src-available(app-loc):
             cases(O.Option) maybe-ast(app-loc):
               | some(ast) =>
+                ast-label = ast.label()
+                {nth-arg; call-type} = ask:
+                  | ast-label == "s-bracket" then:
+                    {if self.index == 0: ast.obj else: ast.key end; "bracket expression"}
+                  | otherwise:
+                    {ast.args.get(self.index); "function application"}
+                end
                 [ED.error:
                   [ED.para:
                     ED.text("The "),
-                    ED.highlight(ED.text("function application"), [ED.locs: app-loc], -1)],
+                    ED.highlight(ED.text(call-type), [ED.locs: app-loc], -1)],
                    ED.cmcode(app-loc),
                   [ED.para:
                     ED.text("failed because the "),
                     ED.highlight(
                       [ED.sequence: ED.ed-nth(self.index + 1), ED.text(" argument")], 
-                      [ED.locs: ast.args.get(self.index).l], 0),
+                      [ED.locs: nth-arg.l], 0),
                     ED.text(" evaluated to an unexpected value.")],
                   self.reason.render-fancy-reason(loc, false, maybe-stack-loc, src-available, maybe-ast)]
               | none      =>
@@ -114,9 +155,8 @@ data FailureReason:
           ED.text(" : The argument at position " + tostring(self.index + 1)),
           ED.text(" was invalid because: ")],
         self.reason.render-reason(loc, from-fail-arg),
-        [ED.para:
-          ED.text("The other arguments were:"),
-          ED.h-sequence-sep(L.map(ED.embed, self.args), " ", " and ")]]
+        [ED.para: ED.text("The other arguments were:")],
+        [ED.para: ED.h-sequence-sep(L.map(ED.embed, self.args), " ", " and ")]]
     end
   | ref-init(loc, reason :: FailureReason) with:
     method render-fancy-reason(self, loc, from-fail-arg, maybe-stack-loc, src-available, maybe-ast) block:

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -476,13 +476,17 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
     function getBracket(loc, obj, field) {
       checkArityC(loc, 3, arguments, false);
       if (obj && obj.dict && obj.dict["get-value"]) {
-        return getFieldLoc(obj, "get-value", loc).app(field);
-      } else {
-        raiseJSJS(
-          thisRuntime.ffi.contractFail(
-            makeSrcloc(loc),
-            thisRuntime.ffi.makeBadBracketException(makeSrcloc(loc), obj)));
+        var gV = getColonFieldLoc(obj, "get-value", loc);
+        if (thisRuntime.isMethod(gV)) {
+          return gV.full_meth(obj, field);
+        } else if (thisRuntime.isFunction(gV)) {
+          return gV.app(field);
+        }
       }
+      raiseJSJS(
+        thisRuntime.ffi.contractFail(
+          makeSrcloc(loc),
+          thisRuntime.ffi.makeBadBracketException(makeSrcloc(loc), obj)));
     }
 
     function getMaker(obj, makerField, exprLoc, constrLoc) {

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -234,10 +234,8 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         }
         var headers = thisRuntime.getField(val, "headers");
         var rowVals = thisRuntime.getField(val, "values");
-        console.log("Before: ", headers, rowVals);
         headers = headers.map(function(h){ return renderValueSkeleton(h, values); });
         rowVals = rowVals.map(function(v) { return renderValueSkeleton(v, values); });
-        console.log("After:", headers, rowVals);
         var row = [];
         for (var i = 0; i < headers.length; i++) {
           row.push(headers[i]);
@@ -473,6 +471,18 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
 
     function getField(obj, field) {
       return thisRuntime.getFieldLoc(obj, field, ["runtime"]);
+    }
+
+    function getBracket(loc, obj, field) {
+      checkArityC(loc, 3, arguments, false);
+      if (obj && obj.dict && obj.dict["get-value"]) {
+        return getFieldLoc(obj, "get-value", loc).app(field);
+      } else {
+        raiseJSJS(
+          thisRuntime.ffi.contractFail(
+            makeSrcloc(loc),
+            thisRuntime.ffi.makeBadBracketException(makeSrcloc(loc), obj)));
+      }
     }
 
     function getMaker(obj, makerField, exprLoc, constrLoc) {
@@ -5696,6 +5706,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'getFieldLoc'      : getFieldLoc,
       'getFieldRef'      : getFieldRef,
       'getFields'        : getFields,
+      'getBracket'       : getBracket,
       'getColonField'    : getColonField,
       'getColonFieldLoc' : getColonFieldLoc,
       'getTuple'         : getTuple,
@@ -6029,6 +6040,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         'getDotAnn': 'gDA',
         'getField': 'gF',
         'getFieldRef': 'gFR',
+        'getBracket': 'gB',
         'hasBrand': 'hB',
         'isActivationRecord': 'isAR',
         'isCont': 'isC',

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -480,6 +480,12 @@
       return err("module-load-failure")(namesList);
     }
 
+    function makeBadBracketException(loc, val) {
+      runtime.checkPyretVal(val);
+      return contract("bad-bracket-target")(loc, val);
+    }
+    
+    
     function makeRecordFieldsFail(value, failures) {
       runtime.checkPyretVal(value);
       return contract("record-fields-fail")(value, failures);
@@ -625,6 +631,7 @@
       throwParseErrorBadOper: throwParseErrorBadOper,
       throwParseErrorBadCheckOper: throwParseErrorBadCheckOper,
 
+      makeBadBracketException: makeBadBracketException,
       makeRecordFieldsFail: makeRecordFieldsFail,
       makeTupleAnnsFail: makeTupleAnnsFail,
       makeFieldFailure: makeFieldFailure,

--- a/src/js/trove/table.js
+++ b/src/js/trove/table.js
@@ -25,8 +25,8 @@
 
     var rowGetValue = runtime.makeMethod1(function(self, arg) {
         ffi.checkArity(2, arguments, "get-value", true);
-        runtime.checkArgsInternal1("tables", "get-value",
-          arg, runtime.String);
+        runtime.checkArgsInternal2("tables", "get-value",
+          self, annRow, arg, runtime.String);
         var index = self.$underlyingTable.headerIndex["column:" + arg];
         if(typeof index === "number") {
           return self.$rowData[index];
@@ -340,31 +340,31 @@
         '_header-raw-array': headers,
         '_rows-raw-array': rows,
 
-        'increasing-by': runtime.makeMethod1(function(_, colname) {
+        'increasing-by': runtime.makeMethod1(function(self, colname) {
           ffi.checkArity(2, arguments, "increasing-by", true);
-          runtime.checkArgsInternal1("tables", "increasing-by",
-            colname, runtime.String);
+          runtime.checkArgsInternal2("tables", "increasing-by",
+            self, annTable, colname, runtime.String);
           return order(true, colname);
         }),
-        'decreasing-by': runtime.makeMethod1(function(_, colname) {
+        'decreasing-by': runtime.makeMethod1(function(self, colname) {
           ffi.checkArity(2, arguments, "decreasing-by", true);
-          runtime.checkArgsInternal1("tables", "decreasing-by",
-            colname, runtime.String);
+          runtime.checkArgsInternal2("tables", "decreasing-by",
+            self, annTable, colname, runtime.String);
           return order(false, colname);
         }),
-        'order-by': runtime.makeMethod2(function(_, colname, increasing) {
+        'order-by': runtime.makeMethod2(function(self, colname, increasing) {
           ffi.checkArity(3, arguments, "order-by", true);
-          runtime.checkArgsInternal2("tables", "order-by",
-            colname, runtime.String, increasing, runtime.Boolean);
+          runtime.checkArgsInternal3("tables", "order-by",
+            self, annTable, colname, runtime.String, increasing, runtime.Boolean);
           if(!hasColumn(colname)) {
             ffi.throwMessageException("The table does not have a column named `"+colname+"`.");
           }
           return order(increasing, colname);
         }),
-        'order-by-columns': runtime.makeMethod1(function(_, specs) {
+        'order-by-columns': runtime.makeMethod1(function(self, specs) {
           ffi.checkArity(2, arguments, "order-by-columns", true);
-          runtime.checkArgsInternal1("tables", "order-by-columns",
-            specs, runtime.List);
+          runtime.checkArgsInternal2("tables", "order-by-columns",
+            self, annTable, specs, runtime.List);
           var specsArray = ffi.toArray(specs);
           var asArrays = [];
           for(var i = 0; i < specsArray.length; i += 1) {
@@ -385,10 +385,10 @@
           }, "order-by-columns");
         }),
 
-        'multi-order': runtime.makeMethod1(function(_, colComps) {
+        'multi-order': runtime.makeMethod1(function(self, colComps) {
           ffi.checkArity(2, arguments, "multi-order", true);
-          runtime.checkArgsInternal1("tables", "multi-order",
-            colComps, runtime.RawArray);
+          runtime.checkArgsInternal2("tables", "multi-order",
+            self, annTable, colComps, runtime.RawArray);
           // colComps is an array of 2-element arrays, [true iff ascending, colName]
           for(var i = 0; i < colComps.length; i += 1) {
             var colname = colComps[i][1];
@@ -403,10 +403,10 @@
           }, "multi-order");
         }),
 
-        'add-column': runtime.makeMethod2(function(_, colname, eltList) {
+        'add-column': runtime.makeMethod2(function(self, colname, eltList) {
           ffi.checkArity(3, arguments, "add-column", true);
-          runtime.checkArgsInternal2("tables", "add-column",
-            colname, runtime.String, eltList, runtime.List);
+          runtime.checkArgsInternal3("tables", "add-column",
+            self, annTable, colname, runtime.String, eltList, runtime.List);
           if(hasColumn(colname)) {
             throw runtime.ffi.throwMessageException("column-name-exists");
           }
@@ -423,9 +423,9 @@
           return makeTable(headers.concat([colname]), newRows);
         }),
 
-        'add-row': runtime.makeMethod1(function(_, row) {
+        'add-row': runtime.makeMethod1(function(self, row) {
           ffi.checkArity(2, arguments, 'add-row', true);
-          runtime.checkArgsInternal1("tables", "add-row", row, annRow);
+          runtime.checkArgsInternal2("tables", "add-row", self, annTable, row, annRow);
           var theseKeys = Object.keys(headerIndex);
           var rowKeys = Object.keys(row.$underlyingTable.headerIndex);
           if(theseKeys.length !== rowKeys.length) {
@@ -447,9 +447,9 @@
           return makeTable(headers, newRows);
         }),
 
-        'row-n': runtime.makeMethod1(function(_, row) {
+        'row-n': runtime.makeMethod1(function(self, row) {
           ffi.checkArity(2, arguments, "row-n", true);
-          runtime.checkArgsInternal1("tables", "row-n", row, runtime.NumInteger);
+          runtime.checkArgsInternal2("tables", "row-n", self, annTable, row, runtime.NumInteger);
           runtime.checkNumNonNegative(row); // NOTE(Ben): These should be converted to a call to checkArgsInternal
           var rowFix = runtime.num_to_fixnum(row);
           if(rowFix >= rows.length) {
@@ -468,10 +468,10 @@
         }),
 
 
-        'column': runtime.makeMethod1(function(_, colname) {
+        'column': runtime.makeMethod1(function(self, colname) {
           ffi.checkArity(2, arguments, "column", true);
-          runtime.checkArgsInternal1("tables", "column",
-            colname, runtime.String);
+          runtime.checkArgsInternal2("tables", "column",
+            self, annTable, colname, runtime.String);
           var lookupName = "column:" + colname;
           if(!(lookupName in headerIndex)) {
             throw runtime.ffi.throwMessageException("no-such-column");
@@ -482,9 +482,9 @@
           return runtime.ffi.makeList(results);
         }),
 
-        'column-n': runtime.makeMethod1(function(_, n) {
+        'column-n': runtime.makeMethod1(function(self, n) {
           ffi.checkArity(2, arguments, "column-n", true);
-          runtime.checkArgsInternal1("tables", "column-n", n, runtime.NumInteger);
+          runtime.checkArgsInternal2("tables", "column-n", self, annTable, n, runtime.NumInteger);
           runtime.checkNumNonNegative(n); // NOTE(Ben): These should be converted to checkArgsInternal1
           var lookupIndex = runtime.num_to_fixnum(n);
           if(lookupIndex >= headers.length) {
@@ -515,9 +515,9 @@
           return runtime.ffi.makeList(headers);
         }),
 
-        'stack': runtime.makeMethod1(function(_, otherTable) {
+        'stack': runtime.makeMethod1(function(self, otherTable) {
           ffi.checkArity(2, arguments, "stack", true);
-          runtime.checkArgsInternal1("tables", "stack", otherTable, annTable);
+          runtime.checkArgsInternal1("tables", "stack", self, annTable, otherTable, annTable);
           var otherHeaders = runtime.getField(otherTable, "_header-raw-array");
           if(otherHeaders.length !== headers.length) {
             return ffi.throwMessageException("Tables have different column sizes in stack: " + headers.length + " " + otherHeaders.length);
@@ -542,9 +542,10 @@
           return makeTable(headers, rows.concat(newRows));
         }),
 
-        'reduce': runtime.makeMethod2(function(_, colname, reducer) {
+        'reduce': runtime.makeMethod2(function(self, colname, reducer) {
           ffi.checkArity(3, arguments, "reduce", true);
-          runtime.checkArgsInternal2("tables", "reduce",
+          runtime.checkArgsInternal3("tables", "reduce",
+                                     self, annTable,
                                      colname, runtime.String,
                                      reducer, runtime.Object);
           if(rows.length === 0) { ffi.throwMessageException("Reducing an empty table (column names were " + headers.join(", ") + ")"); }
@@ -574,10 +575,10 @@
           return makeTable(headers, []);
         }),
 
-        'drop': runtime.makeMethod1(function(_, colname) {
+        'drop': runtime.makeMethod1(function(self, colname) {
           ffi.checkArity(2, arguments, "drop", true);
           runtime.checkArgsInternal1("tables", "drop",
-            colname, runtime.String);
+            self, annTable, colname, runtime.String);
           var newHeaders = headers.filter(function(h) { return h !== colname; })
           var newRows = rows.map(function(rawRow) {
             return rawRow.filter(function(h, i) {
@@ -588,10 +589,10 @@
         }),
 
 
-        'build-column': runtime.makeMethod1(function(_, colname, func) {
+        'build-column': runtime.makeMethod1(function(self, colname, func) {
           ffi.checkArity(3, arguments, "build-column", true);
-          runtime.checkArgsInternal2("tables", "build-column",
-            colname, runtime.String, func, runtime.Function);
+          runtime.checkArgsInternal3("tables", "build-column",
+            self, annTable, colname, runtime.String, func, runtime.Function);
 
           if(hasColumn(colname)) {
             ffi.throwMessageException("build-column: tried adding the column " + colname + " but it already exists (existing column names were " + headers.join(", ") + ")");
@@ -614,10 +615,10 @@
           }, "table-add-column");
         }),
 
-        'filter-by': runtime.makeMethod2(function(_, colname, pred) {
+        'filter-by': runtime.makeMethod2(function(self, colname, pred) {
           ffi.checkArity(3, arguments, "filter-by", true);
-          runtime.checkArgsInternal2("tables", "filter-by",
-            colname, runtime.String, pred, runtime.Function);
+          runtime.checkArgsInternal3("tables", "filter-by",
+            self, annTable, colname, runtime.String, pred, runtime.Function);
           if(!(("column:" + colname) in headerIndex)) {
             throw runtime.ffi.throwMessageException("no-such-column");
           }
@@ -632,10 +633,10 @@
         }),
 
 
-        'filter': runtime.makeMethod1(function(_, pred) {
+        'filter': runtime.makeMethod1(function(self, pred) {
           ffi.checkArity(2, arguments, "filter", true);
-          runtime.checkArgsInternal1("tables", "filter",
-            pred, runtime.Function);
+          runtime.checkArgsInternal2("tables", "filter",
+            self, annTable, pred, runtime.Function);
           var wrappedPred = function(rawRow) {
             return pred.app(makeRow({ headerIndex: headerIndex }, rawRow));
           }
@@ -651,20 +652,20 @@
           return runtime.makeNumber(rows.length);
         }),
         
-        'get-column': runtime.makeMethod1(function(_, col_name) {
+        'get-column': runtime.makeMethod1(function(self, col_name) {
           ffi.checkArity(2, arguments, "get-column", true);
-          runtime.checkArgsInternal1("tables", "get-column",
-            col_name, runtime.String);
+          runtime.checkArgsInternal2("tables", "get-column",
+            self, annTable, col_name, runtime.String);
           if(!hasColumn(col_name)) {
             ffi.throwMessageException("The table does not have a column named `"+col_name+"`.");
           }
           return runtime.ffi.makeList(getColumn(col_name));
         }),
 
-        'select-columns': runtime.makeMethod1(function(_, colnames) {
+        'select-columns': runtime.makeMethod1(function(self, colnames) {
           ffi.checkArity(2, arguments, "select-columns", true);
-          runtime.checkArgsInternal1("tables", "select-columns",
-            colnames, runtime.List);
+          runtime.checkArgsInternal2("tables", "select-columns",
+            self, annTable, colnames, runtime.List);
 
           var colnamesList = ffi.toArray(colnames);
           if(colnamesList.length === 0) {

--- a/tests/pyret/test-compile-helper.arr
+++ b/tests/pyret/test-compile-helper.arr
@@ -125,6 +125,18 @@ end
 
 contract-error = { success: false, runtime: true, check-errors: check-contract-error }
 
+fun contract-error-contains(check-err):
+  { success: false,
+    runtime: true,
+    check-errors:
+      lam(errors):
+        msg = L.render-error-message(errors).message
+        string-contains(msg, check-err)
+      end
+  }
+end
+  
+
 fun field-error(fields):
   { success: false,
     runtime: true,

--- a/tests/pyret/tests/test-contracts.arr
+++ b/tests/pyret/tests/test-contracts.arr
@@ -11,6 +11,7 @@ run-to-result = CH.run-to-result
 run-str = CH.run-str
 output = CH.output
 contract-error = CH.contract-error
+contract-error-contains = CH.contract-error-contains
 compile-error = CH.compile-error
 success = CH.success
 
@@ -441,6 +442,18 @@ check "standalone contract statements":
     ```
     foo :: <A, B>(x :: A) -> B
     fun foo<A, B>(x): 5 end
-    ```) is%(output) success  
+    ```) is%(output) success
+
+  run-str("{get-value: 4}[3]") is%(output) contract-error-contains("The bracket expression at")
+  run-str("5[3]") is%(output) contract-error-contains("The bracket expression at")
+  run-str(
+    ```
+    fun want-row(r): r["a"] end
+    want-row(table: a row: 1 end)
+    ```) is%(output) contract-error-contains("The bracket expression at")
+  run-str(
+    ```
+    table: a row: 1 end.row-n(0)["a"]
+    ```) is%(output) success
 end
 


### PR DESCRIPTION
… prim-app.  This fixes #1307.

The concept of a non-flat prim-app is of broader utility: it allows us to define operations as primitive runtime functions that nevertheless might fail, and so they requires a step in compiled output.  (Several other things could be refactored to use non-flat prim-apps too, which currently are compiled via clunkier workarounds with methods and such.)