### PR TITLE
Fixing pprint of AST

### DIFF
--- a/src/arr/trove/ast.arr
+++ b/src/arr/trove/ast.arr
@@ -1183,13 +1183,16 @@ data Expr:
     ) with:
     method label(self): "s-for" end,
     method tosource(self):
-      ann-part = if is-a-blank(self.ann): PP.mt-doc else: str-arrow + break-one + self.ann.tosource() end
+      ann-part =
+        if is-a-blank(self.ann): PP.mt-doc
+        else: break-one + str-arrow + break-one + self.ann.tosource()
+        end
       header = PP.group(str-for
           + self.iterator.tosource()
           + PP.surround-separate(2 * INDENT, 0, PP.lparen + PP.rparen, PP.lparen, PP.commabreak, PP.rparen,
           self.bindings.map(lam(b): b.tosource() end))
           + PP.group(PP.nest(2 * INDENT,
-            break-one + ann-part + blocky-colon(self.blocky))))
+            ann-part + blocky-colon(self.blocky))))
       PP.surround(INDENT, 1, header, self.body.tosource(), str-end)
     end
   | s-check(

--- a/src/arr/trove/file.arr
+++ b/src/arr/trove/file.arr
@@ -6,7 +6,10 @@ provide {
   file-exists: file-exists,
   file-times: file-times,
   file-to-string: file-to-string,
-  real-path: real-path
+  real-path: real-path,
+  list-files: list-files,
+  is-file: is-file,
+  is-dir: is-dir
 } end
 provide-types *
 
@@ -45,6 +48,12 @@ fun file-to-string(path) block:
 end
 
 real-path = F.real-path
+
+list-files = F.list-files
+
+is-file = F.is-file
+
+is-dir = F.is-dir
 
 fun output-file(path :: String, append :: Boolean):
   out-fd(F.open-output-file(path, append))

--- a/src/js/trove/filelib.js
+++ b/src/js/trove/filelib.js
@@ -11,6 +11,8 @@
       "file-times": "tany",
       "real-path": "tany",
       "exists": "tany",
+      "is-file": "tany",
+      "is-dir": "tany",
       "close-output-file": "tany",
       "close-input-file": "tany",
       "create-dir": "tany",
@@ -144,6 +146,26 @@
           var e = fs.existsSync(s);
           return RUNTIME.makeBoolean(e);
         }, "exists"),
+      "is-file": RUNTIME.makeFunction(function(path) {
+          RUNTIME.ffi.checkArity(1, arguments, "is-file", false);
+          RUNTIME.checkString(path);
+          var s = RUNTIME.unwrap(path);
+          if (!fs.existsSync(s)) {
+            return RUNTIME.makeBoolean(false);
+          }
+          var stats = fs.lstatSync(s);
+          return RUNTIME.makeBoolean(stats.isFile());
+        }, "is-file"),
+      "is-dir": RUNTIME.makeFunction(function(path) {
+          RUNTIME.ffi.checkArity(1, arguments, "is-file", false);
+          RUNTIME.checkString(path);
+          var s = RUNTIME.unwrap(path);
+          if (!fs.existsSync(s)) {
+            return RUNTIME.makeBoolean(false);
+          }
+          var stats = fs.lstatSync(s);
+          return RUNTIME.makeBoolean(stats.isDirectory());
+        }, "is-dir"),
       "close-output-file": RUNTIME.makeFunction(function(file) { 
           RUNTIME.ffi.checkArity(1, arguments, "close-output-file", false);
           RUNTIME.checkOpaque(file);

--- a/src/js/trove/reactors.js
+++ b/src/js/trove/reactors.js
@@ -219,7 +219,7 @@
               i += 1;
               return ans;
             });
-            console.log('tables =', tables);
+            // console.log('tables =', tables);
             return gf(tables, "internal").makeTable(["tick", "state"], rows);
             // return runtime.makeTable(["tick", "state"], rows);
           }

