### PR TITLE
Move Source Line FFI helpers

### DIFF
--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -16,6 +16,7 @@
   nativeRequires: [],
   theModule: function(runtime, namespace, uri, L, Se, O, E, EQ, ERR, S, CON, /* CH, */ ED, VS) {
     var gf = runtime.getField;
+    var srcloc = runtime.getField(S, "values");
     L = gf(L, "values");
     Se = gf(Se, "values");
     O = gf(O, "values");
@@ -38,6 +39,31 @@
         lst = lnk(arr[i], lst);
       }
       return lst;
+    }
+
+    function makePyretPos(fileName, p) {
+      var n = runtime.makeNumber;
+      return runtime.getField(srcloc, "srcloc").app(
+        runtime.makeString(fileName),
+        n(p.startRow),
+        n(p.startCol),
+        n(p.startChar),
+        n(p.endRow),
+        n(p.endCol),
+        n(p.endChar)
+      );
+    }
+    function combinePyretPos(fileName, p1, p2) {
+      var n = runtime.makeNumber;
+      return runtime.getField(srcloc, "srcloc").app(
+        runtime.makeString(fileName),
+        n(p1.startRow),
+        n(p1.startCol),
+        n(p1.startChar),
+        n(p2.endRow),
+        n(p2.endCol),
+        n(p2.endChar)
+      );
     }
 
     function makeTreeSet(arr) {
@@ -573,6 +599,8 @@
     runtime.makePrimAnn("List", isList);
 
     return runtime.makeJSModuleReturn({
+      makePyretPos : makePyretPos,
+      combinePyretPos : combinePyretPos,
       throwUpdateNonObj : throwUpdateNonObj,
       throwUpdateFrozenRef : throwUpdateFrozenRef,
       throwUpdateNonRef : throwUpdateNonRef,

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -16,7 +16,6 @@
   nativeRequires: [],
   theModule: function(runtime, namespace, uri, L, Se, O, E, EQ, ERR, S, CON, /* CH, */ ED, VS) {
     var gf = runtime.getField;
-    var srcloc = runtime.getField(S, "values");
     L = gf(L, "values");
     Se = gf(Se, "values");
     O = gf(O, "values");
@@ -43,7 +42,7 @@
 
     function makePyretPos(fileName, p) {
       var n = runtime.makeNumber;
-      return runtime.getField(srcloc, "srcloc").app(
+      return runtime.getField(S, "srcloc").app(
         runtime.makeString(fileName),
         n(p.startRow),
         n(p.startCol),
@@ -55,7 +54,7 @@
     }
     function combinePyretPos(fileName, p1, p2) {
       var n = runtime.makeNumber;
-      return runtime.getField(srcloc, "srcloc").app(
+      return runtime.getField(S, "srcloc").app(
         runtime.makeString(fileName),
         n(p1.startRow),
         n(p1.startCol),

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -17,31 +17,11 @@
     var link = RUNTIME.getField(lists, "link");
     var empty = RUNTIME.getField(lists, "empty");
 
+    var makePyretPos = RUNTIME.ffi.makePyretPos;
+    var combinePyretPos = RUNTIME.ffi.combinePyretPos;
+
     //var data = "#lang pyret\n\nif (f(x) and g(y) and h(z) and i(w) and j(u)): true else: false end";
-    function makePyretPos(fileName, p) {
-      var n = RUNTIME.makeNumber;
-      return RUNTIME.getField(srcloc, "srcloc").app(
-        RUNTIME.makeString(fileName),
-        n(p.startRow),
-        n(p.startCol),
-        n(p.startChar),
-        n(p.endRow),
-        n(p.endCol),
-        n(p.endChar)
-      );
-    }
-    function combinePyretPos(fileName, p1, p2) {
-      var n = RUNTIME.makeNumber;
-      return RUNTIME.getField(srcloc, "srcloc").app(
-        RUNTIME.makeString(fileName),
-        n(p1.startRow),
-        n(p1.startCol),
-        n(p1.startChar),
-        n(p2.endRow),
-        n(p2.endCol),
-        n(p2.endChar)
-      );
-    }
+    
     function isSignedNumberAsStmt(stmt) {
       var node = stmt;
       if (node.name !== "stmt") return false;       node = node.kids[0];


### PR DESCRIPTION
Move the Source Line FFI helpers from parse-pyret.js to ffi.js

As far as I can tell, error data types expect a transformed source line data structure. As I am writing other error checking modules partially in Javascript, it would be useful to have these helpers available in general.