### PR TITLE
Attempting to give a better error message for function calls with spaces in them

### DIFF
--- a/src/arr/compiler/ast-util.arr
+++ b/src/arr/compiler/ast-util.arr
@@ -68,44 +68,6 @@ fun wrap-if-needed(exp :: A.Expr) -> A.Expr:
   end
 end
 
-fun unwrap-if-wrapped(exp :: A.Expr) -> A.Expr:
-  cases(A.Expr) exp:
-    | s-app(_, f, args) =>
-      cases(A.Expr) f:
-        | s-dot(_, obj, field) =>
-          cases(A.Expr) obj:
-            | s-id(_, name) =>
-              cases(A.Name) name:
-                | s-name(_, ident) =>
-                  if (ident == "builtins") and (field == "trace-value"):
-                    cases(List) args:
-                      | link(loc, rest) =>
-                        cases(List) rest:
-                          | link(arg, tail) =>
-                            if A.is-s-srcloc(loc) and L.is-empty(tail):
-                              arg
-                            else:
-                              exp
-                            end
-                          | else =>
-                            exp
-                        end
-                      | else =>
-                        exp
-                    end
-                  else:
-                    exp
-                  end
-                | else => exp
-              end
-            | else => exp
-          end
-        | else => exp
-      end
-    | else => exp
-  end
-end
-
 fun wrap-toplevels(prog :: A.Program) -> A.Program:
   cases(A.Program) prog:
     | s-program(l1, _prov, _prov-types, provides, imps, body) =>

--- a/src/arr/compiler/ast-util.arr
+++ b/src/arr/compiler/ast-util.arr
@@ -68,6 +68,44 @@ fun wrap-if-needed(exp :: A.Expr) -> A.Expr:
   end
 end
 
+fun unwrap-if-wrapped(exp :: A.Expr) -> A.Expr:
+  cases(A.Expr) exp:
+    | s-app(_, f, args) =>
+      cases(A.Expr) f:
+        | s-dot(_, obj, field) =>
+          cases(A.Expr) obj:
+            | s-id(_, name) =>
+              cases(A.Name) name:
+                | s-name(_, ident) =>
+                  if (ident == "builtins") and (field == "trace-value"):
+                    cases(List) args:
+                      | link(loc, rest) =>
+                        cases(List) rest:
+                          | link(arg, tail) =>
+                            if A.is-s-srcloc(loc) and L.is-empty(tail):
+                              arg
+                            else:
+                              exp
+                            end
+                          | else =>
+                            exp
+                        end
+                      | else =>
+                        exp
+                    end
+                  else:
+                    exp
+                  end
+                | else => exp
+              end
+            | else => exp
+          end
+        | else => exp
+      end
+    | else => exp
+  end
+end
+
 fun wrap-toplevels(prog :: A.Program) -> A.Program:
   cases(A.Program) prog:
     | s-program(l1, _prov, _prov-types, provides, imps, body) =>

--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -1866,7 +1866,7 @@ data CompileError:
           ED.text(".")],
         [ED.para: ED.text("Pick a different name for one of them.")]]
     end
