### PR TITLE
New feature: creating a directory tree

### DIFF
--- a/src/js/trove/string-dict.js
+++ b/src/js/trove/string-dict.js
@@ -1414,7 +1414,9 @@
     };
     var internal = {
       checkISD: jsCheckISD,
-      checkMSD: jsCheckMSD
+      checkMSD: jsCheckMSD,
+      isISD:    isImmutableStringDict,
+      isMSD:    isMutableStringDict
     };
     return runtime.makeModuleReturn(vals, types, internal);
   }


### PR DESCRIPTION
Implements a new method `create-dir-tree`, which is like `mkdir -p` but enhanced.  Given a base directory, and a string-dict of string-dicts of ..., where the innermost string-dicts' values are irrelevant, build a directory tree whose nesting structure corresponds to the keys of the string-dicts.