### PR TITLE
Starting a new `filesystem`/`filesystem-internal` library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ascii-table": "^0.0.9",
         "benchmark": "^2.1.4",
         "browserify": "^17.0.1",
+        "buffer": "^6.0.3",
         "canvas": "^3.1.0",
         "command-line-args": "^3.0.5",
         "command-line-usage": "^4.0.1",
@@ -550,7 +551,7 @@
         "pako": "~1.0.5"
       }
     },
-    "node_modules/buffer": {
+    "node_modules/browserify/node_modules/buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
       "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
@@ -559,6 +560,30 @@
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ascii-table": "^0.0.9",
     "benchmark": "^2.1.4",
     "browserify": "^17.0.1",
+    "buffer": "^6.0.3",
     "canvas": "^3.1.0",
     "command-line-args": "^3.0.5",
     "command-line-usage": "^4.0.1",

--- a/src/arr/compiler/locators/builtin.arr
+++ b/src/arr/compiler/locators/builtin.arr
@@ -51,12 +51,12 @@ fun set-typable-builtins(uris :: List<String>):
 end
 
 fun make-builtin-js-locator(basedir, builtin-name):
-  raw = B.builtin-raw-locator(P.join(basedir, builtin-name))
+  raw = B.builtin-raw-locator(FS.join(basedir, builtin-name))
   {
     method needs-compile(_, _): false end,
     method get-uncached(_): none end,
     method get-modified-time(self):
-      FS.stat(P.join(basedir, builtin-name + ".js")).mtime
+      FS.stat(FS.join(basedir, builtin-name + ".js")).mtime
     end,
     method get-options(self, options):
       options.{ check-mode: false, type-check: false }
@@ -92,7 +92,7 @@ fun make-builtin-js-locator(basedir, builtin-name):
         datatypes: raw-array-to-list(raw.get-raw-datatype-provides())
       })
       some(CL.module-as-string(provs, CM.no-builtins, CM.computed-none,
-          CM.ok(JSP.ccp-file(P.join(basedir, builtin-name + ".js")))))
+          CM.ok(JSP.ccp-file(FS.join(basedir, builtin-name + ".js")))))
     end,
 
     method _equals(self, other, req-eq):
@@ -102,7 +102,7 @@ fun make-builtin-js-locator(basedir, builtin-name):
 end
 
 fun make-builtin-arr-locator(basedir, builtin-name):
