### PR TITLE
minor improvements to multiple-regression() function

### DIFF
--- a/src/arr/trove/statistics.arr
+++ b/src/arr/trove/statistics.arr
@@ -13,6 +13,7 @@ provide:
   variance-sample,
   stdev-sample,
   linear-regression,
+  matrix-based-multiple-regression,
   multiple-regression,
   r-squared,
   z-test,
@@ -243,7 +244,7 @@ fun matrix-based-multiple-regression(x_s_s :: List<List<Number>>, y_s :: List<Nu
   B_pred_fn
 end
 
-fun multiple-regression(x_s_s :: List<Any>, y_s :: List<Number>) -> (Any -> Number):
+fun multiple-regression(x_s_s :: List<List<Number>>, y_s :: List<Number>) -> (Any -> Number):
   doc: "returns a predictor function given a list of list of independent inputs and the correspoinding list of outputs"
   MR.multiple-regression(x_s_s, y_s)
 end

--- a/src/js/trove/multiple-regression.js
+++ b/src/js/trove/multiple-regression.js
@@ -174,7 +174,9 @@
           runtime.checkNumber(x);
           result += runtime.num_to_fixnum(x) * B[i+1][0]
         }
-        return runtime.makeNumber(result);
+        console.log('predr result before return', result);
+        return runtime.num_to_roughnum(result);
+        // return runtime.makeNumber(result);
       }
       return runtime.makeFunction(Bfunc, "predictor");
     }


### PR DESCRIPTION
- tighten arg type for multiple-regression()
- ensure multiple-regression predictor returns its JS-calculated result as roughnum
- statistics.arr also provides matrix-based-multiple-regression()