-  | same-line(a :: Loc, b :: Loc) with:
+  | same-line(a :: Loc, b :: Loc, b-is-paren :: Boolean) with:
     method render-fancy-reason(self):
       [ED.error:
         [ED.para:
@@ -1875,8 +1875,16 @@ data CompileError:
           ED.highlight(ED.text("another expression"), [list: self.b], 1),
           ED.text(":")],
         ED.cmcode(self.a + self.b),
-        [ED.para:
-          ED.text("Each expression within a block should be on its own line.")]]
+        if self.b-is-paren:
+          [ED.para:
+            ED.text("Each expression within a block should be on its own line.  "),
+            ED.text("If you meant to write a function call, there should be no space between the "),
+            ED.highlight(ED.text("function expression"), [list: self.a], 0),
+            ED.text(" and the "), ED.highlight(ED.text("arguments"), [list: self.b], 1), ED.text(".")]
+        else:
+          [ED.para:
+            ED.text("Each expression within a block should be on its own line.")]
+        end]
     end,
     method render-reason(self):
       [ED.error:

--- a/src/arr/compiler/well-formed.arr
+++ b/src/arr/compiler/well-formed.arr
@@ -4,6 +4,7 @@ provide {
 provide-types *
 
 import ast as A
+import file("ast-util.arr") as AU
 import srcloc as SL
 import error-display as ED
 import file("compile-structs.arr") as C
@@ -240,7 +241,7 @@ fun ensure-distinct-lines(loc :: Loc, prev-is-template :: Boolean, stmts :: List
                 if A.is-s-template(first) and prev-is-template:
                   add-error(C.template-same-line(loc, first.l))
                 else if not(A.is-s-template(first)) and not(prev-is-template):
-                  add-error(C.same-line(loc, first.l))
+                  add-error(C.same-line(loc, first.l, A.is-s-paren(AU.unwrap-if-wrapped(first))))
                 else:
                   nothing
                 end

--- a/src/arr/compiler/well-formed.arr
+++ b/src/arr/compiler/well-formed.arr
@@ -241,7 +241,7 @@ fun ensure-distinct-lines(loc :: Loc, prev-is-template :: Boolean, stmts :: List
                 if A.is-s-template(first) and prev-is-template:
                   add-error(C.template-same-line(loc, first.l))
                 else if not(A.is-s-template(first)) and not(prev-is-template):
-                  add-error(C.same-line(loc, first.l, A.is-s-paren(AU.unwrap-if-wrapped(first))))
+                  add-error(C.same-line(loc, first.l, A.is-s-paren(first)))
                 else:
                   nothing
                 end

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -2467,7 +2467,8 @@ data ParseError:
             ED.text("Pyret thinks this code is probably a function header:")],
           ED.cmcode(self.a),
           [ED.para:
-            ED.text("Function header must not have space before the "),
+            ED.highlight(ED.text("Function headers"), [ED.locs: self.a], -1),
+            ED.text(" must not have space before the "),
             ED.highlight(ED.text("arguments"), [ED.locs: self.b], 0),
             ED.text(".")]]
       else:
@@ -2482,8 +2483,8 @@ data ParseError:
       [ED.error:
         [ED.para:
           ED.text("Pyret thinks the code at "), ED.loc(self.a + self.b),
-          ED.text(" is probably a function call, but there should be no space"),
-          ED.text(" between the function and its arguments.")]]
+          ED.text(" is probably a function header, but there should be no space"),
+          ED.text(" between the arguments.")]]
     end
   | parse-error-next-token(loc, next-token :: String) with:
     method render-fancy-reason(self, src-available):

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -2431,6 +2431,34 @@ data RuntimeError:
 end
 
 data ParseError:
+  | parse-error-bad-app(a, b) with:
+    method render-fancy-reason(self, src-available):
+      if src-available(self.a) and src-available(self.b):
+        [ED.error:
+          [ED.para:
+            ED.text("Pyret thinks this code is probably a function call:")],
+          ED.cmcode(self.a + self.b),
+          [ED.para:
+            ED.text("Function calls must not have space between the "),
+            ED.highlight(ED.text("function expression"), [ED.locs: self.a], 0),
+            ED.text(" and the "),
+            ED.highlight(ED.text("arguments"), [ED.locs: self.b], 1),
+            ED.text(".")]]
+      else:
+        [ED.error:
+          [ED.para:
+            ED.text("Pyret thinks the code at "), ED.loc(self.a + self.b),
+            ED.text(" is probably a function call, but there should be no space"),
+            ED.text(" between the function and its arguments.")]]
+      end
+    end,
+    method render-reason(self):
+      [ED.error:
+        [ED.para:
+          ED.text("Pyret thinks the code at "), ED.loc(self.a + self.b),
+          ED.text(" is probably a function call, but there should be no space"),
+          ED.text(" between the function and its arguments.")]]
+    end
   | parse-error-next-token(loc, next-token :: String) with:
     method render-fancy-reason(self, src-available):
       if src-available(self.loc):