-  path = P.join(basedir, builtin-name + ".arr")
+  path = FS.join(basedir, builtin-name + ".arr")
   var ast = nothing
   {
     method get-modified-time(self):
@@ -185,7 +185,7 @@ end
 
 fun maybe-make-builtin-locator(builtin-name :: String) -> Option<CL.Locator> block:
   matching-arr-files = for map(p from builtin-arr-dirs):
-    full-path = P.join(p, builtin-name + ".arr")
+    full-path = FS.join(p, builtin-name + ".arr")
     if FS.exists(full-path):
       some(full-path)
     else:
@@ -193,7 +193,7 @@ fun maybe-make-builtin-locator(builtin-name :: String) -> Option<CL.Locator> blo
     end
   end.filter(is-some).map(_.value)
   matching-js-files = for map(p from builtin-js-dirs):
-    full-path = P.join(p, builtin-name + ".js")
+    full-path = FS.join(p, builtin-name + ".js")
     if FS.exists(full-path):
       some(full-path)
     else:

--- a/src/arr/compiler/locators/builtin.arr
+++ b/src/arr/compiler/locators/builtin.arr
@@ -1,7 +1,6 @@
 provide *
 import builtin-modules as B
 import string-dict as SD
-import file as F
 import filesystem as FS
 import pathlib as P
 import parse-pyret as PP
@@ -116,7 +115,7 @@ fun make-builtin-arr-locator(basedir, builtin-name):
     end,
     method get-module(self) block:
       when ast == nothing block:
-        when not(F.file-exists(path)):
+        when not(FS.exists(path)):
           raise("File " + path + " does not exist")
         end
         ast := CL.pyret-ast(PP.surface-parse(FS.read-file-string(path), self.uri()))
@@ -143,7 +142,7 @@ fun make-builtin-arr-locator(basedir, builtin-name):
       # does not handle provides from dependencies currently
       # NOTE(joe): Until we serialize provides correctly, just return false here
       cpath = path + ".js"
-      if F.file-exists(path) and F.file-exists(cpath):
+      if FS.exists(path) and FS.exists(cpath):
         stimes = FS.stat(path)
         ctimes = FS.stat(cpath)
         ctimes.mtime <= stimes.mtime
@@ -153,7 +152,7 @@ fun make-builtin-arr-locator(basedir, builtin-name):
     end,
     method get-compiled(self):
       cpath = path + ".js"
-      if F.file-exists(path) and F.file-exists(cpath):
+      if FS.exists(path) and FS.exists(cpath):
         # NOTE(joe):
         # Since we're not explicitly acquiring locks on files, there is a race
         # condition in the next few lines – a user could potentially delete or
@@ -187,7 +186,7 @@ end
 fun maybe-make-builtin-locator(builtin-name :: String) -> Option<CL.Locator> block:
   matching-arr-files = for map(p from builtin-arr-dirs):
     full-path = P.join(p, builtin-name + ".arr")
-    if F.file-exists(full-path):
+    if FS.exists(full-path):
       some(full-path)
     else:
       none
@@ -195,7 +194,7 @@ fun maybe-make-builtin-locator(builtin-name :: String) -> Option<CL.Locator> blo
   end.filter(is-some).map(_.value)
   matching-js-files = for map(p from builtin-js-dirs):
     full-path = P.join(p, builtin-name + ".js")
-    if F.file-exists(full-path):
+    if FS.exists(full-path):
       some(full-path)
     else:
       none

--- a/src/arr/compiler/locators/jsfile.arr
+++ b/src/arr/compiler/locators/jsfile.arr
@@ -1,6 +1,7 @@
 provide *
 import builtin-modules as B
 import file as F
+import filesystem as FS
 import pathlib as P
 import file("./builtin.arr") as BL
 import file("../compile-lib.arr") as CL
@@ -17,7 +18,7 @@ fun make-jsfile-locator(path):
     method get-uncached(_): none end,
     method needs-compile(_, _): false end,
     method get-modified-time(self):
-      F.file-times(path + ".js").mtime
+      FS.stat(path + ".js").mtime
     end,
     method get-options(self, options):
       options.{ check-mode: false }
@@ -40,7 +41,7 @@ fun make-jsfile-locator(path):
       CM.standard-globals
     end,
 
-    method uri(_): "jsfile://" + string-replace(F.real-path(path + ".js"), P.path-sep, "/") end,
+    method uri(_): "jsfile://" + string-replace(FS.resolve(path + ".js"), P.path-sep, "/") end,
     method name(_): P.basename(path, "") end,
 
     method set-compiled(_, _, _): nothing end,
@@ -52,7 +53,7 @@ fun make-jsfile-locator(path):
         aliases: raw-array-to-list(raw.get-raw-alias-provides()),
         datatypes: raw-array-to-list(raw.get-raw-datatype-provides())
       })
-      some(CL.module-as-string(provs, CM.no-builtins, CM.computed-none, CM.ok(JSP.ccp-file(F.real-path(path + ".js")))))
+      some(CL.module-as-string(provs, CM.no-builtins, CM.computed-none, CM.ok(JSP.ccp-file(FS.resolve(path + ".js")))))
     end,
 
     method _equals(self, other, req-eq):

--- a/src/arr/compiler/locators/jsfile.arr
+++ b/src/arr/compiler/locators/jsfile.arr
@@ -1,6 +1,5 @@
 provide *
 import builtin-modules as B
-import file as F
 import filesystem as FS
 import pathlib as P
 import file("./builtin.arr") as BL

--- a/src/js/base/runtime.js
+++ b/src/js/base/runtime.js
@@ -3872,6 +3872,20 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       return makePause(pause, resumer);
     }
 
+    function pauseAwait(p) {
+      if(!('then' in p)) { return p; }
+
+      return pauseStack(async (restarter) => {
+        try {
+          const result = await p;
+          return restarter.resume(result);
+        }
+        catch(e) {
+          return restarter.error(e);
+        }
+      });
+    }
+
     function PausePackage() {
       this.resumeVal = null;
       this.errorVal = null;
@@ -6118,6 +6132,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'isPause'     : isPause,
 
       'pauseStack'  : pauseStack,
+      'await'       : pauseAwait,
       'schedulePause'  : schedulePause,
       'breakAll' : breakAll,
 

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -85,7 +85,18 @@
              * filesystemprovider) */
             return fsp.mkdir(p);
         }
