### PR TITLE
Changes to keep Examplar working with latest Anchor changes -- pls review, don't merge yet!

### DIFF
--- a/ide/src/reps/ExamplarReport.tsx
+++ b/ide/src/reps/ExamplarReport.tsx
@@ -122,7 +122,11 @@ function failingWheatTests(wheatResults: ExamplarResult[]) {
     const failResults = wheatResults.flatMap(wr => {
         if(wr.result.type !== 'run-result') { return []; }
         console.log("Wheat result: ", wr);
+        // fixme: check that .$renderedChecks exists
+        if (!wr.result.result.result.$renderedChecks) { return []; }
         const checks = wr.result.result.result.$renderedChecks as RenderedCheckResultsAndSummary;
+        // fixme: check that .renderedChecks exists
+        if (!checks.renderedChecks) { return []; }
         const failed = checks.renderedChecks.flatMap((c) => c.testResults.filter((tr) => tr.$name !== 'success'));
         if(failed.length === 0) { return []; }
         return [failed[0].rendered];

--- a/src/runtime/checker.ts
+++ b/src/runtime/checker.ts
@@ -235,7 +235,8 @@ type LocsRecord = {
 // Record<CheckOperand, Srcloc | undefined>
 
 export function makeCheckContext(mainModuleName: string, checkAll: boolean) {
-  const blockResults: CheckBlockResult[] = [];
+  // fixme: blockResults no longer constant
+  let blockResults: CheckBlockResult[] = [];
   function addBlockResult(cbr : CheckBlockResult) {
     blockResults.push(cbr);
   }
@@ -690,9 +691,17 @@ export function makeCheckContext(mainModuleName: string, checkAll: boolean) {
     },
   };
 
+  function moduleDirPart(moduleName: string) {
+    return moduleName.replace(/\/([^\/]*)$/, '');
+  }
+
   return {
     runChecks: (moduleName: string, checks: TestCase[]) => {
       console.log(`Running a check-block for ${moduleName} while in mainModule ${mainModuleName}`);
+      if (moduleDirPart(moduleName) !== moduleDirPart(mainModuleName)) {
+        // fixme: blockResults emptied when changing Anchor project dir
+        blockResults = [];
+      }
       if (checkAll || (moduleName === mainModuleName)) {
         checks.forEach(c => {
           const { name, location, keywordCheck, run } = c;


### PR DESCRIPTION
- runtime/checker.ts: blockResults initialized after every Anchor project change
- reducer.ts: improve addCodeToCheckArray() to analyze its argument checkArray's testresults, and def/use extractRelevantCode() to get better program fragments into the test results
- work around blockresults excessive accumulation (until fix)
- ExamplarReport.tsx: check .$renderedChecks and .renderedChecks are truthy to prevent errors (until fix)