@@ -2526,7 +2554,7 @@ data ParseError:
             ED.text("Pyret thinks the string ")],
           ED.cmcode(self.loc),
           [ED.para:
-            ED.text("is unterminated; you may be missing closing punctuation. If you intended to write a multi-line string, use "),
+            ED.text("is not finished; you may be missing closing punctuation. If you intended to write a multi-line string, use "),
             ED.code(ED.text("```")),
             ED.text(" instead of quotation marks.")]]
       else:
@@ -2534,7 +2562,7 @@ data ParseError:
           [ED.para:
             ED.text("Pyret thinks the string at "),
             ED.loc(self.loc),
-            ED.text("is unterminated; you may be missing closing punctuation. If you intended to write a multi-line string, use "),
+            ED.text("is not finished; you may be missing closing punctuation. If you intended to write a multi-line string, use "),
             ED.code(ED.text("```")),
             ED.text(" instead of quotation marks.")]]
       end

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -2459,6 +2459,32 @@ data ParseError:
           ED.text(" is probably a function call, but there should be no space"),
           ED.text(" between the function and its arguments.")]]
     end
+  | parse-error-bad-fun-header(a, b) with:
+    method render-fancy-reason(self, src-available):
+      if src-available(self.a) and src-available(self.b):
+        [ED.error:
+          [ED.para:
+            ED.text("Pyret thinks this code is probably a function header:")],
+          ED.cmcode(self.a),
+          [ED.para:
+            ED.text("Function header must not have space before the "),
+            ED.highlight(ED.text("arguments"), [ED.locs: self.b], 0),
+            ED.text(".")]]
+      else:
+        [ED.error:
+          [ED.para:
+            ED.text("Pyret thinks the code at "), ED.loc(self.a),
+            ED.text(" is probably a function header, but there should be no space"),
+            ED.text(" before the arguments.")]]
+      end
+    end,
+    method render-reason(self):
+      [ED.error:
+        [ED.para:
+          ED.text("Pyret thinks the code at "), ED.loc(self.a + self.b),
+          ED.text(" is probably a function call, but there should be no space"),
+          ED.text(" between the function and its arguments.")]]
+    end
   | parse-error-next-token(loc, next-token :: String) with:
     method render-fancy-reason(self, src-available):
       if src-available(self.loc):

--- a/src/js/base/pyret-grammar.bnf
+++ b/src/js/base/pyret-grammar.bnf
@@ -177,6 +177,13 @@ lambda-expr: LBRACE fun-header (BLOCK|COLON) doc-string block where-clause RBRAC
 method-expr: METHOD fun-header (BLOCK|COLON) doc-string block where-clause END
 
 app-expr: expr app-args
+# These two productions are carefully rigged to *not* parse unary `f (x)`
+# otherwise, we'd admit ambiguous parses.  Instead, parse-pyret detects these
+# two cases and produces a parse error, while well-formedness detects the unary
+# case and produces a well-formedness error with a similar message.
+     | expr PARENSPACE RPAREN
+     | expr PARENSPACE binop-expr COMMA binop-expr (COMMA binop-expr)* RPAREN
+     
 # application must have the function expression immediately adjacent to
 # the argument list, so as not to be confused with parenthesized exprs
 app-args: PARENNOSPACE opt-comma-binops RPAREN

--- a/src/js/base/pyret-grammar.bnf
+++ b/src/js/base/pyret-grammar.bnf
@@ -87,9 +87,10 @@ type-let-expr: TYPE-LET type-let-bind (COMMA type-let-bind)* (BLOCK|COLON) block
 contract-stmt: NAME COLONCOLON ty-params (ann | noparen-arrow-ann)
 
 fun-expr: FUN NAME fun-header (BLOCK|COLON) doc-string block where-clause END
