### PR TITLE
make type check errors use the to-string() method directly

### DIFF
--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -1956,9 +1956,9 @@ data CompileError:
           ED.text("Type checking failed because of a type inconsistency.")],
         [ED.para:
           ED.text("The type constraint "),
-          ED.highlight(ED.text(tostring(type-1)), [list: type-1.l], 0),
+          ED.highlight(ED.text(type-1.to-string()), [list: type-1.l], 0),
           ED.text(" was incompatible with the type constraint "),
-          ED.highlight(ED.text(tostring(type-2)), [list: type-2.l], 1)]]
+          ED.highlight(ED.text(type-2.to-string()), [list: type-2.l], 1)]]
     end,
     method render-reason(self):
       {type-1; type-2} = if self.type-1.l.before(self.type-2.l): {self.type-1; self.type-2} else: {self.type-2; self.type-1} end
@@ -1967,10 +1967,10 @@ data CompileError:
           ED.text("Type checking failed because of a type inconsistency.")],
         [ED.para:
           ED.text("The type constraint "),
-          ED.code(ED.text(tostring(type-1))),
+          ED.code(ED.text(type-1.to-string())),
           ED.text(" at "), draw-and-highlight(type-1.l),
           ED.text(" was incompatible with the type constraint "),
-          ED.code(ED.text(tostring(type-2))),
+          ED.code(ED.text((type-2.to-string()))),
           ED.text(" at "), draw-and-highlight(type-2.l)]]
     end
   | incorrect-type(bad-name :: String, bad-loc :: A.Loc, expected-name :: String, expected-loc :: A.Loc) with:
@@ -2020,7 +2020,7 @@ data CompileError:
       [ED.error:
         [ED.para:
           ED.text("The type checker rejected your program because the type application "),
-          ED.highlight(ED.embed(self.app-type), [list: self.app-type.l], 0),
+          ED.highlight(ED.code(ED.text(self.app-type.to-string())), [list: self.app-type.l], 0),
           ED.text(" expected " + tostring(self.expected-length) + " type arguments, "),
           ED.text("but it received " + tostring(self.app-type.args.length()))]]
     end,
@@ -2028,7 +2028,7 @@ data CompileError:
       [ED.error:
         [ED.para:
           ED.text("The type checker rejected your program because the type application "),
-          ED.highlight(ED.embed(self.app-type), [list: self.app-type.l], 0),
+          ED.highlight(ED.code(ED.text(self.app-type.to-string())), [list: self.app-type.l], 0),
           ED.text(" expected " + tostring(self.expected-length) + " type arguments, "),
           ED.text("but it received " + tostring(self.app-type.args.length()))]]
     end
@@ -2049,7 +2049,7 @@ data CompileError:
                 + "given, but the type signature of the "),
           ed-applicant],
         [ED.para:
-          ED.embed(self.fun-typ)],
+          ED.code(ED.text(self.fun-typ.to-string()))],
         [ED.para:
           ED.text("indicates that it evaluates to a function accepting exactly "),
           ED.ed-args(self.fun-typ.args.length()),
@@ -2070,7 +2070,7 @@ data CompileError:
           ED.ed-args(self.app-expr.args.length()),
           ED.text(" and the type signature of the applicant")],
         [ED.para:
-          ED.embed(self.fun-typ)],
+          ED.code(ED.text(self.fun-typ.to-string()))],
         [ED.para:
           ED.text("indicates that it evaluates to a function accepting exactly "),
           ED.ed-args(self.fun-typ.args.length()),

--- a/src/arr/compiler/type-check-structs.arr
+++ b/src/arr/compiler/type-check-structs.arr
@@ -1206,7 +1206,7 @@ fun instantiate-object-type(typ :: Type, context :: Context) -> FoldResult<Type>
         | t-existential(_, exists-l, _) =>
           typing-error([list: C.unable-to-infer(exists-l)])
         | else =>
-          fold-errors([list: C.incorrect-type(tostring(a-onto), a-onto.l, "a polymorphic type", a-l)])
+          fold-errors([list: C.incorrect-type(a-onto.to-string(), a-onto.l, "a polymorphic type", a-l)])
       end
     | t-record(_, _, _) =>
       fold-result(typ, context)
@@ -1221,7 +1221,7 @@ fun instantiate-object-type(typ :: Type, context :: Context) -> FoldResult<Type>
         instantiate-object-type(typ, context)
       end)
     | else =>
