### PR TITLE
Add more information to default where: block check names

### DIFF
--- a/src/arr/compiler/desugar-check.arr
+++ b/src/arr/compiler/desugar-check.arr
@@ -165,7 +165,7 @@ fun get-checks(stmts):
         cases(A.Expr) stmt:
           | s-fun(l, name, _, _, _, _, _, _, _check, _) =>
             cases(Option) _check:
-              | some(v) => link(check-info(l, name, v.visit(check-stmts-visitor), true), add-check(rest))
+              | some(v) => link(check-info(l, name + "()" + " where block", v.visit(check-stmts-visitor), true), add-check(rest))
               | none => add-check(rest)
             end
           | s-data(l, name, _, _, _, _, _, _check) =>


### PR DESCRIPTION
All check blocks come with a default name.

For where blocks, it is simply a copy of the function name.

With new CLI options like `--checks "only:<pat>"` that do substring matching, it's useful to have more information in these names. For example, a common case in an autograder might involve matching the name of a test case to express ``the name of the where block for the function called f''.

This changes the where block naming from:

```
file:///Users/joe/src/pyret-lang/test.arr:3:0-7:3: f (0/1)

  line 6, column 2: failed because:
    Values not equal 6 8

Passed: 0; Failed: 1; Ended in Error: 0; Total: 1
```

to:

```
file:///Users/joe/src/pyret-lang/test.arr:3:0-7:3: f() where block (0/1)

  line 6, column 2: failed because:
    Values not equal 6 8

Passed: 0; Failed: 1; Ended in Error: 0; Total: 1
```