### PR TITLE
Add reporting of LHS values when error occurs in RHS predicate

### DIFF
--- a/src/arr/trove/checker.arr
+++ b/src/arr/trove/checker.arr
@@ -482,6 +482,52 @@ data TestResult:
           VS.vs-value(exn-unwrap(self.actual-exn)),
           VS.vs-value(self.exn-place)])
     end,
+  | failure-exn-satisfies-rhs(loc :: Loc, actual-exn, lhs-value) with:
+    method render-fancy-reason(self, maybe-stack-loc, src-available, maybe-ast):
+      if self.loc.is-builtin():
+        self.render-reason(true)
+      else if src-available(self.loc):
+        cases(Option) maybe-ast(self.loc):
+          | some(test-ast) =>
+            [ED.error:
+              on-right.test-preamble(test-ast),
+              ED.cmcode(self.loc),
+              ED.paragraph(
+                [list: ED.text("It did not expect the evaluation of the "),
+                    ED.highlight(ED.text("predicate"),  [ED.locs: test-ast.right.value.l], -3),
+                    ED.text(" to raise an exception:"),
+                    ED.embed(self.actual-exn),
+                    ED.paragraph(
+                      [list: ED.text("Given input on the "),
+                        ED.highlight(ED.text("left side"), [ED.locs: test-ast.left.l], -2),
+                        ED.text(" of the test:"),
+                        ED.paragraph([list: ED.embed(self.lhs-value)])]
+                      )])
+              ]
+          | none => self.render-reason()
+        end
+      else:
+        self.render-reason(false)
+      end
+    end,
+    method render-reason(self):
+      [ED.error:
+        [ED.para: ED.text("Got unexpected exception ")],
+        ED.embed(self.actual-exn),
+        [ED.para: ED.text("When evaluating predicate on left side value "), ED.embed(self.lhs-value)]]
+    end,
+    method access-stack(self, get-stack) block:
+      # print("The stack is being accessed")
+      # print(get-stack(self.actual-exn))
+      get-stack(self.actual-exn)
+    end,
+    method _output(self):
+      VS.vs-constr("failure-exn-satisfies-rhs",
+        [list:
+          VS.vs-value(self.loc),
+          VS.vs-value(exn-unwrap(self.actual-exn)),
+          VS.vs-value(self.lhs-value)])
+    end,
   | failure-no-exn(loc :: Loc, exn-expected :: Option<String>, exn-src, wanted :: Boolean) with:
     method render-fancy-reason(self, maybe-stack-loc, src-available, maybe-ast):
       if self.loc.is-builtin() block:
@@ -966,7 +1012,7 @@ fun make-check-context(main-module-name :: String, check-all :: Boolean):
           | right(exn) =>
             exn-v = exn-unwrap(exn)
             if E.is-arity-mismatch(exn-v) or E.is-non-function-app(exn-v): add-result(error-not-pred(loc, pv, 1))
-            else: add-result(failure-exn(loc, exn, on-right))
+            else: add-result(failure-exn-satisfies-rhs(loc, exn, lv))
             end
           | left(test-result) =>
             ask:
@@ -984,7 +1030,7 @@ fun make-check-context(main-module-name :: String, check-all :: Boolean):
           | right(exn) =>
             exn-v = exn-unwrap(exn)
             if E.is-arity-mismatch(exn-v) or E.is-non-function-app(exn-v): add-result(error-not-pred(loc, pv, 1))
-            else: add-result(failure-exn(loc, exn, on-right))
+            else: add-result(failure-exn-satisfies-rhs(loc, exn, lv))
             end
           | left(cause-result) =>
             ask:
@@ -1015,7 +1061,7 @@ fun make-check-context(main-module-name :: String, check-all :: Boolean):
           | right(exn) =>
             exn-v = exn-unwrap(exn)
             if E.is-arity-mismatch(exn-v) or E.is-non-function-app(exn-v): add-result(error-not-pred(loc, pv, 1))
-            else: add-result(failure-exn(loc, exn, on-right))
+            else: add-result(failure-exn-satisfies-rhs(loc, exn, lv))
             end
           | left(test-result) =>
             ask:
@@ -1033,7 +1079,7 @@ fun make-check-context(main-module-name :: String, check-all :: Boolean):
           | right(exn) =>
             exn-v = exn-unwrap(exn)
             if E.is-arity-mismatch(exn-v) or E.is-non-function-app(exn-v): add-result(error-not-pred(loc, pv, 1))
-            else: add-result(failure-exn(loc, exn, on-right))
+            else: add-result(failure-exn-satisfies-rhs(loc, exn, lv))
             end
           | left(cause-result) =>
             ask:


### PR DESCRIPTION
This, at least partly, addresses #1633.

In particular, it adds a new case of `TestResult`, `failure-exn-satisfies-rhs`, which is used when it a satisfies test where an exception was trigger in the RHS. In those cases, we have a value on the LHS, so we should show it along with the exception. I didn't see tests of this kind of behavior, but please point me if there is a way to do it. The four cases that will trigger the new behavior are:

```
check:
  1 satisfies lam(v): raise("error") end
end

check:
  1 satisfies lam(v): raise("error") end because 1
end

check:
  1 violates lam(v): raise("error") end
end

check:
  1 violates lam(v): raise("error") end because 1
end
```

And the new error message looks like:

<img width="677" alt="Screen Shot 2021-12-14 at 1 58 40 PM" src="https://user-images.githubusercontent.com/569509/146062288-75a23428-5ab8-4063-b28a-80249cdddd5a.png">

I noticed, as I was doing this, that there may be other cases where there is more information that could be shown, e.g., if an error is triggered by the refinement of an `is` test, neither the left nor right value is shown, which it seems like they should be:

```
check:
  1 is%(lam(v1,v2): raise("error") end) 1
end
```

Of course, there are still more variations -- e.g., if the right side of an `is` test errors, the left side value could be shown, etc. Of course, _maybe_ there is a way to make this visible in the stack trace which would subsume all of this? Though with the stack manipulation that's going on, perhaps that is expecting too much.