### PR TITLE
Return true in identical equality when numbers are equal

### DIFF
--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -2435,13 +2435,19 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
 
     // JS function from Pyret values to Pyret equality answers
     function identical3(v1, v2) {
+      var v1IsRough = jsnums.isRoughnum(v1);
+      var v2IsRough = jsnums.isRoughnum(v2);
+
+      var v1IsNum = jsnums.isPyretNumber(v1)
+      var v2IsNum = jsnums.isPyretNumber(v2)
+
       if (isFunction(v1) && isFunction(v2)) {
         return thisRuntime.ffi.unknown.app("Functions", v1,  v2);
       } else if (isMethod(v1) && isMethod(v2)) {
         return thisRuntime.ffi.unknown.app('Methods', v1,  v2);
-      } else if (jsnums.isRoughnum(v1) && jsnums.isRoughnum(v2)) {
+      } else if (v1IsRough && v2IsRough) {
         return thisRuntime.ffi.unknown.app('Roughnums', v1,  v2);
-      } else if (v1 === v2) {
+      } else if (v1 === v2 || (!(v1IsRough || v2IsRough) && v1IsNum && v2IsNum && jsnums.equals(v1, v2, NumberErrbacks))) {
         return thisRuntime.ffi.equal;
       } else {
         return thisRuntime.ffi.notEqual.app("", v1, v2);

--- a/tests/pyret/tests/test-equality.arr
+++ b/tests/pyret/tests/test-equality.arr
@@ -5,6 +5,8 @@ import equality as E
 check "numbers":
   identical(1, 1) is true
   identical(1, 2) is false
+  identical(4/5, 4/5) is true
+  identical(4/5, 3/5) is false
   equal-always(1, 1) is true
   equal-always(1, 2) is false
   equal-now(1, 1) is true


### PR DESCRIPTION
Fixes a bug that occurs from only checking === equality, which will return false on different instances of equivalent Rationals as they are different javascript objects

This is pulled out of the changes in the units PR, as it should be shipped separately