-      fold-errors([list: C.incorrect-type(tostring(typ), typ.l, "an object type", typ.l)])
+      fold-errors([list: C.incorrect-type(typ.to-string(), typ.l, "an object type", typ.l)])
   end
 end
 

--- a/src/arr/compiler/type-check.arr
+++ b/src/arr/compiler/type-check.arr
@@ -474,7 +474,7 @@ fun _checking(e :: Expr, expect-type :: Type, top-level :: Boolean, context :: C
               | t-ref(arg-type, _, _) =>
                 checking(value, arg-type, top-level, context)
               | else =>
-                typing-error([list: C.incorrect-type-expression(tostring(id-type), l, tostring(t-ref(id-type, l, false)), l, e)])
+                typing-error([list: C.incorrect-type-expression(id-type.to-string(), l, t-ref(id-type, l, false).to-string(), l, e)])
             end
           end)
         | s-if-pipe(l, branches) =>
@@ -878,7 +878,7 @@ fun _synthesis(e :: Expr, top-level :: Boolean, context :: Context) -> TypingRes
           | t-ref(arg-type, _, _) =>
             typing-result(e, arg-type.set-loc(l), context)
           | else =>
-            typing-error([list: C.incorrect-type-expression(tostring(id-type), id-type.l, tostring(t-ref(id-type, l, false)), l, e)])
+            typing-error([list: C.incorrect-type-expression(id-type.to-string(), id-type.l, t-ref(id-type, l, false).to-string(), l, e)])
         end
       end)
     | s-id-letrec(l, id, safe) =>
@@ -911,7 +911,7 @@ fun _synthesis(e :: Expr, top-level :: Boolean, context :: Context) -> TypingRes
           | t-ref(typ, _, _) =>
             typing-result(new-get-bang, typ.set-loc(l), context)
           | else =>
-            typing-error([list: C.incorrect-type-expression(tostring(field-type), field-type.l, "a ref type", l, e)])
+            typing-error([list: C.incorrect-type-expression(field-type.to-string(), field-type.l, "a ref type", l, e)])
         end
       end)
     | s-bracket(l, obj, field) =>
@@ -1923,7 +1923,7 @@ fun synthesis-extend(update-loc :: Loc, obj :: Expr, obj-type :: Type, fields ::
         | t-existential(_, l, _) =>
           typing-error([list: C.unable-to-infer(l)])
         | else =>
-          typing-error([list: C.incorrect-type-expression(tostring(obj-type), obj-type.l, "an object type", update-loc, obj)])
+          typing-error([list: C.incorrect-type-expression(obj-type.to-string(), obj-type.l, "an object type", update-loc, obj)])
       end
     end)
   end)
@@ -1944,7 +1944,7 @@ fun synthesis-update(update-loc :: Loc, obj :: Expr, obj-type :: Type, fields ::
                     fold-result(link(A.s-data-field(field.l, field.name, new-value), fields), context)
                   end)
                 | else =>
