### PR TITLE
Start anchor for phone

### DIFF
--- a/ide/src/Chatitor.tsx
+++ b/ide/src/Chatitor.tsx
@@ -221,7 +221,7 @@ function Chatitor({
   );
   const promptHint = (
     <div style={{
-      width: '48em',
+      width: '100%',
       textAlign: 'right',
       margin: '0.3em auto',
       transition: isFocused ? 'opacity 0.2s 1s ease-in' : 'opacity 0.2s ease-in',

--- a/ide/src/index.css
+++ b/ide/src/index.css
@@ -39,24 +39,15 @@ and overriding of rules. */
 }
 
 .chat-scroll {
-  width: 100%;
   overflow: auto;
   display: flex;
   flex-direction: column;
+  width: calc(min(100%, 60em) - 20px);
+  margin: 0 auto;
 }
 
-.chat-layout-compact .chats,
-.chat-layout-normal .chats {
-  margin: 2em auto;
-}
-
-.chat-layout-compact .chats {
-  width: 70em;
-  min-width: 40em;
-}
-.chat-layout-normal .chats {
-  min-width: 40em;
-  max-width: min(70%, 60em);
+.chats {
+  margin: 2em;
 }
 
 .chat-layout-compact .chat .CodeMirror,
@@ -172,8 +163,7 @@ and overriding of rules. */
 }
 
 .prompt {
-  width: 45em;
-  margin: 0 auto;
+  margin: 0 4em 0 2em;
   position: relative;
 }
 .send-button {


### PR DESCRIPTION
- [x] Redo chat and editor layout to be more responsive to narrow widths
- [ ] Improve target sizes for inputs (the + and some other buttons are too small to reliably tap)
- [ ] Full-width layout for File and Options tabs on narrow screens
- [ ] Figure out how to handle iOS default zoom.
  - iOS on default zooms in on the page and breaks the layout for inputs with fontSize < 16px. We can accept this, default to 16px font size for editor text on mobile (Adam needs to figure out how to do this), or disable all user zooming (bad for a11y)

## Preview

| Before | After|
| -- | -- |
| ![IMG_977F833546FE-1](https://user-images.githubusercontent.com/8495/210156513-6b4944f0-3d3e-42b1-adb1-61ac7709001f.jpeg) | ![IMG_05F67147ECCA-1](https://user-images.githubusercontent.com/8495/210156502-fcc09723-1b12-4673-aba5-994b14ac7d35.jpeg) | 