--- a/tests/pyret/main2.arr
+++ b/tests/pyret/main2.arr
@@ -42,6 +42,7 @@ import file("./tests/test-tuple.arr") as _
 import file("./tests/test-reactor.arr") as _
 import file("./tests/test-tail-call.arr") as _
 import file("./tests/test-parse.arr") as _
+import file("./tests/test-pprint.arr") as _
 import file("./tests/test-parse-errors.arr") as _
 import file("./tests/test-flatness.arr") as _
 import file("./tests/test-module-syntax.arr") as _

--- a/tests/pyret/tests/test-pprint.arr
+++ b/tests/pyret/tests/test-pprint.arr
@@ -1,0 +1,65 @@
+provide *
+
+import either as E
+import option as O
+import pprint as PP
+import ast as A
+import file as F
+import string-dict as SD
+import file("../test-parse-helper.arr") as TPH
+
+fun map-files-in-dir-rec<A>(dir :: String, func :: (String -> Option<A>)) -> SD.StringDict<A> block:
+  acc = [SD.mutable-string-dict: ]
+  fun help(path):
+    for each(f from F.list-files(path)):
+      shadow path = path + "/" + f
+      if F.is-file(path):
+        cases(O.Option) func(path):
+          | none => nothing
+          | some(ans) => acc.set-now(path, ans)
+        end
+      else if F.is-dir(path):
+        help(path)
+      else:
+        nothing
+      end
+    end
+  end
+  help(dir)
+  acc.freeze()
+end
+
+fun keep-arr-files(path :: String) -> Option<String>:
+  if string-ends-with(path, ".arr"): some(path) else: none end
+end
+
+files = map-files-in-dir-rec(".", keep-arr-files).keys-list()
+
+fix-numbers = A.default-map-visitor.{
+  method s-frac(self, l, num, den): A.s-num(l, num / den) end,
+  method s-rfrac(self, l, num, den): A.s-num(l, num-to-roughnum(num / den)) end
+}
+
+check:
+  for each(k from files) block:
+    print(k + "...\n")
+    src-str = F.file-to-string(k)
+    cases(E.Either) TPH.maybe-parse(src-str) block:
+      | left(_) => nothing
+      | right(ast1) =>
+        shadow ast1 = ast1.visit(fix-numbers)
+        tosource = ast1.tosource()
+        for each(len from [list: 40, 80, 160]):
+          re-src-str = tosource.pretty(len).join-str("\n")
+          cases(E.Either) TPH.maybe-parse(re-src-str) block:
+            | left(err) =>
+              err is ast1
+            | right(ast2) =>
+              shadow ast2 = ast2.visit(fix-numbers)
+              ast1.visit(A.dummy-loc-visitor) is-roughly ast2.visit(A.dummy-loc-visitor)
+          end
+        end
+    end
+  end
+end
+

--- a/tests/pyret/tests/test-tuple.arr
+++ b/tests/pyret/tests/test-tuple.arr
@@ -165,7 +165,7 @@ end
 
 check "parse and print tuple-binding":
   x = P.surface-parse("for each({k;v;} from elts): k end", "test")
-  x.tosource().pretty(80) is [list: "for each({ k; v } from elts) -> Any: k end"]
+  x.tosource().pretty(80) is [list: "for each({ k; v } from elts): k end"]
 end
 
 check "tuple deconstruction":


### PR DESCRIPTION
This PR adds a few file APIs so that we can enumerate all the files in a directory, and then run them through a round-trip parse/pretty-print/parse cycle to ensure that our printing is consistent with our parsing.  And after some bug-fixes...It nearly is!  We don't quite render numbers faithfully to their original source-text: an input of e.g. `1.25` would get printed back out as `5/4`, and then get parsed as a fraction instead.  This is pretty minor, though, so this PR confirms that pretty-printing really does work correctly.