### PR TITLE
Add some checking to raw-array-build

### DIFF
--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -4057,7 +4057,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
 
     var check_array_size = function(name, size) {
       checkNumInteger(size);
-      checkNumPositive(size);
+      checkNumNonNegative(size);
       // NOTE(joe):
       // Per https://www.ecma-international.org/ecma-262/5.1/#sec-9.6, we
       // couldn't create anything larger anyway atop JS, and 4 billion elements

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -4171,7 +4171,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         cleanQuit = false;
       }
 
-      check_array_size(len);
+      check_array_size("raw-array-build-opt", len);
       while (cleanQuit && curIdx < len) {
         if (--thisRuntime.RUNGAS <= 0) {
           thisRuntime.EXN_STACKHEIGHT = 0;

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -4096,6 +4096,18 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         $ans = thisRuntime.makeCont();
       }
 
+      checkNumInteger(len);
+      checkNumPositive(len);
+      // NOTE(joe):
+      // Per https://www.ecma-international.org/ecma-262/5.1/#sec-9.6, we
+      // couldn't create anything larger anyway atop JS, and 4 billion elements
+      // ought to be enough for anyone (cue laughter from 2050)
+      const MAX_ARRAY_SIZE = 4294967295;
+      if(jsnums.greaterThan(len, MAX_ARRAY_SIZE)) {
+        thisRuntime.throwMessageException("raw-array-build: cannot create array larger than " + MAX_ARRAY_SIZE);
+      }
+      len = jsnums.toFixnum(len);
+
       while (cleanQuit && (curIdx < len)) {
         if (--thisRuntime.RUNGAS <= 0) {
           thisRuntime.EXN_STACKHEIGHT = 0;

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -15,6 +15,8 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
   var codePointAt = codePoint.codePointAt;
   var fromCodePoint = codePoint.fromCodePoint;
 
+  const MAX_ARRAY_SIZE = 4294967295;
+
   /**
      Creates a Pyret runtime
      @param {{stdout : function(string), initialGas : number}}
@@ -4053,6 +4055,18 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       }
     }
 
+    var check_array_size = function(name, size) {
+      checkNumInteger(size);
+      checkNumPositive(size);
+      // NOTE(joe):
+      // Per https://www.ecma-international.org/ecma-262/5.1/#sec-9.6, we
+      // couldn't create anything larger anyway atop JS, and 4 billion elements
+      // ought to be enough for anyone (cue laughter from 2050)
+      if(jsnums.greaterThan(size, MAX_ARRAY_SIZE)) {
+        thisRuntime.throwMessageException(name + ": cannot create array larger than " + MAX_ARRAY_SIZE);
+      }
+    }
+
     var raw_array_from_list = function(lst) {
       if (arguments.length !== 1) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["raw-array-from-list"], 1, $a, false); }
       thisRuntime.checkArgsInternal1("RawArrays", "raw-array-from-list", lst, thisRuntime.List);
@@ -4063,6 +4077,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["raw-array-of"], 2, $a, false); }
       thisRuntime.checkArgsInternal1("RawArrays", "raw-array-of",
         len, thisRuntime.Number);
+      check_array_size("raw-array-of", len);
       var arr = new Array(len);
       var i = 0;
       while(i < len) {
@@ -4096,17 +4111,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         $ans = thisRuntime.makeCont();
       }
 
-      checkNumInteger(len);
-      checkNumPositive(len);
-      // NOTE(joe):
-      // Per https://www.ecma-international.org/ecma-262/5.1/#sec-9.6, we
-      // couldn't create anything larger anyway atop JS, and 4 billion elements
-      // ought to be enough for anyone (cue laughter from 2050)
-      const MAX_ARRAY_SIZE = 4294967295;
-      if(jsnums.greaterThan(len, MAX_ARRAY_SIZE)) {
-        thisRuntime.throwMessageException("raw-array-build: cannot create array larger than " + MAX_ARRAY_SIZE);
-      }
-      len = jsnums.toFixnum(len);
+      check_array_size("raw-array-build", len);
 
       while (cleanQuit && (curIdx < len)) {
         if (--thisRuntime.RUNGAS <= 0) {
@@ -4166,6 +4171,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
         cleanQuit = false;
       }
 
+      check_array_size(len);
       while (cleanQuit && curIdx < len) {
         if (--thisRuntime.RUNGAS <= 0) {
           thisRuntime.EXN_STACKHEIGHT = 0;

--- a/tests/pyret/tests/test-array.arr
+++ b/tests/pyret/tests/test-array.arr
@@ -282,6 +282,12 @@ check:
   raw-array-build(lam(x): x end, 9007199254740992) raises "larger than"
   raw-array-build(lam(x): x end, 4294967296) raises "larger than"
 
+  raw-array-build-opt(lam(x): x end, 2.5) raises "NumInteger"
+  raw-array-build-opt(lam(x): x end, -2) raises "NumPositive"
+  # This constant is one larger than MAX_SAFE_INTEGER in JS
+  raw-array-build-opt(lam(x): x end, 9007199254740992) raises "larger than"
+  raw-array-build-opt(lam(x): x end, 4294967296) raises "larger than"
+
   raw-array-of("a", 2.5) raises "NumInteger"
   raw-array-of("a", -2) raises "NumPositive"
   raw-array-of("a", 9007199254740992) raises "larger than"

--- a/tests/pyret/tests/test-array.arr
+++ b/tests/pyret/tests/test-array.arr
@@ -278,7 +278,12 @@ end
 check:
   raw-array-build(lam(x): x end, 2.5) raises "NumInteger"
   raw-array-build(lam(x): x end, -2) raises "NumPositive"
-  # This is one larger than MAX_SAFE_INTEGER in JS
+  # This constant is one larger than MAX_SAFE_INTEGER in JS
   raw-array-build(lam(x): x end, 9007199254740992) raises "larger than"
   raw-array-build(lam(x): x end, 4294967296) raises "larger than"
+
+  raw-array-of("a", 2.5) raises "NumInteger"
+  raw-array-of("a", -2) raises "NumPositive"
+  raw-array-of("a", 9007199254740992) raises "larger than"
+  raw-array-of("a", 4294967296) raises "larger than"
 end

--- a/tests/pyret/tests/test-array.arr
+++ b/tests/pyret/tests/test-array.arr
@@ -277,19 +277,19 @@ end
 
 check:
   raw-array-build(lam(x): x end, 2.5) raises "NumInteger"
-  raw-array-build(lam(x): x end, -2) raises "NumPositive"
+  raw-array-build(lam(x): x end, -2) raises "NumNonNegative"
   # This constant is one larger than MAX_SAFE_INTEGER in JS
   raw-array-build(lam(x): x end, 9007199254740992) raises "larger than"
   raw-array-build(lam(x): x end, 4294967296) raises "larger than"
 
   raw-array-build-opt(lam(x): x end, 2.5) raises "NumInteger"
-  raw-array-build-opt(lam(x): x end, -2) raises "NumPositive"
+  raw-array-build-opt(lam(x): x end, -2) raises "NumNonNegative"
   # This constant is one larger than MAX_SAFE_INTEGER in JS
   raw-array-build-opt(lam(x): x end, 9007199254740992) raises "larger than"
   raw-array-build-opt(lam(x): x end, 4294967296) raises "larger than"
 
   raw-array-of("a", 2.5) raises "NumInteger"
-  raw-array-of("a", -2) raises "NumPositive"
+  raw-array-of("a", -2) raises "NumNonNegative"
   raw-array-of("a", 9007199254740992) raises "larger than"
   raw-array-of("a", 4294967296) raises "larger than"
 end

--- a/tests/pyret/tests/test-array.arr
+++ b/tests/pyret/tests/test-array.arr
@@ -274,3 +274,11 @@ check:
 
   filtered is=~ raw-array-build(lam(x): x * 2 end, 2500)
 end
+
+check:
+  raw-array-build(lam(x): x end, 2.5) raises "NumInteger"
+  raw-array-build(lam(x): x end, -2) raises "NumPositive"
+  # This is one larger than MAX_SAFE_INTEGER in JS
+  raw-array-build(lam(x): x end, 9007199254740992) raises "larger than"
+  raw-array-build(lam(x): x end, 4294967296) raises "larger than"
+end

--- a/tests/pyret/tests/test-lists.arr
+++ b/tests/pyret/tests/test-lists.arr
@@ -34,6 +34,7 @@ check "range where: block":
   lists.range(0,0) is [list: ]
   lists.range(0,1) is [list: 0]
   lists.range(-5,5) is [list: -5, -4, -3, -2, -1, 0, 1, 2, 3, 4]
+  lists.range(0, 1/2) raises "Integer"
 end
 
 check "repeat where: block":


### PR DESCRIPTION
1. Make sure fractional sizes are not allowed
2. Make sure negative sizes are not allowed
3. Make sure sizes greater than what we can allocate in JS are not allowed

For 1, we can know this isn't affecting any programs that expect behavior like
floor(), because the current behavior treated fractions like 0 so nothing would
be allocated.

Ditto for 2.

For 3, I can see arguments for another (larger) size, potentially, but also I
don't think it's unreasonable for different platforms to have different limits,
and this is a pretty reasonable limit for JS. As in, I don't think we're going
to implement massive arrays atop our JS implementation, and if the language
moves on to another platform it can have a different limit there.

@blerner any objections?