-
+        async function relative(from, to) {
+            return path.relative(from, to);
+        }
+        async function isAbsolute(p) {
+            return path.isAbsolute(p);
+        }
+        async function basename(p) {
+            return path.basename(p);
+        }
+        async function dirname(p) {
+            return path.dirname(p);
+        }
         return runtime.makeJSModuleReturn({
             readFile: wrap(readFile),
             writeFile: wrap(writeFile),
@@ -95,6 +106,10 @@
             join: wrap(join),
             'path-sep': path.sep,
             createDir: wrap(createDir),
+            relative: wrap(relative),
+            isAbsolute: wrap(isAbsolute),
+            basename: wrap(basename),
+            dirname: wrap(dirname),
         });
     }
 })

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -64,9 +64,12 @@
             };
         }
 
-
         async function resolve(...paths) {
             return path.resolve(...paths);
+        }
+
+        async function exists(p) {
+            return fsp.exists(p);
         }
 
         return runtime.makeJSModuleReturn({
@@ -74,7 +77,7 @@
             writeFile: wrap(writeFile),
             stat: wrap(stat),
             resolve: wrap(resolve),
-            init: initializedOK
+            exists: wrap(exists),
         });
     }
 })

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -73,7 +73,8 @@
             readFile: wrap(readFile),
             writeFile: wrap(writeFile),
             stat: wrap(stat),
-            resolve: wrap(resolve)
+            resolve: wrap(resolve),
+            init: initializedOK
         });
     }
 })

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -69,7 +69,10 @@
         }
 
         async function exists(p) {
-            return fsp.exists(p);
+            // NOTE(joe): this is sync because the async version is deprecated
+            // See https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_existssync_path
+            // Also, `exists` is not defined on the `fs.promises` api
+            return fs.existsSync(p);
         }
 
         return runtime.makeJSModuleReturn({

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -79,6 +79,13 @@
             return path.join(...paths);
         }
 
+        async function createDir(p) {
+            /* NOTE(joe): this does not create parent dirs because other
+             * platforms may not support it (in particular VScode
+             * filesystemprovider) */
+            return fsp.mkdir(p);
+        }
+
         return runtime.makeJSModuleReturn({
             readFile: wrap(readFile),
             writeFile: wrap(writeFile),
@@ -87,6 +94,7 @@
             exists: wrap(exists),
             join: wrap(join),
             'path-sep': path.sep,
+            createDir: wrap(createDir),
         });
     }
 })

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -34,11 +34,11 @@
         }
         const fsp = fs.promises;
         function wrap(f) {
-            return async function(...args) {
-                if(!initializedOK) {
+            if(initializedOK) { return f; }
+            else {
+                return async function(...args) {
                     throw runtime.ffi.makeMessageException(`filesystem-internal: Cannot call ${f.name} because fs.promises not available`)
                 }
-                return f(...args);
             }
         }
         async function readFile(p) {
@@ -75,12 +75,18 @@
             return fs.existsSync(p);
         }
 
+        async function join(...paths) {
+            return path.join(...paths);
+        }
+
         return runtime.makeJSModuleReturn({
             readFile: wrap(readFile),
             writeFile: wrap(writeFile),
             stat: wrap(stat),
             resolve: wrap(resolve),
             exists: wrap(exists),
+            join: wrap(join),
+            'path-sep': path.sep,
         });
     }
 })

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -4,11 +4,16 @@
     ],
     provides: {
         values: {
-            'read-file-string': ["arrow", ["String"], "String"]
-        }
+            'read-file-string': ["arrow", ["String"], "String"],
+            'write-file-string': ["arrow", ["String", "String"], "String"],
+            'stat': ["arrow", ["String"], "Any"],
+            'resolve': ["arrow", ["String"], "String"],
+        },
+        types: {}
     },
