### PR TITLE
Fixes #1407

### DIFF
--- a/src/arr/compiler/type-defaults.arr
+++ b/src/arr/compiler/type-defaults.arr
@@ -596,7 +596,7 @@ module-const-error = t-module("builtin://error",
       [list: ],
       [list:
         t-variant("parse-error-next-token", [list: {"loc"; t-top}, {"next-token"; t-string}], [string-dict: ]),
-        t-variant("parse-error-bad-check-operator", [list: {"loc"; t-top}, {"next-token"; t-string}], [string-dict: ]),
+        t-variant("parse-error-bad-check-operator", [list: {"op"; t-top}], [string-dict: ]),
         t-variant("parse-error-bad-operator", [list: {"loc"; t-top}, {"next-token"; t-string}], [string-dict: ]),
         t-variant("parse-error-bad-number", [list: {"loc"; t-top}, {"next-token"; t-string}], [string-dict: ]),
         t-variant("parse-error-eof", [list: {"loc"; t-top}], [string-dict: ]),

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -2592,28 +2592,44 @@ data ParseError:
           draw-and-highlight(self.loc),
           ED.text("; number literals in Pyret require at least one digit before the decimal point.")]]
     end
-  | parse-error-bad-check-operator(loc) with:
+  | parse-error-bad-check-operator(op) with:
     method render-fancy-reason(self, src-available):
-      if src-available(self.loc):
+      if src-available(self.op.l):
         [ED.error: 
           [ED.para:
             ED.text("The "),
-            ED.highlight(ED.text("testing operator"), [ED.locs: self.loc], 0)],
-          ED.cmcode(self.loc),
+            ED.highlight(ED.text("testing operator"), [ED.locs: self.op.l], 0)],
+          ED.cmcode(self.op.l),
           [ED.para:
             ED.text(" must be used inside a "),
             ED.code(ED.text("check")), ED.text(" or "), ED.code(ED.text("where")), ED.text(" block.")],
-          [ED.para:
-            ED.text("Did you mean to use one of the comparison operators instead?")]]
+          cases(Any) self.op:
+            | s-op-raises(_) =>
+              [ED.para:
+                ED.text("You may have been looking for the "), ED.code(ED.text("raise")),
+                ED.text(" operator, or perhaps you meant to use a comparison operator instead.")]
+            | else =>
+              [ED.para:
+                ED.text("Did you mean to use one of the comparison operators instead?")]
+          end
+        ]
       else:
         [ED.error: 
           [ED.para-nospace:
             ED.text("The testing operator at "),
-            ED.loc(self.loc),
+            ED.loc(self.op.l),
             ED.text(" must be used inside a "),
             ED.code(ED.text("check")), ED.text(" or "), ED.code(ED.text("where")), ED.text(" block.")],
-          [ED.para:
-            ED.text("Did you mean to use one of the comparison operators instead?")]]
+          cases(Any) self.op:
+            | s-raises(_) =>
+              [ED.para:
+                ED.text("You may have been looking for the "), ED.code(ED.text("raise")),
+                ED.text(" operator, or perhaps you meant to use a comparison operator instead.")]
+            | else =>
+              [ED.para:
+                ED.text("Did you mean to use one of the comparison operators instead?")]
+          end
+        ]
       end
     end,
     method render-reason(self):

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -1409,7 +1409,7 @@
           else if (nextTok.name === "COLONCOLON")
             RUNTIME.ffi.throwParseErrorColonColon(makePyretPos(fileName, nextTok.pos));
           else if (typeof opLookup[String(nextTok.value).trim()] === "function")
-            RUNTIME.ffi.throwParseErrorBadCheckOper(makePyretPos(fileName, nextTok.pos));
+            RUNTIME.ffi.throwParseErrorBadCheckOper(opLookup[String(nextTok.value).trim()](makePyretPos(fileName, nextTok.pos)));
           else
             RUNTIME.ffi.throwParseErrorNextToken(makePyretPos(fileName, nextTok.pos), nextTok.value || nextTok.toString(true));
         }


### PR DESCRIPTION
Tracking the actual bad test operator through to the error message, so we can give a distinct error message for `raises` vs `raise` (and potentially other operators later, if needed)