-                  fold-errors([list: C.incorrect-type(tostring(old-type), old-type.l, tostring(t-ref(old-type, update-loc, false)), update-loc)])
+                  fold-errors([list: C.incorrect-type(old-type.to-string(), old-type.l, t-ref(old-type, update-loc, false).to-string(), update-loc)])
               end
           end
         end, fields, context, empty).typing-bind(lam(final-fields, shadow context):
@@ -1965,14 +1965,14 @@ fun synthesis-update(update-loc :: Loc, obj :: Expr, obj-type :: Type, fields ::
                       fold-result(link(A.s-data-field(field.l, field.name, new-value), fields), context)
                     end)
                   | else =>
-                    fold-errors([list: C.incorrect-type(tostring(old-type), old-type.l, tostring(t-ref(old-type, update-loc, false)), update-loc)])
+                    fold-errors([list: C.incorrect-type(old-type.to-string(), old-type.l, t-ref(old-type, update-loc, false).to-string(), update-loc)])
                 end
             end
           end, fields, context, empty).typing-bind(lam(final-fields, shadow context):
             typing-result(A.s-update(update-loc, obj, final-fields), obj-type, context)
           end)
         end)
-        # typing-error([list: C.incorrect-type-expression(tostring(obj-type), obj-type.l, "an object type", update-loc, obj)])
+        # typing-error([list: C.incorrect-type-expression(obj-type.to-string(), obj-type.l, "an object type", update-loc, obj)])
     end
   end)
 end
@@ -2035,7 +2035,7 @@ fun check-fun(fun-loc :: Loc, body :: Expr, params :: List<A.Name>, args :: List
         end)
       end)
     | else =>
-      typing-error([list: C.incorrect-type(tostring(expect-type), expect-type.l, "a function", fun-loc)])
+      typing-error([list: C.incorrect-type(expect-type.to-string(), expect-type.l, "a function", fun-loc)])
   end.solve-bind()
 end
 
@@ -2075,7 +2075,7 @@ fun synthesis-instantiation(l :: Loc, expr :: Expr, params :: List<A.Ann>, top-l
         end)
       | t-existential(_, exists-l, _) =>
         typing-error([list: C.unable-to-infer(exists-l)])
-      | else => typing-error([list: C.incorrect-type(tostring(tmp-type), tmp-type.l, "a polymorphic type", l)])
+      | else => typing-error([list: C.incorrect-type(tmp-type.to-string(), tmp-type.l, "a polymorphic type", l)])
     end
   end)
 end
@@ -2092,7 +2092,7 @@ fun handle-if-branch(branch :: A.IfBranch, context :: Context) -> FoldResult<{A.
 end
 
 fun synthesis-tuple-index(access-loc :: Loc, tup :: Expr, tup-type-loc :: Loc, tup-type :: Type, index :: Number, recreate :: (Loc, Expr, Number -> Expr), context :: Context) -> TypingResult:
-  non-tup-err = typing-error([list: C.incorrect-type(tostring(tup-type), tup-type-loc, "a tuple type", access-loc)])
+  non-tup-err = typing-error([list: C.incorrect-type(tup-type.to-string(), tup-type-loc, "a tuple type", access-loc)])
   tuple-view(access-loc, tup-type-loc, tup-type,
   lam(l, maybe-tup-members):
     cases(Option<List<Type>>) maybe-tup-members:
@@ -2112,7 +2112,7 @@ end
 fun tuple-view(access-loc :: Loc, tup-type-loc :: Loc, tup-type :: Type,
                 handle :: (Loc, Option<List<Type>> -> TypingResult),
                 context :: Context) -> TypingResult:
-  non-tup-err = typing-error([list: C.incorrect-type(tostring(tup-type), tup-type-loc, "a tuple type", access-loc)])
+  non-tup-err = typing-error([list: C.incorrect-type(tup-type.to-string(), tup-type-loc, "a tuple type", access-loc)])
   cases(Type) tup-type:
     | t-tuple(fields, _, _) =>
       handle(tup-type-loc, some(fields))


### PR DESCRIPTION
It looks like constructor printing used to be overridden for the sake
of errors. However, this is silly because we want constructor printing
for spying on types and so on within the compiler.

So make the error rendering contexts use to-string explicitly.

Down the line this should be a richer renderable type struct, but
ED.embed does constructor printing as well so stringifying with
the existing stringifier is better.

@blerner @mkolosick can you do a brief review of this to make sure I'm not missing something obvious?