-    nativeRequires: [],
-    theModule: function(runtime, _, _, fsInternal) {
+    nativeRequires: ['buffer'],
+    theModule: function(runtime, _, _, fsInternal, buffer) {
+        const Buffer = buffer.Buffer;
         function readFileString(path) {
             runtime.checkArgsInternal1('filesystem', 'read-file-string', path, runtime.String);
             const result = fsInternal.readFile(path)
@@ -20,13 +25,27 @@
             const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8'));
             return runtime.await(result);
         }
+        function resolve(path) {
+            const result = fsInternal.resolve(path);
+            return runtime.await(result);
+        }
         function stat(path) {
             runtime.checkArgsInternal1('filesystem', 'stat', path, runtime.String);
-            return runtime.makeObj
+            const result = fsInternal.stat(path).then((stats) => {
+                return runtime.makeObject({
+                    ctime: stats.ctime,
+                    mtime: stats.mtime,
+                    size: stats.size,
+                    native: stats
+                });
+            });
+            return runtime.await(result);
         }
         return runtime.makeModuleReturn({
             'read-file-string': runtime.makeFunction(readFileString),
             'write-file-string': runtime.makeFunction(writeFileString),
+            'stat': runtime.makeFunction(stat),
+            'resolve': runtime.makeFunction(resolve),
         }, {});
     }
 })

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -10,7 +10,11 @@
             'resolve': ["arrow", ["String"], "String"],
             'exists': ["arrow", ["String"], "Boolean"],
             'join': ["arrow", ["String", "String"], "String"],
-            'create-dir': ["arrow", ["String"], "String"]
+            'create-dir': ["arrow", ["String"], "String"],
+            'basename': ["arrow", ["String"], "String"],
+            'dirname': ["arrow", ["String"], "String"],
+            'relative': ["arrow", ["String", "String"], "String"],
+            'is-absolute': ["arrow", ["String"], "Boolean"],
         },
         types: {}
     },
@@ -58,6 +62,26 @@
             const result = fsInternal.createDir(path);
             return runtime.await(result);
         }
+        function basename(path) {
+            runtime.checkArgsInternal1('filesystem', 'basename', path, runtime.String);
+            const result = fsInternal.basename(path);
+            return runtime.await(result);
+        }
+        function dirname(path) {
+            runtime.checkArgsInternal1('filesystem', 'dirname', path, runtime.String);
+            const result = fsInternal.dirname(path);
+            return runtime.await(result);
+        }
+        function relative(from, to) {
+            runtime.checkArgsInternal2('filesystem', 'relative', from, runtime.String, to, runtime.String);
+            const result = fsInternal.relative(from, to);
+            return runtime.await(result);
+        }
+        function isAbsolute(path) {
+            runtime.checkArgsInternal1('filesystem', 'is-absolute', path, runtime.String);
+            const result = fsInternal.isAbsolute(path);
+            return runtime.await(result);
+        }
         return runtime.makeModuleReturn({
             'read-file-string': runtime.makeFunction(readFileString),
             'write-file-string': runtime.makeFunction(writeFileString),
@@ -66,6 +90,10 @@
             'exists': runtime.makeFunction(exists),
             'join': runtime.makeFunction(join),
             'create-dir': runtime.makeFunction(createDir),
+            'basename': runtime.makeFunction(basename),
+            'dirname': runtime.makeFunction(dirname),
+            'relative': runtime.makeFunction(relative),
+            'is-absolute': runtime.makeFunction(isAbsolute),
         }, {});
     }
 })

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -29,7 +29,7 @@
         }
         function writeFileString(path, data) {
             runtime.checkArgsInternal2('filesystem', 'write-file-string', path, runtime.String, data, runtime.String);
-            const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8'));
+            const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8')).then(() => runtime.nothing);
             return runtime.await(result);
         }
         function resolve(path) {
@@ -59,7 +59,7 @@
         }
         function createDir(path) {
             runtime.checkArgsInternal1('filesystem', 'create-dir', path, runtime.String);
-            const result = fsInternal.createDir(path);
+            const result = fsInternal.createDir(path).then(() => runtime.nothing);
             return runtime.await(result);
         }
         function basename(path) {

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -9,7 +9,8 @@
             'stat': ["arrow", ["String"], "Any"],
             'resolve': ["arrow", ["String"], "String"],
             'exists': ["arrow", ["String"], "Boolean"],
-            'join': ["arrow", ["String", "String"], "String"]
+            'join': ["arrow", ["String", "String"], "String"],
+            'create-dir': ["arrow", ["String"], "String"]
         },
         types: {}
     },
@@ -52,6 +53,11 @@
             const result = fsInternal.exists(path);
             return runtime.await(result);
         }
