### PR TITLE
Fixing a very strange bug in the tokenizer for certain programs

### DIFF
--- a/src/js/base/pyret-tokenizer.js
+++ b/src/js/base/pyret-tokenizer.js
@@ -540,7 +540,7 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
           }
         }
         if (nestingDepth === 0) {
-          return this.makeWSToken("COMMENT", ""/*this.str.slice(pos, this.pos)*/, line, col, pos);
+          return this.makeWSToken(line, col, pos);
         } else {
           var ws_loc = SrcLoc.make(line, col, pos, this.curLine, this.curCol, this.pos);
           return this.makeToken("UNTERMINATED-BLOCK-COMMENT", this.str.slice(pos, this.pos), ws_loc, tok_spec);


### PR DESCRIPTION
```
import lists as L

#|  |#

#
```

This code was using the wrong signature for `makeWSToken`, so it wasn't passing in the correct srcloc positions.  (Thanks to Yanyan for finding this bug.)