### PR TITLE
Fix escapes

### DIFF
--- a/src/arr/compiler/type-defaults.arr
+++ b/src/arr/compiler/type-defaults.arr
@@ -53,7 +53,7 @@ tvf = t-var(A.global-names.make-atom("F"))
 tvg = t-var(A.global-names.make-atom("G"))
 tvh = t-var(A.global-names.make-atom("H"))
 
-t-image = t-name(module-uri("builtin://image"), A.s-type-global("Image"))
+t-image = t-name(module-uri("builtin://image-lib"), A.s-type-global("Image"))
 t-option = t-name(module-uri("builtin://option"), A.s-type-global("Option"))
 t-reactor = t-name(module-uri("builtin://reactors"), A.s-type-global("Reactor"))
 t-equality-result = t-name(module-uri("builtin://equality"), A.s-type-global("EqualityResult"))

--- a/src/js/base/pyret-tokenizer.js
+++ b/src/js/base/pyret-tokenizer.js
@@ -191,7 +191,7 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
     new RegExp("```(?:" +
                "\\\\[01234567]{1,3}" +
                "|\\\\x[0-9a-fA-F]{1,2}" +
-               "|\\\\u[0-9a-fA-f]{1,4}" +
+               "|\\\\u[0-9a-fA-F]{1,4}" +
                "|\\\\[\\\\nrt\"\'`]" +
                "|`{1,2}(?!`)" +
                "|[^`\\\\])*```", "g"); // NOTE: Allow unescaped newlines
@@ -199,14 +199,14 @@ define("pyret-base/js/pyret-tokenizer", ["jglr/jglr"], function(E) {
     new RegExp("\"(?:" +
                "\\\\[01234567]{1,3}" +
                "|\\\\x[0-9a-fA-F]{1,2}" +
-               "|\\\\u[0-9a-fA-f]{1,4}" +
+               "|\\\\u[0-9a-fA-F]{1,4}" +
                "|\\\\[\\\\nrt\"\']" +
                "|[^\\\\\"\n\r])*\"", "g");
   const squot_str =
     new RegExp("\'(?:" +
                "\\\\[01234567]{1,3}" +
                "|\\\\x[0-9a-fA-F]{1,2}" +
-               "|\\\\u[0-9a-fA-f]{1,4}" +
+               "|\\\\u[0-9a-fA-F]{1,4}" +
                "|\\\\[\\\\nrt\"\']" +
                "|[^\\\\\'\n\r])*\'", "g");
 

--- a/src/js/trove/reactors.js
+++ b/src/js/trove/reactors.js
@@ -12,7 +12,7 @@
                  origin: { "import-type": "uri", uri: "builtin://reactor-events" },
                  name: "Event" },
       "Image": { tag: "name",
-                 origin: { "import-type": "uri", uri: "builtin://image" },
+                 origin: { "import-type": "uri", uri: "builtin://image-lib" },
                  name: "Image" },
       "ValueSkeleton": { tag: "name",
                          origin: { "import-type": "uri", uri: "builtin://valueskeleton" },

--- a/tests/parse/parse.js
+++ b/tests/parse/parse.js
@@ -779,6 +779,16 @@ R(["pyret-base/js/pyret-tokenizer", "pyret-base/js/pyret-parser", "fs"], functio
       expect(parse("spy \"five\": x end")).not.toBe(false);
       expect(parse("spy \"five\": x: 5 end")).not.toBe(false);
     });
+
+    it("should not parse escapes ending in G (bracket) through ` (backtick)", function() {
+      expect(parse("\"\\uG\"")).toBe(false);
+      expect(parse("'\\uG'")).toBe(false);
+      expect(parse("```\\uG```")).toBe(false);
+      expect(parse("\"\\u`\"")).toBe(false);
+      expect(parse("'\\u`'")).toBe(false);
+      expect(parse("```\\u````")).toBe(false);
+      expect(parse("\"\\u`\"")).toBe(false);
+    });
   });
 
   jazz.execute();


### PR DESCRIPTION
The regexes in the tokenizer mistakenly used `A-f` rather than `A-F` for unicode escapes, leading to odd escapes being allowed.