+        function createDir(path) {
+            runtime.checkArgsInternal1('filesystem', 'create-dir', path, runtime.String);
+            const result = fsInternal.createDir(path);
+            return runtime.await(result);
+        }
         return runtime.makeModuleReturn({
             'read-file-string': runtime.makeFunction(readFileString),
             'write-file-string': runtime.makeFunction(writeFileString),
@@ -59,6 +65,7 @@
             'resolve': runtime.makeFunction(resolve),
             'exists': runtime.makeFunction(exists),
             'join': runtime.makeFunction(join),
+            'create-dir': runtime.makeFunction(createDir),
         }, {});
     }
 })

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -24,20 +24,33 @@
         function readFileString(path) {
             runtime.checkArgsInternal1('filesystem', 'read-file-string', path, runtime.String);
             const result = fsInternal.readFile(path)
-                .then((contents) => Buffer.from(contents).toString('utf8'));
+                .then((contents) => Buffer.from(contents).toString('utf8'))
+                .catch((err) => {
+                    throw runtime.throwMessageException(`Error reading file: ${path}: ${String(err)}`);
+                });
             return runtime.await(result);
         }
         function writeFileString(path, data) {
             runtime.checkArgsInternal2('filesystem', 'write-file-string', path, runtime.String, data, runtime.String);
-            const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8')).then(() => runtime.nothing);
+            const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8'))
+                .then(() => runtime.nothing)
+                .catch((err) => {
+                    throw runtime.throwMessageException(`Error writing file: ${path}: ${String(err)}`);
+                });
             return runtime.await(result);
         }
         function resolve(path) {
-            const result = fsInternal.resolve(path);
+            const result = fsInternal.resolve(path)
+                .catch((err) => {
+                    throw runtime.throwMessageException(`Error resolving path: ${path}: ${String(err)}`);
+                });
             return runtime.await(result);
         }
         function join(path1, path2) {
-            const result = fsInternal.join(path1, path2);
+            const result = fsInternal.join(path1, path2)
+                .catch((err) => {
+                    throw runtime.throwMessageException(`Error joining paths: ${path1}, ${path2}: ${String(err)}`);
+                });
             return runtime.await(result);
         }
         function stat(path) {
@@ -49,37 +62,58 @@
                     size: stats.size,
                     native: stats
                 });
+            })
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error getting stats for file: ${path}: ${String(err)}`);
             });
             return runtime.await(result);
         }
         function exists(path) {
             runtime.checkArgsInternal1('filesystem', 'exists', path, runtime.String);
-            const result = fsInternal.exists(path);
+            const result = fsInternal.exists(path)
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error checking existence of file: ${path}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         function createDir(path) {
             runtime.checkArgsInternal1('filesystem', 'create-dir', path, runtime.String);
-            const result = fsInternal.createDir(path).then(() => runtime.nothing);
+            const result = fsInternal.createDir(path).then(() => runtime.nothing)
+            .catch(err => {
+                throw runtime.throwMessageException(`Error creating directory: ${path}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         function basename(path) {
             runtime.checkArgsInternal1('filesystem', 'basename', path, runtime.String);
-            const result = fsInternal.basename(path);
+            const result = fsInternal.basename(path)
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error getting basename of path: ${path}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         function dirname(path) {
             runtime.checkArgsInternal1('filesystem', 'dirname', path, runtime.String);
-            const result = fsInternal.dirname(path);
+            const result = fsInternal.dirname(path)
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error getting dirname of path: ${path}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         function relative(from, to) {
             runtime.checkArgsInternal2('filesystem', 'relative', from, runtime.String, to, runtime.String);
-            const result = fsInternal.relative(from, to);
+            const result = fsInternal.relative(from, to)
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error getting relative path from ${from} to ${to}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         function isAbsolute(path) {
             runtime.checkArgsInternal1('filesystem', 'is-absolute', path, runtime.String);
-            const result = fsInternal.isAbsolute(path);
+            const result = fsInternal.isAbsolute(path)
+            .catch((err) => {
+                throw runtime.throwMessageException(`Error checking if path is absolute: ${path}: ${String(err)}`);
+            });
             return runtime.await(result);
         }
         return runtime.makeModuleReturn({

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -9,6 +9,7 @@
             'stat': ["arrow", ["String"], "Any"],
             'resolve': ["arrow", ["String"], "String"],
             'exists': ["arrow", ["String"], "Boolean"],
+            'join': ["arrow", ["String", "String"], "String"]
         },
         types: {}
     },
@@ -28,6 +29,10 @@
         }
         function resolve(path) {
             const result = fsInternal.resolve(path);
+            return runtime.await(result);
+        }
+        function join(path1, path2) {
+            const result = fsInternal.join(path1, path2);
             return runtime.await(result);
         }
         function stat(path) {
@@ -53,6 +58,7 @@
             'stat': runtime.makeFunction(stat),
             'resolve': runtime.makeFunction(resolve),
             'exists': runtime.makeFunction(exists),
+            'join': runtime.makeFunction(join),
         }, {});
     }
 })

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -1,0 +1,32 @@
+({
+    requires: [
+        { "import-type": "builtin", "name": "filesystem-internal" },
+    ],
+    provides: {
+        values: {
+            'read-file-string': ["arrow", ["String"], "String"]
+        }
+    },
+    nativeRequires: [],
+    theModule: function(runtime, _, _, fsInternal) {
+        function readFileString(path) {
+            runtime.checkArgsInternal1('filesystem', 'read-file-string', path, runtime.String);
+            const result = fsInternal.readFile(path)
+                .then((contents) => Buffer.from(contents).toString('utf8'));
+            return runtime.await(result);
+        }
+        function writeFileString(path, data) {
+            runtime.checkArgsInternal2('filesystem', 'write-file-string', path, runtime.String, data, runtime.String);
+            const result = fsInternal.writeFile(path, Buffer.alloc(data.length, data, 'utf8'));
+            return runtime.await(result);
+        }
+        function stat(path) {
+            runtime.checkArgsInternal1('filesystem', 'stat', path, runtime.String);
+            return runtime.makeObj
+        }
+        return runtime.makeModuleReturn({
+            'read-file-string': runtime.makeFunction(readFileString),
+            'write-file-string': runtime.makeFunction(writeFileString),
+        }, {});
+    }
+})

