### PR TITLE
Make table-from-columns work with empty lists

### DIFF
--- a/src/arr/trove/tables.arr
+++ b/src/arr/trove/tables.arr
@@ -72,13 +72,16 @@ raw-row = {
   make5: lam(t1, t2, t3, t4, t5): builtins.raw-make-row([raw-array: t1, t2, t3, t4, t5]) end,
 }
 
+fun empty-table(col-names :: List<String>) -> Table:
+  for fold(t from table: ignore end.drop("ignore"),
+           c from col-names):
+    t.add-column(c, empty)
+  end
+end
+
 fun table-from-raw-array(arr):
-  cols = raw-array-get(arr, 0).get-column-names()
-  with-cols =
-    for fold(t from table: ignore end.drop("ignore"),
-            c from cols):
-      t.add-column(c, empty)
-    end
+  col-names = raw-array-get(arr, 0).get-column-names()
+  with-cols = empty-table(col-names)
   for raw-array-fold(t from with-cols, r from arr, _ from 0):
     t.add-row(r)
   end
@@ -95,13 +98,10 @@ table-from-rows = {
 }
 
 fun table-from-column<A>(col-name :: String, values :: List<A>) -> Table:
-  rows = for map(v from values):
-    raw-row.make([raw-array: {col-name; v}])
+  for fold(t from empty-table([list: col-name]), v from values):
+    t.add-row([raw-row: {col-name; v}])
   end
-  table-from-rows.make(raw-array-from-list(rows))
 end
-
-
 
 table-from-cols :: RawArray<{String; List<Any>}> -> Table
 fun table-from-cols(colspecs):

--- a/tests/pyret/tests/test-tables.arr
+++ b/tests/pyret/tests/test-tables.arr
@@ -754,3 +754,12 @@ check:
   cs.length() is 5
 end
 
+check "empty table-from-columns":
+  t = [table-from-columns:
+    {"a"; [list: ]},
+    {"b"; [list: ]}
+  ]
+
+  t.length() is 0
+  t.column-names() is [list: "a", "b"]
+end


### PR DESCRIPTION
This should fix #1653

This is my first PR so I might be wrong, but here is the solution:
When creating array from a column name and values, we don't have to map values to raw rows and then create Table out of them. Instead, we can create empty table with one column and then add all rows to it.