### PR TITLE
Expose num_to_roughnum from runtime

### DIFF
--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -5912,6 +5912,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'num_to_string': num_tostring,
       'num_tostring_digits': num_tostring_digits,
       'num_to_fixnum': num_to_fixnum,
+      'num_to_roughnum': num_to_roughnum,
 
       'string_contains': string_contains,
       'string_append': string_append,


### PR DESCRIPTION
This PR exposes the `num_to_roughnum` function on the Pyret runtime.

This function is heavily used in the TensorFlow addition (see brownplt/code.pyret.org#287), but should be relatively easy to swap out if there are better alternatives. There might be a better way to create Roughnums from a JavaScript library that I'm missing, so let me know if this is unnecessary.