--- a/src/js/trove/filesystem.js
+++ b/src/js/trove/filesystem.js
@@ -5,9 +5,10 @@
     provides: {
         values: {
             'read-file-string': ["arrow", ["String"], "String"],
-            'write-file-string': ["arrow", ["String", "String"], "String"],
+            'write-file-string': ["arrow", ["String", "String"], "Nothing"],
             'stat': ["arrow", ["String"], "Any"],
             'resolve': ["arrow", ["String"], "String"],
+            'exists': ["arrow", ["String"], "Boolean"],
         },
         types: {}
     },
@@ -41,11 +42,17 @@
             });
             return runtime.await(result);
         }
+        function exists(path) {
+            runtime.checkArgsInternal1('filesystem', 'exists', path, runtime.String);
+            const result = fsInternal.exists(path);
+            return runtime.await(result);
+        }
         return runtime.makeModuleReturn({
             'read-file-string': runtime.makeFunction(readFileString),
             'write-file-string': runtime.makeFunction(writeFileString),
             'stat': runtime.makeFunction(stat),
             'resolve': runtime.makeFunction(resolve),
+            'exists': runtime.makeFunction(exists),
         }, {});
     }
 })

--- a/src/js/trove/require-node-compile-dependencies.js
+++ b/src/js/trove/require-node-compile-dependencies.js
@@ -20,6 +20,9 @@ define("seedrandom", [], function() {return seedrandom;});
 sourcemap = require("source-map");
 define("source-map", [], function () { return sourcemap; });
 
+buffer = require("buffer");
+define("buffer", [], function () { return buffer; });
+
 jssha256 = require("js-sha256");
 define("js-sha256", [], function () { return jssha256; });
 

--- a/src/js/trove/require-node-dependencies.js
+++ b/src/js/trove/require-node-dependencies.js
@@ -29,6 +29,9 @@ define("source-map", [], function () { return sourcemap; });
 jssha256 = require("js-sha256");
 define("js-sha256", [], function () { return jssha256; });
 
+buffer = require("buffer");
+define("buffer", [], function () { return buffer; });
+
 fs = nodeRequire("fs");
 define("fs", [], function () { return fs; });
 

