### PR TITLE
Reword error messages to avoid the use of "identifier",

### DIFF
--- a/src/arr/compiler/compile-structs.arr
+++ b/src/arr/compiler/compile-structs.arr
@@ -689,7 +689,7 @@ data CompileError:
           ED.text(" errored:")],
         ED.cmcode(self.loc),
         [ED.para:
-          ED.text("This name is reserved is reserved by Pyret, and cannot be used as an identifier.")]]
+          ED.text("This name is reserved by Pyret, and cannot be used in a definition.")]]
     end,
     method render-reason(self):
       [ED.error:
@@ -698,7 +698,7 @@ data CompileError:
           ED.code(ED.text(self.id)),
           ED.text(" at "),
           ED.loc(self.loc),
-          ED.text(" is reserved by Pyret, and cannot be used as an identifier.")]]
+          ED.text(" is reserved by Pyret, and cannot be used in a definition.")]]
     end
   | contract-on-import(loc :: Loc, name :: String, import-loc :: Loc, import-uri :: String) with:
     method render-fancy-reason(self):
@@ -1328,7 +1328,7 @@ data CompileError:
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("The identifier "),
+              ED.text("The name "),
               ED.code(ED.text(self.name.toname())),
               ED.text(" at "),
               ED.loc(self.name-loc),
@@ -1347,7 +1347,7 @@ data CompileError:
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("The identifier "),
+              ED.text("The name "),
               ED.code(ED.highlight(ED.text(self.id.id.toname()), [ED.locs: self.id.l], 0)),
               ED.text(" is unbound:")],
              ED.cmcode(self.id.l),
@@ -1367,7 +1367,7 @@ data CompileError:
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("The identifier "),
+              ED.text("The name "),
               ED.code(ED.text(self.id.id.toname())),
               ED.text(" at "),
               ED.loc(self.id.l),
@@ -1511,7 +1511,7 @@ data CompileError:
       [ED.error:
         [ED.para:
           ED.text("The "),
-          ED.highlight(ED.text("identifier"), [ED.locs: self.loc], self.loc),
+          ED.highlight(ED.text("name"), [ED.locs: self.loc], self.loc),
           ED.text(" is used in a dot-annotation")],
         ED.cmcode(self.loc),
         [ED.para:
@@ -1521,7 +1521,7 @@ data CompileError:
       #### TODO ###
       [ED.error:
         [ED.para-nospace:
-          ED.text("Identifier "),
+          ED.text("The name "),
           ED.text(tostring(self.name)),
           ED.text(" is used in a dot-annotation at "),
           draw-and-highlight(self.loc),
@@ -1591,7 +1591,7 @@ data CompileError:
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("Defining the anonymous recursive identifier "),
+              ED.text("Defining the anonymous recursive binding "),
               ED.code(ED.text("rec _")),
               ED.text(" at "),
               ED.loc(self.loc),
@@ -1625,7 +1625,7 @@ data CompileError:
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("The anonymous identifier "),
+              ED.text("The anonymous binding "),
               ED.code(ED.text("shadow _")),
               ED.text(" at "),
               ED.loc(self.loc),
@@ -1823,9 +1823,9 @@ data CompileError:
         | builtin(_) =>
           [ED.error:
             [ED.para:
-              ED.text("The declaration of the identifier named "),
+              ED.text("The declaration named "),
               ED.highlight(ED.code(ED.text(self.id)), [list: self.new-loc], new-loc-color),
-              ED.text(" is preceeded in the same scope by a declaration of an identifier also named "),
+              ED.text(" is preceeded in the same scope by another declaration also named "),
               ED.highlight(ED.code(ED.text(self.id)), [list: self.old-loc], old-loc-color),
               ED.text(".")]]
         | srcloc(_, _, _, _, _, _, _) =>
@@ -1845,22 +1845,22 @@ data CompileError:
         | builtin(_) =>
           [ED.error:
             [ED.para:
-              ED.text("The declaration of the identifier named "),
+              ED.text("The declaration named "),
               ED.code(ED.text(self.id)),
               ED.text(" at "),
               ED.loc(self.new-loc),
-              ED.text(" is preceeded in the same scope by a declaration of an identifier also named "),
+              ED.text(" is preceeded in the same scope by another declaration also named "),
               ED.code(ED.text(self.id)),
               ED.text(" at "),
               ED.loc(self.old-loc)]]
         | srcloc(_, _, _, _, _, _, _) =>
           [ED.error:
             [ED.para:
-              ED.text("The declaration of the identifier named "),
+              ED.text("The declaration named "),
               ED.code(ED.text(self.id)),
               ED.text(" at "),
               ED.loc(self.new-loc),
-              ED.text(" is preceeded in the same scope by a declaration of an identifier also named "),
+              ED.text(" is preceeded in the same scope by another declaration also named "),
               ED.code(ED.text(self.id)),
               ED.text(" at "),
               ED.loc(self.old-loc)]]
@@ -1893,7 +1893,7 @@ data CompileError:
           ED.code(ED.text(self.id)),
           ED.text(" at "),
           ED.loc(self.new-loc),
-          ED.text(" is preceeded in the same object by a field of an identifier also named "),
+          ED.text(" is preceeded in the same object by a field that is also named "),
           ED.code(ED.text(self.id)),
           ED.text(" at "),
           ED.loc(self.old-loc),

--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -2088,7 +2088,7 @@ data RuntimeError:
       if self.loc.is-builtin():
         [ED.error:
           [ED.para:
-            ED.text("The identifier "), 
+            ED.text("The name "), 
             ED.code(ED.text(self.name)),
             ED.text(" is unbound in "),
             ED.loc(self.loc)],
@@ -2097,7 +2097,7 @@ data RuntimeError:
         [ED.error:
           [ED.para:
             ED.text("The "),
-            ED.highlight(ED.text("identifier"), [ED.locs: self.loc], 0)],
+            ED.highlight(ED.text("name"), [ED.locs: self.loc], 0)],
           ED.cmcode(self.loc),
           [ED.para:
             ED.text(" is unbound. Although it has been previously defined, it is being "),
@@ -2106,7 +2106,7 @@ data RuntimeError:
       else:
         [ED.error:
           [ED.para:
-            ED.text("The identifier "), 
+            ED.text("The name "), 
             ED.code(ED.text(self.name)),
             ED.text(" in "),
             ED.loc(self.loc),
@@ -2117,7 +2117,7 @@ data RuntimeError:
       if self.loc.is-builtin():
         [ED.error:
           [ED.para:
-            ED.text("The identifier "), 
+            ED.text("The name "), 
             ED.code(ED.text(self.name)),
             ED.text(" is unbound in "),
             ED.loc(self.loc)],
@@ -2125,7 +2125,7 @@ data RuntimeError:
       else:
         [ED.error:
           [ED.para:
-            ED.text("The identifier "), 
+            ED.text("The name "), 
             ED.code(ED.text(self.name)),
             ED.text(" in "),
             ED.loc(self.loc),


### PR DESCRIPTION
 while also not conflating mutable and immutable "variables"..