-fun-header: ty-params args return-ann
+fun-header: ty-params args return-ann | ty-params bad-args return-ann
 ty-params: [(LANGLE|LT) comma-names (RANGLE|GT)]
 args: (PARENNOSPACE|PARENAFTERBRACE) [binding (COMMA binding)*] RPAREN
+bad-args: PARENSPACE [binding (COMMA binding)*] RPAREN
 return-ann: [THINARROW ann]
 doc-string: [DOC STRING]
 where-clause: [WHERE block]

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -474,6 +474,9 @@
         runtime.makeSrcloc(col_loc)));
     }
 
+    function throwParseErrorBadApp(fun_loc, args_loc) {
+      raise(err("parse-error-bad-app")(fun_loc, args_loc));
+    }
     function throwParseErrorNextToken(loc, nextToken) {
       raise(err("parse-error-next-token")(loc, nextToken));
     }
@@ -650,6 +653,7 @@
       throwUnfinishedTemplate: throwUnfinishedTemplate,
       throwModuleLoadFailureL: throwModuleLoadFailureL,
 
+      throwParseErrorBadApp: throwParseErrorBadApp,
       throwParseErrorNextToken: throwParseErrorNextToken,
       throwParseErrorColonColon: throwParseErrorColonColon,
       throwParseErrorEOF: throwParseErrorEOF,

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -477,6 +477,9 @@
     function throwParseErrorBadApp(fun_loc, args_loc) {
       raise(err("parse-error-bad-app")(fun_loc, args_loc));
     }
+    function throwParseErrorBadFunHeader(fun_loc, args_loc) {
+      raise(err("parse-error-bad-fun-header")(fun_loc, args_loc));
+    }
     function throwParseErrorNextToken(loc, nextToken) {
       raise(err("parse-error-next-token")(loc, nextToken));
     }
@@ -654,6 +657,7 @@
       throwModuleLoadFailureL: throwModuleLoadFailureL,
 
       throwParseErrorBadApp: throwParseErrorBadApp,