--- a/tests/pyret/main2.arr
+++ b/tests/pyret/main2.arr
@@ -28,6 +28,7 @@ import file("./tests/test-record-concat.arr") as _
 import file("./tests/test-rec.arr") as _
 import file("./tests/test-compile-errors.arr") as _
 import file("./tests/test-well-formed.arr") as _
+import file("./tests/test-filesystem.arr") as _
 import file("./tests/test-file.arr") as _
 import file("./tests/test-path.arr") as _
 import file("./tests/test-repl.arr") as _

--- a/tests/pyret/tests/test-filesystem.arr
+++ b/tests/pyret/tests/test-filesystem.arr
@@ -14,6 +14,8 @@ check:
   FS.exists(p) is true
   p2 = "./non-existing-file"
   FS.exists(p2) is false
+
+  FS.read-file-string("nonexistent") raises "ENOENT"
 end
 
 check:

--- a/tests/pyret/tests/test-filesystem.arr
+++ b/tests/pyret/tests/test-filesystem.arr
@@ -5,5 +5,14 @@ s = "fairly unique string to test this filesystem test"
 check:
   contents = FS.read-file-string("./tests/pyret/tests/test-filesystem.arr")
   contents satisfies string-contains(_, s)
+
+  p = FS.resolve("./tests/../tests/pyret/tests/./test-file.arr")
+  expected = [list: "", "tests", "pyret", "tests", "test-file.arr"].join-str("/")
+  l = string-split(p, expected)
+  l.length() is 2
+  l.get(1) is ""
+  FS.exists(p) is true
+  p2 = "./non-existing-file"
+  FS.exists(p2) is false
 end
 

--- a/tests/pyret/tests/test-filesystem.arr
+++ b/tests/pyret/tests/test-filesystem.arr
@@ -16,3 +16,37 @@ check:
   FS.exists(p2) is false
 end
 
+check:
+    FS.relative("/a/b/c", "/d/e/f") is "../../../d/e/f"
+    FS.relative("a/b/c", "d/e/f") is "../../../d/e/f"
+    FS.relative(FS.resolve("a/b/c"), FS.resolve("d/e/f")) is "../../../d/e/f"
+    FS.relative("a/b/c", "file.arr") is "../../../file.arr"
+    FS.relative(".", "a/b/c/file.arr") is "a/b/c/file.arr"
+    FS.relative("a", "a/b/c/file.arr") is "b/c/file.arr"
+    FS.relative("a/b", "a/b/c/file.arr") is "c/file.arr"
+
+    FS.relative("a/b/c", "a/b/file.arr") is "../file.arr"
+end
+
+check:
+    "/" satisfies FS.is-absolute
+    "/a/b/c" satisfies FS.is-absolute
+    "/../a/b/c" satisfies FS.is-absolute
+    "/a/../c/d" satisfies FS.is-absolute
+    "../../../../../../../../.." violates FS.is-absolute
+    "." violates FS.is-absolute
+    ".." violates FS.is-absolute
+    "a/b/c" violates FS.is-absolute
+    "./a/b/c" violates FS.is-absolute
+end
+
+check:
+    FS.basename("/a/b/c") is "c"
+    FS.basename("/a/b/c.arr") is "c.arr"
+    FS.basename("rel/dir/c.arr") is "c.arr"
+    FS.basename("a") is "a"
+
+    FS.dirname("a") is "."
+    FS.dirname(".") is "."
+    FS.dirname("./a/b/c/file.txt") is "./a/b/c"
+end

--- a/tests/pyret/tests/test-filesystem.arr
+++ b/tests/pyret/tests/test-filesystem.arr
@@ -1,0 +1,9 @@
+import filesystem as FS
+
+s = "fairly unique string to test this filesystem test"
+
+check:
+  contents = FS.read-file-string("./tests/pyret/tests/test-filesystem.arr")
+  contents satisfies string-contains(_, s)
+end
+


### PR DESCRIPTION
This is very much a WIP, not worth comments yet but I find keeping a PR open and up-to-date useful.

It is this, but unironically: https://xkcd.com/927/

The idea is to:

- Pick a small set of filesystem functionality we can support across VScode extensions, Node FS, browserFS, and whatever the next not-quite-a-real-fs platform is.
- Compile with a different filesystem-internal in different contexts (CPO will override this builtin import) that always has a consistent interface that is relatively easy to provide across contexts
- Allow `filesystem` to rely on that interface to provide any Pyret-level users with the desired functionality

