### PR TITLE
Don't include redundant locs in wf-errors

### DIFF
--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -428,8 +428,7 @@ data CompileError:
     method render-reason(self):
       [ED.error:
         ED.paragraph([list: ED.highlight(ED.text("Well-formedness:"), [list: self.loc], 0), ED.text(" ")]
-            + self.msg),
-        ED.cmcode(self.loc)]
+            + self.msg)]
     end
   | wf-empty-block(loc :: A.Loc) with:
     method render-fancy-reason(self):


### PR DESCRIPTION
Fixes #1436

No tests included because the test suite seems to check that `C.wf-err`s are thrown, but not their specific contents. Happy to find a way include tests if y'all want them

Example of an error message now:

> Well-formedness: (at file:///Users/ben/src/pyret-lang/build/t.arr:2:2-2:9) A standalone variable name probably isn't intentional.

cc @blerner 