+      throwParseErrorBadFunHeader: throwParseErrorBadFunHeader,
       throwParseErrorNextToken: throwParseErrorNextToken,
       throwParseErrorColonColon: throwParseErrorColonColon,
       throwParseErrorEOF: throwParseErrorEOF,

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -525,16 +525,25 @@
         },
         'fun-header': function(node) {
           // (fun-header ty-params args return-ann)
-          return {
-            tyParams: tr(node.kids[0]),
-            args: tr(node.kids[1]),
-            returnAnn: tr(node.kids[2])
-          };
+          if (node.kids[1].name === "bad-args") {
+            return {
+              lparenPos: pos(node.kids[1].kids[0].pos)
+            };
+          } else {
+            return {
+              tyParams: tr(node.kids[0]),
+              args: tr(node.kids[1]),
+              returnAnn: tr(node.kids[2])
+            };
+          }
         },
         'fun-expr': function(node) {
           // (fun-expr FUN fun-name fun-header COLON doc body check END)
           var isBlock = (node.kids[3].name === "BLOCK");
           var header = tr(node.kids[2]);
+          if (header.lparenPos) {
+            RUNTIME.ffi.throwParseErrorBadFunHeader(pos2(node.kids[0].pos, node.kids[3].pos), header.lparenPos);
+          }
           var checkRes = tr(node.kids[6]);
           return RUNTIME.getField(ast, 's-fun')
             .app(pos(node.pos), symbol(node.kids[1]),
@@ -823,6 +832,9 @@
             // (obj-field METHOD key fun-header COLON doc body check END)
             var isBlock = (node.kids[3].name === "BLOCK");
             var header = tr(node.kids[2]);
+            if (header.lparenPos) {
+              RUNTIME.ffi.throwParseErrorBadFunHeader(pos2(node.kids[0].pos, node.kids[3].pos), header.lparenPos);
+            }
             var checkRes = tr(node.kids[6])
             return RUNTIME.getField(ast, 's-method-field')
               .app(pos(node.pos), tr(node.kids[1]), header.tyParams, header.args, header.returnAnn,
@@ -1003,6 +1015,9 @@
             // (field METHOD key fun-header (BLOCK|COLON) doc body check END)
             var isBlock = (node.kids[3].name === "BLOCK");
             var header = tr(node.kids[2]);
+            if (header.lparenPos) {
+              RUNTIME.ffi.throwParseErrorBadFunHeader(pos2(node.kids[0].pos, node.kids[3].pos), header.lparenPos);
+            }
             var checkRes = tr(node.kids[6])
             return RUNTIME.getField(ast, "s-method-field")
               .app(pos(node.pos), tr(node.kids[1]), header.tyParams, header.args, header.returnAnn,
@@ -1239,6 +1254,9 @@
           // (lambda-expr LAM fun-header COLON doc body check END)
           var isBlock = (node.kids[2].name === "BLOCK");
           var header = tr(node.kids[1]);
+          if (header.lparenPos) {
+            RUNTIME.ffi.throwParseErrorBadFunHeader(pos2(node.kids[0].pos, node.kids[2].pos), header.lparenPos);
+          }
           var checkRes = tr(node.kids[5]);
           return RUNTIME.getField(ast, 's-lam')
             .app(pos(node.pos), RUNTIME.makeString(""), header.tyParams, header.args, header.returnAnn,
@@ -1248,6 +1266,9 @@
           // (method-expr METHOD fun-header COLON doc body check END)
           var isBlock = (node.kids[2].name === "BLOCK");
           var header = tr(node.kids[1]);
+          if (header.lparenPos) {
+            RUNTIME.ffi.throwParseErrorBadFunHeader(pos2(node.kids[0].pos, node.kids[2].pos), header.lparenPos);
+          }
           var checkRes = tr(node.kids[5]);
           return RUNTIME.getField(ast, 's-method')
             .app(pos(node.pos), RUNTIME.makeString(""), header.tyParams, header.args, header.returnAnn,

--- a/src/js/trove/parse-pyret.js
+++ b/src/js/trove/parse-pyret.js
@@ -1146,9 +1146,14 @@
           }
         },
         'app-expr': function(node) {
-          // (app-expr f args)
-          return RUNTIME.getField(ast, 's-app')
-            .app(pos(node.pos), tr(node.kids[0]), tr(node.kids[1]));
+          if (node.kids.length > 2) {
+            RUNTIME.ffi.throwParseErrorBadApp(pos(node.kids[0].pos),
+                                              pos2(node.kids[1].pos, node.kids[node.kids.length - 1].pos));
+          } else {
+            // (app-expr f args)
+            return RUNTIME.getField(ast, 's-app')
+              .app(pos(node.pos), tr(node.kids[0]), tr(node.kids[1]));
+          }
         },
         'id-expr': function(node) {
           // (id-expr x)

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -517,9 +517,9 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
       expect(parse("{(a): true}")).not.toBe(false);
       expect(parse("{(a, b): true}")).not.toBe(false); // colon ==> lambda
       expect(parse("{(a, b); true}")).toBe(false); // semicolon ==> tuple with invalid first arg
-      expect(parse("{ (): true}")).toBe(false);
-      expect(parse("{ (a): true}")).toBe(false);
-      expect(parse("{ (a, b): true}")).toBe(false);
+      expect(parse("{ (): true}")).not.toBe(false);  // NOTE: will be caught with a bad-args parse later
+      expect(parse("{ (a): true}")).not.toBe(false); // NOTE: will be caught with a bad-args parse later
+      expect(parse("{ (a, b): true}")).not.toBe(false);  // NOTE: will be caught with a bad-args parse later
       expect(parse("{(1 + 2); (3 + 4)}")).not.toBe(false);
       expect(parse("{ (1 + 2); (3 + 4) }")).not.toBe(false);
     });

--- a/tests/pyret/tests/test-parse-errors.arr
+++ b/tests/pyret/tests/test-parse-errors.arr
@@ -1,5 +1,7 @@
 import error as ERR
+import file("../../../src/arr/compiler/compile-structs.arr") as CS
 import file("../test-parse-helper.arr") as P
+import file("../test-compile-helper.arr") as C
 
 get-parse-error = P.get-parse-error
 wss = P.wss
@@ -45,7 +47,7 @@ check "coloncolon":
 end
 
 check "eof":
-  for map(program from eof):
+  for each(program from eof):
     get-parse-error(program) satisfies ERR.is-parse-error-eof
   end
 end
@@ -60,7 +62,7 @@ unterminated-string = [list:
 ]
 
 check "unterminated string":
-  for map(program from unterminated-string):
+  for each(program from unterminated-string):
     get-parse-error(program) satisfies ERR.is-parse-error-unterminated-string
   end
 end
@@ -75,7 +77,7 @@ bad-operator = [list:
 ]
 
 check "bad operator":
-  for map(program from bad-operator):
+  for each(program from bad-operator):
     get-parse-error(program) satisfies ERR.is-parse-error-bad-operator
   end
 end
@@ -87,7 +89,51 @@ bad-number = [list:
 ]
 
 check "bad-number":
-  for map(program from bad-number):
+  for each(program from bad-number):
     get-parse-error(program) satisfies ERR.is-parse-error-bad-number
+  end
+end
+
+check "spacey-apps":
+  get-parse-error("foo ()") satisfies ERR.is-parse-error-bad-app
+  get-parse-error("foo (x, y)") satisfies ERR.is-parse-error-bad-app
+  P.does-parse("foo (x)") is true
+  C.run-str("foo (x)") is%(C.output) C.compile-error(lam(e): CS.is-same-line(e) and e.b-is-paren end)
+end
+
+spacey-headers = [list:
+  "fun foo (): 6 end",
+  "fun foo (x): 6 end",
+  "fun foo (x :: Number): 6 end",
+  "fun foo (x, y): 6 end",
+  "lam (): 6 end",
+  "lam (x): 6 end",
+  "lam (x :: Number): 6 end",
+  "lam (x, y): 6 end",
+  "{ (): 6 }",
+  "{ (x): 6 }",
+  "{ (x :: Number): 6 }",
+  "{ (x, y): 6 }",
+  "method (): 6 end",
+  "method (x): 6 end",
+  "method (x :: Number): 6 end",
+  "method (x, y): 6 end",
+  "data Foo: z with: method foo (): 6 end end",
+  "data Foo: z with: method foo (x): 6 end end",
+  "data Foo: z with: method foo (x :: Number): 6 end end",
+  "data Foo: x with: method foo (x, y): 6 end end",
+  "{ x : method (): 6 end }",
+  "{ x : method (x): 6 end }",
+  "{ x : method (x :: Number): 6 end }",
+  "{ x : method (x, y): 6 end }",
+  "{ method x (): 6 end }",
+  "{ method x (x): 6 end }",
+  "{ method x (x :: Number): 6 end }",
+  "{ method x (x, y): 6 end }",
+]
+
+check "spacey-headers":
+  for each(program from spacey-headers):
+    get-parse-error(program) satisfies ERR.is-parse-error-bad-fun-header
   end
 end


### PR DESCRIPTION
I.e. `f ()`, `g (x)`, `h (y, z)`, etc.

This is *hacky* and not very robust: we detect unary cases as well-formedness errors, and everything else as "parse errors".  The well-formedness error has to attempt to unwrap the pieces it receives, to undo the builtin["trace-value"] wrapping.  The "parse errors" actually successfully parse, but complain anyway!  The grammar rules for handling 0-arity and 2+arity are carefully rigged to be disjoint from the unary case, so that we avoid ambiguous parses; I'm only *mostly* confident that they really are unambiguous.

![image](https://user-images.githubusercontent.com/918464/61717095-6c626780-ad2e-11e9-956b-1533eacf33b1.png)
