### PR TITLE
Allow shadowing included ids, and more configurable REPL

### DIFF
--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -159,6 +159,7 @@ end
 # Import this module, and bind the given value and type bindings from it
 data ExtraImport:
   | extra-import(dependency :: Dependency, as-name :: String, values :: List<String>, types :: List<String>)
+  | extra-include(dependency :: Dependency)
 end
 
 data Loadable:

--- a/tests/pyret/tests/test-compile-errors.arr
+++ b/tests/pyret/tests/test-compile-errors.arr
@@ -59,15 +59,14 @@ check "underscores":
 end
 
 check "shadowing":
-  cmsgs("some = 5") is%(contain-all)
+  cmsgs(```
+  a = 10
+  block:
+    a = 5
+    a
+  end```) is%(contain-all)
   [list:
-    "declaration of `some` at ", "shadows a previous declaration of `some` defined at builtin://option"
-  ]
-  cmsgs("some = 5") is%(contain-none) [list: "and imported from" ]
-
-  cmsgs("import some from option\nsome = 5") is%(contain-all)
-  [list:
-    "declaration of `some` at ", "shadows a previous declaration of `some` defined at builtin://option", "and imported from"
+    "declaration of `a` at ", "shadows a previous declaration of `a` defined at"
   ]
 end
 

--- a/tests/pyret/tests/test-repl.arr
+++ b/tests/pyret/tests/test-repl.arr
@@ -89,12 +89,10 @@ check:
   result2 = next-interaction("sd")
   result2 satisfies E.is-right
 
+  # NOTE(joe): an odd case – sd gets and `orig-loc` of builtin://string-dict, so
+  # it hits the case where it's a module import so can be shadowed
   result3 = next-interaction("sd = 5")
-  result3 satisfies E.is-left
-  msg3 = msgs(result3)
-  msg3 is%(string-contains) "declaration of `sd` at "
-  msg3 is%(string-contains) "imported from" # TODO: update this text when the error message is fixed
-  
+  result3 satisfies E.is-right
 end
 
 check:
@@ -102,28 +100,16 @@ check:
   L.get-result-answer(result.v) is none
 
   result2 = next-interaction("some = 5")
-  result2 satisfies E.is-left
-  msg2 = msgs(result2)
-  msg2 is%(string-contains) "declaration of `some` at "
-  msg2 is%(string-contains) "shadows a previous declaration of `some` defined at builtin://option"
-  msg2 is%(string-contains) "and imported from"
+  result2 satisfies E.is-right
 
   result3 = restart("some = 5", false)
-  result3 satisfies E.is-left
-  msg3 = msgs(result3)
-  msg3 is%(string-contains) "declaration of `some` at"
-  msg3 is%(string-contains) "shadows a previous declaration of `some` defined at builtin://option"
-  msg3 is-not%(string-contains) "and imported from"
+  result3 satisfies E.is-right
 
   result4 = restart("include ast", false)
   L.get-result-answer(result4.v) is none
 
   result5 = next-interaction("s-program = 5")
-  result5 satisfies E.is-left
-  msg5 = msgs(result5)
-  msg5 is%(string-contains) "declaration of `s-program` at "
-  msg5 is%(string-contains) "shadows a previous declaration of `s-program` defined at builtin://ast"
-  msg5 is%(string-contains) "and imported from"
+  result5 satisfies E.is-right
 end
 
 check:


### PR DESCRIPTION
1. A new check in resolve-scope before reporting shadowing errors that doesn't
count shadowing errors if they are between an id and an included id (except in
the case of REPL ids from definitions:// and interactions://, which are special
origins). This is bad in some ways because e.g. the beginner who writes `circle
= circle(50, "solid", "red")` will likely be confused. But it's worth seeing
what this looks like.

2. Allow clients of the repl library to pass in preferred extra imports when
constructing the definitions locator.

3. Allow ExtraImport s to be expressed as blanket include statements