### PR TITLE
Fix Tokenizer.prototype.tokenizeFrom string length after normalizing

### DIFF
--- a/lib/jglr/jglr.js
+++ b/lib/jglr/jglr.js
@@ -216,7 +216,7 @@ define("jglr/jglr", ["jglr/rnglr"], function(E) {
       else
         this.str = str;
       
-      this.len = str.length; // XXX Not necessarily unicode-aware
+      this.len = this.str.length; // XXX Not necessarily unicode-aware
       this.curCol = 0;
       this.curLine = 1;
       this.pos = 0;

--- a/tests/pyret/tests/test-parse.arr
+++ b/tests/pyret/tests/test-parse.arr
@@ -389,7 +389,7 @@ check "should parse block comments":
   does-parse('lam(x #| stuff |#, y): x + y end') is true
   does-parse('lam(x #| two |##| comments|#, y): x + y end') is true
   does-parse('#| |# |#') is false
-	does-parse('#|क़ string length changes on normalize|#') is true
+  does-parse('#|क़ string length changes on normalize|#') is true
 end
 
 check "should not ignore the line after an empty hash comment":

--- a/tests/pyret/tests/test-parse.arr
+++ b/tests/pyret/tests/test-parse.arr
@@ -389,6 +389,7 @@ check "should parse block comments":
   does-parse('lam(x #| stuff |#, y): x + y end') is true
   does-parse('lam(x #| two |##| comments|#, y): x + y end') is true
   does-parse('#| |# |#') is false
+	does-parse('#|क़ string length changes on normalize|#') is true
 end
 
 check "should not ignore the line after an empty hash comment":

--- a/tests/pyret/tests/test-strings.arr
+++ b/tests/pyret/tests/test-strings.arr
@@ -44,6 +44,7 @@ check:
   string-length("a") is 1
   string-length("\n\r \t") is 4
   string-length("λjs") is 3
+	string-length("𢡊") is 2
   
   string-tonumber("45") is 45
   # TODO(joe): some string-to-number parsing issue on the number below

--- a/tests/pyret/tests/test-strings.arr
+++ b/tests/pyret/tests/test-strings.arr
@@ -44,7 +44,7 @@ check:
   string-length("a") is 1
   string-length("\n\r \t") is 4
   string-length("λjs") is 3
-	string-length("𢡊") is 2
+  string-length("𢡊") is 2
   
   string-tonumber("45") is 45
   # TODO(joe): some string-to-number parsing issue on the number below


### PR DESCRIPTION
This pull request addresses #1627, in which I was getting strange bugs on a particular character.

Currently `tokenizeFrom` normalizes the given source string to Unicode Normalization Form C, then stores the original string's length in a separate variable `this.len`. However, calling `.normalize()` on a string can change its length, so its necessary `this.len` reflects the length of the newly normalized string to avoid lexing errors.

This issue turns out to be pretty prevalent, and I've found a slew of characters that cause the same error in Pyret right now. Below is a small sample of them that I found with a small script, but there are a lot more (even common characters with accent marks, like é, may have this issue).

```
'̈́क़ख़ग़ज़ड़ढ़फ़य़ড়ঢ়য়ਲ਼ਸ਼ਖ਼ਗ਼ਜ਼ਫ਼ଡ଼ଢ଼གྷཌྷདྷབྷཛྷཀྵཱཱིུྲྀླཱྀྀྒྷྜྷྡྷྦྷྫྷྐྵ⫝̸𤋮𢡊𢡄𣏕𥉉𥳐𧻓יִײַשׁשׂשּׁשּׂאַאָאּבּגּדּהּוּזּטּיּךּכּלּמּנּסּףּפּצּקּרּשּתּוֹבֿכֿפֿ𝅗𝅥𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲𝆹𝅥𝆺𝅥𝆹𝅥𝅮𝆺𝅥𝅮𝆹𝅥𝅯𝆺𝅥𝅯 क़ ख़ ग़ ज़ ड़ ढ़ फ़ य़ ড় ঢ় য় ਲ਼ ਸ਼ ਖ਼ ਗ਼ ਜ਼ ਫ਼ ଡ଼ ଢ଼ གྷ ཌྷ དྷ བྷ ཛྷ ཀྵ ཱི ཱུ ྲྀ ླྀ ཱྀ ྒྷ ྜྷ ྡྷ ྦྷ ྫྷ ྐྵ ⫝̸ 𤋮 𢡊 𢡄 𣏕 𥉉 𥳐 𧻓 יִ ײַ שׁ שׂ שּׁ שּׂ אַ אָ אּ בּ גּ דּ הּ וּ זּ טּ יּ ךּ כּ לּ מּ נּ סּ ףּ פּ צּ קּ רּ שּ תּ וֹ בֿ כֿ פֿ 𝅗𝅥 𝅘𝅥 𝅘𝅥𝅮 𝅘𝅥𝅯 𝅘𝅥𝅰 𝅘𝅥𝅱 𝅘𝅥𝅲 𝆹𝅥 𝆺𝅥 𝆹𝅥𝅮 𝆺𝅥𝅮 𝆹𝅥𝅯 𝆺𝅥𝅯 
```

In addition to fixing this issue by simply having `this.len` reflect the normalized string's length, I've also written two tests in the areas that I've found this to be an issue, namely block comments and string literals. If they're misplaced / unnecessary / not enough I can certainly change them!