### PR TITLE
Avoiding an unwanted crash in the scenario of #1405

### DIFF
--- a/src/arr/compiler/well-formed.arr
+++ b/src/arr/compiler/well-formed.arr
@@ -313,7 +313,7 @@ fun reachable-ops(self, l, op-l, op, ast):
   end
 end
 
-fun reject-standalone-exprs(stmts :: List%(is-link), ignore-last :: Boolean) block:
+fun reject-standalone-exprs(stmts :: List, ignore-last :: Boolean) block:
   to-examine = if ignore-last:
     # Ignore the last statement, because it might well be an expression
     stmts.reverse().rest.reverse()


### PR DESCRIPTION
```
fun foo():
  5
where:
end
```

caused the `%(is-link)` annotation to fail, so that we couldn't even display the intended well-formedness errors.