### PR TITLE
fix: properly parse octal escape sequences

### DIFF
--- a/src/js/base/pyret-tokenizer.js
+++ b/src/js/base/pyret-tokenizer.js
@@ -62,7 +62,7 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
       else if (esc === "\\") { ret += "\\"; }
       else if (esc[0] === 'u') { ret += String.fromCharCode(parseInt(esc.slice(1), 16)); }
       else if (esc[0] === 'x') { ret += String.fromCharCode(parseInt(esc.slice(1), 16)); }
-      else { ret += String.fromCharCode(parseInt(esc.slice(2), 8)); }
+      else { ret += String.fromCharCode(parseInt(esc, 8)); }
       match = escapes.exec(s);
     }
     ret += s;

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -228,20 +228,20 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
     });
 
     it('should lex octal escape sequences', function() {
-      const escapeSequences = ['\\0', '\\77', '\\101'];
-      const expectedSequences = ['0', '77', '101'];
+      const escapeSequences = ["'\\0'", "'\\77'", "'\\101'"];
+      const expectedValues = ["'\0'", "'?'", "'A'"];
       for (let i = 0; i < escapeSequences.length; ++i) {
-        const expectedValues = ['\\', expectedSequences[i], undefined];
+        const tokens = lex(escapeSequences[i]);
+        expect(tokens.length).toBe(2);
+        expect(tokens[0].value).toBe(expectedValues[i]);
+        expect(tokens[1].name).toBe("EOF");
 
-        const lexedValues = lex(escapeSequences[i]).map(token => token.value);
-        expect(lexedValues).toEqual(expectedValues);
-
-        const parseStr = `str = "${escapeSequences[i]}"`;
+        const parseStr = `str = ${escapeSequences[i]}`;
         expect(parse(parseStr)).not.toBe(false);
       }
 
       // invalid escape sequence
-      expect(parse('str = \'\\8\'')).toBe(false);
+      expect(parse("str = '\\8'")).toBe(false);
     });
   });
   describe("parsing", function() {

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -762,6 +762,14 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
       expect(parse("spy \"five\": x end")).not.toBe(false);
       expect(parse("spy \"five\": x: 5 end")).not.toBe(false);
     });
+
+    it("should parse octal escape squences", function() {
+      expect(parse("\\0")).toBe("");
+      expect(parse("\\101")).toBe("A");
+      expect(parse("\\101bc")).toBe("Abc");
+      expect(parse("\\77")).toBe("?");
+      expect(parse("\\88")).toBe("88");
+    });
   });
 
   jazz.execute();

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -764,11 +764,16 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
     });
 
     it("should parse octal escape squences", function() {
-      expect(parse("\\0")).toBe("");
-      expect(parse("\\101")).toBe("A");
-      expect(parse("\\101bc")).toBe("Abc");
-      expect(parse("\\77")).toBe("?");
-      expect(parse("\\88")).toBe("88");
+      expect(parse("a = '\\0'").toString()).toContain(stringAst('\\u0000'));
+      expect(parse("a = '\\101'").toString()).toContain(stringAst('A'));
+      expect(parse("a = '\\101bc'").toString()).toContain(stringAst('Abc'));
+      expect(parse("a = '\\77'").toString()).toContain(stringAst('?'));
+
+      expect(parse("a = '\\88'")).toBe(false);
+
+      function stringAst(str) {
+        return `'STRING "'${str}'"`;
+      }
     });
   });
 

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -226,6 +226,23 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
       expect(parse("```asd``\\````")).not.toBe(false);
       expect(parse("```asd```asd```")).toBe(false);
     });
+
+    it('should lex octal escape sequences', function() {
+      const escapeSequences = ['\\0', '\\77', '\\101'];
+      const expectedSequences = ['0', '77', '101'];
+      for (let i = 0; i < escapeSequences.length; ++i) {
+        const expectedValues = ['\\', expectedSequences[i], undefined];
+
+        const lexedValues = lex(escapeSequences[i]).map(token => token.value);
+        expect(lexedValues).toEqual(expectedValues);
+
+        const parseStr = `str = "${escapeSequences[i]}"`;
+        expect(parse(parseStr)).not.toBe(false);
+      }
+
+      // invalid escape sequence
+      expect(parse('str = \'\\8\'')).toBe(false);
+    });
   });
   describe("parsing", function() {
     it("should parse lets and letrecs", function() {
@@ -761,19 +778,6 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
       expect(parse("spy: 5 end")).toBe(false);
       expect(parse("spy \"five\": x end")).not.toBe(false);
       expect(parse("spy \"five\": x: 5 end")).not.toBe(false);
-    });
-
-    it("should parse octal escape squences", function() {
-      expect(parse("a = '\\0'").toString()).toContain(stringAst('\\u0000'));
-      expect(parse("a = '\\101'").toString()).toContain(stringAst('A'));
-      expect(parse("a = '\\101bc'").toString()).toContain(stringAst('Abc'));
-      expect(parse("a = '\\77'").toString()).toContain(stringAst('?'));
-
-      expect(parse("a = '\\88'")).toBe(false);
-
-      function stringAst(str) {
-        return `'STRING "'${str}'"`;
-      }
     });
   });
 

--- a/tests/pyret/tests/test-strings.arr
+++ b/tests/pyret/tests/test-strings.arr
@@ -137,6 +137,11 @@ check:
   string-to-code-points("abcd") is [list: 97, 98, 99, 100]
   string-to-code-points("") is [list:]
 
+  # octal escape sequences
+  string-to-code-point("\0") is 0
+  string-to-code-point("\77") is 63
+  string-to-code-point("\101") is 65
+
   string-from-code-points([list: 955, 97, 10]) is "λa\n"
   string-from-code-points([list: 955, -1]) raises "Natural Number"
   string-from-code-points([list:]) is ""


### PR DESCRIPTION
Fixes #1480.

Currently, octal escape sequences are parsed incorrectly because the
sequence is evaluated only partially. The "\\" delimiter in an octal
sequence like "\101" is already siphoned off during escape sequence
matching, so it is enough to simply parse the match of the numeric
sequence "101".