### PR TITLE
Some small Anchor UI updates

### DIFF
--- a/ide/package-lock.json
+++ b/ide/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ide",
       "version": "0.1.0",
       "dependencies": {
         "@babel/core": "7.9",

--- a/ide/src/App.css
+++ b/ide/src/App.css
@@ -11,6 +11,7 @@ with style={{ ... }}.
 html, body, #root {
     height: 100%;
     margin: 0;
+    font-family: sans-serif;
 }
 
 .page-container {

--- a/ide/src/App.css
+++ b/ide/src/App.css
@@ -135,7 +135,6 @@ button::-moz-focus-inner {
 .run-option-label {
     text-align: center;
     line-height: 3em;
-    font-family: sans-serif;
     font-size: 14px;
     padding-left: 1em;
     cursor: pointer;
@@ -174,8 +173,11 @@ button::-moz-focus-inner {
     background: #b30c00;
 }
 
-.run-option-disabled:hover, .run-queued:hover, .menu:hover, .menu-content-button:hover, .fs-browser-item:hover, .option:hover {
+.run-option-disabled:hover, .run-queued:hover, .menu:hover, .menu-content-button:hover, .option:hover {
     background: #979797;
+}
+.fs-browser-item:hover {
+    background: rgba(0,0,0,0.3);
 }
 
 .run-option-checkbox {
@@ -272,10 +274,10 @@ button::-moz-focus-inner {
     color: #fff;
 }
 
-.fs-browser-item {
+.fs-browser-item, .fs-browser-header {
     border: none;
     height: 2.7em;
-    background: rgba(0, 0, 0, 0.3);
+    background: darkgray;
     color: #fff;
     text-align: left;
     flex: none;

--- a/ide/src/FSBrowser.tsx
+++ b/ide/src/FSBrowser.tsx
@@ -395,6 +395,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
             >
               <label
                 className="fs-browser-item"
+                title="Upload file"
                 style={{
                   width: '2.3em',
                   height: '100%',
@@ -416,6 +417,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
               <button
                 className="fs-browser-item"
                 onClick={this.toggleEditFile}
+                title="New file"
                 type="button"
               >
                 <FilePlus />
@@ -423,6 +425,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
               <button
                 className="fs-browser-item"
                 onClick={this.toggleEditDirectory}
+                title="New folder"
                 type="button"
               >
                 <FolderPlus />

--- a/ide/src/FSBrowser.tsx
+++ b/ide/src/FSBrowser.tsx
@@ -365,7 +365,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <div
-            className="fs-browser-item"
+            className="fs-browser-header"
             style={{
               display: 'flex',
               flexDirection: 'row',
@@ -412,7 +412,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
                     display: 'none',
                   }}
                 />
-                <Upload />
+                <Upload width="20px" />
               </label>
               <button
                 className="fs-browser-item"
@@ -420,7 +420,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
                 title="New file"
                 type="button"
               >
-                <FilePlus />
+                <FilePlus width="20px" />
               </button>
               <button
                 className="fs-browser-item"
@@ -428,7 +428,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
                 title="New folder"
                 type="button"
               >
-                <FolderPlus />
+                <FolderPlus width="20px" />
               </button>
               {/* {!this.browsingRoot
                   && (

--- a/ide/src/FSBrowser.tsx
+++ b/ide/src/FSBrowser.tsx
@@ -80,8 +80,12 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
     return 0;
   }
 
+  nameInputRef: HTMLInputElement | null;
+
   constructor(props: FSBrowserProps) {
     super(props);
+
+    this.nameInputRef = null;
 
     this.state = {
       editType: undefined,
@@ -174,6 +178,11 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
     } else {
       this.setState({
         editType: EditType.CreateFile,
+      }, () => {
+        const input = this.nameInputRef;
+        if (input) {
+          input.focus();
+        }
       });
     }
   };
@@ -190,6 +199,11 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
     } else {
       this.setState({
         editType: EditType.CreateDirectory,
+      }, () => {
+        const input = this.nameInputRef;
+        if (input) {
+          input.focus();
+        }
       });
     }
   };
@@ -310,10 +324,10 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
             }}
             >
               {editType === EditType.CreateFile ? (
-                <div>Name:</div>
+                <div>New file name:</div>
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
-                  Name:
+                  New folder name:
                 </div>
               )}
             </pre>
@@ -325,6 +339,7 @@ class FSBrowser extends React.Component<FSBrowserProps, FSBrowserState> {
               }}
             >
               <input
+                ref={(input) => { that.nameInputRef = input; }}
                 type="text"
                 value={editValue}
                 onChange={that.onChange}

--- a/ide/src/FSItem.tsx
+++ b/ide/src/FSItem.tsx
@@ -14,32 +14,43 @@ type FSItemProps = {
   selected: boolean;
 };
 
-type FSItemState = {};
+type FSItemState = { hover: boolean };
 
 export default class FSItem extends React.Component<FSItemProps, FSItemState> {
+  constructor(props: FSItemProps) {
+    super(props);
+    this.state = { hover: false };
+  }
+
   render() {
     const { path, selected, onClick } = this.props;
 
     const stats = control.fs.statSync(path);
 
+    const { hover } = this.state;
+
     const label = (() => {
       if (stats.isDirectory()) {
         return (
-          <Folder />
+          <Folder width="16" />
         );
       } if (stats.isFile()) {
         return (
-          <File />
+          <File width="16" />
         );
       }
       return '?';
     })();
 
-    const background = selected ? 'darkgray' : 'rgba(0, 0, 0, 0.3)';
+    let background = 'rgba(0, 0, 0, 0.3)';
+    if (selected) background = 'darkgray';
+    if (hover) background = 'rgba(0,0,0,0.5)';
 
     return (
       <button
         onClick={onClick}
+        onMouseEnter={() => this.setState({ hover: true })}
+        onMouseLeave={() => this.setState({ hover: false })}
         style={{
           background,
           border: 0,
@@ -54,11 +65,12 @@ export default class FSItem extends React.Component<FSItemProps, FSItemState> {
         <div style={{
           display: 'flex',
           flexDirection: 'row',
+          alignItems: 'center',
         }}
         >
           <div style={{
-            width: '1em',
-            paddingRight: '1em',
+            paddingLeft: '.4em',
+            paddingRight: '.6em',
           }}
           >
             {label}


### PR DESCRIPTION
## Done in this PR

- [x] Apply sans-serif font globally, to avoid unstyled text in footer.
- [x] Add titles/tooltips to file browser icons for a11y and usability.
- [x] Adjust styling of file sidebar: align icons and names, adjust spacing, hover states
- [x] Auto-focus new file/folder name input when it's shown.

## Preview

### Before:
<img width="1098" alt="Before" src="https://user-images.githubusercontent.com/8495/210154049-d0a9d4d4-17a7-4571-9f28-22eb6725ebc5.png">

### After:

<img width="1098" alt="After" src="https://user-images.githubusercontent.com/8495/210154051-3df58527-40bb-40f4-9d37-06d2cf3cbbdf.png">


## Some proposed next steps
- Make the layout work better on phones/tablets of different sizes.
  - Relatedly, would it be interesting to make the chat interface embeddable so you could have interactive examples or a sidebar for online books like DCIC?
- Review accessibility and especially color contrast.'
- Add in support for themeing.
- Several kinds of error messages currently don't show specific line/column info but probably have enough information to.

## Questions
- When you're in a nested folder, why does the option to navigate up a layer only show up in developer mode? I can see developer mode controlling if you can exit up above "projects", or whether the option is named ".." as opposed to some more user-friendly thing. But currently, when not in developer mode, you can create and navigate to a nested folder, but you can't then escape it (except by refreshing).
- A number of the programs on the [Pyret homepage](https://www.pyret.org/index.html) don't work out-of-the-box in either anchor or CPO. In particular, `BinTree` complains about missing annotations, `print` seems to error, and `request` doesn't seem to be easily-importable. Would folks be interested in an audit of which examples work where and possibly some suggested updates?