### PR TITLE
Add parser-interface, a separate location for defining parser error passes

### DIFF
--- a/src/arr/compiler/compile-lib.arr
+++ b/src/arr/compiler/compile-lib.arr
@@ -2,7 +2,7 @@ provide *
 provide-types *
 
 import either as E
-import parse-pyret as P
+import parser-interface as P
 import ast as A
 import load-lib as L
 import render-error-display as RED

--- a/src/arr/compiler/locators/builtin.arr
+++ b/src/arr/compiler/locators/builtin.arr
@@ -3,7 +3,7 @@ import builtin-modules as B
 import string-dict as SD
 import file as F
 import pathlib as P
-import parse-pyret as PP
+import parser-interface as PP
 import file("../compile-lib.arr") as CL
 import file("../compile-structs.arr") as CM
 import file("../type-structs.arr") as T

--- a/src/arr/compiler/locators/file.arr
+++ b/src/arr/compiler/locators/file.arr
@@ -1,7 +1,7 @@
 provide *
 
 import builtin-modules as B
-import parse-pyret as PP
+import parser-interface as PP
 import file("../compile-lib.arr") as CL
 import file("../compile-structs.arr") as CS
 import file("../js-of-pyret.arr") as JSP

--- a/src/arr/compiler/repl.arr
+++ b/src/arr/compiler/repl.arr
@@ -4,7 +4,7 @@ import ast as A
 import base as _
 import either as E
 import load-lib as L
-import parse-pyret as P
+import parser-interface as P
 import string-dict as SD
 import runtime-lib as R
 import sets as S

--- a/src/arr/compiler/resolve-scope.arr
+++ b/src/arr/compiler/resolve-scope.arr
@@ -4,7 +4,7 @@ provide *
 provide-types *
 import ast as A
 import srcloc as S
-import parse-pyret as PP
+import parser-interface as PP
 import string-dict as SD
 import lists as L
 import file("compile-structs.arr") as C

--- a/src/js/trove/parser-interface.js
+++ b/src/js/trove/parser-interface.js
@@ -1,0 +1,22 @@
+({
+  requires: [
+    { "import-type": "builtin", name: "parse-pyret" }
+  ],
+  nativeRequires: [],
+  provides: {},
+
+  theModule: function(RUNTIME, NAMESPACE, uri, parser) {
+    
+    // Plug in parser error passes here
+    function surfaceParse(data, filename) {
+      // NOTE: relies on internal module representation. Is there a better way to do this?
+      var parseFunction = parser.dict["defined-values"]["surface-parse"];
+
+      return parseFunction.app(data, filename);
+    }
+
+    return RUNTIME.makeModuleReturn({
+          'surface-parse': RUNTIME.makeFunction(surfaceParse, "surfaceParse"),
+        }, {});
+  }
+})


### PR DESCRIPTION
Add parser-interface.js, a central location where various parser error passes can be clearly added or removed.

Written in Javascript to avoid the stack traces automatically reported by Pyret's 'raise' keyword.

There are currently no parser error passes implemented.

As a side note, I could not get the FFI helper getField() to work on the module. If there's something I missed let me know.