### PR TITLE
[DRAFT] Change table load to retain original header row, for improved errors

### DIFF
--- a/src/arr/trove/error.arr
+++ b/src/arr/trove/error.arr
@@ -18,6 +18,9 @@ end
 fun horz-list-values(vals):
   [ED.para: ED.h-sequence(vals.map(lam(val): ED.embed(val) end), ",") ]
 end
+fun horz-list-str-ids(vals):
+  [ED.para: ED.h-sequence(vals.map(lam(val): ED.text(val) end), ",") ]
+end
 
 fun ed-simple-intro(name, loc):
   ed-simple-intro-a-an(name, loc, "a")
@@ -1924,6 +1927,39 @@ data RuntimeError:
           [ED.para: ED.text(" but got " + this-str), ED.embed(num-args), ED.text(arg-str)],
           vert-list-values(self.fun-app-args)])
     end
+
+    | header-row-mismatch(expected-headers, orig-headers, provided-row) with:
+    method render-fancy-reason(self, maybe-stack-loc, src-available, maybe-ast):
+      cases(O.Option) maybe-stack-loc(0, true):
+        | some(l) =>
+          [ED.error:
+            ed-intro("table construction", l, -1, true),
+            [ED.para: ED.text("The table could not be constructed because the number of expected headers didn't match the number found in the data.")],
+            [ED.para: ED.text("Expected to have " + num-to-string(raw-array-length(self.expected-headers)) + " columns:")],
+            horz-list-str-ids(raw-array-to-list(self.expected-headers)),
+            cases(O.Option) self.orig-headers:
+              | some(oh) =>
+                [ED.para: [ED.para: ED.text("Instead, found header with " + num-to-string(raw-array-length(oh)) + " columns:"),
+                                    horz-list-str-ids(raw-array-to-list(oh))],
+                          [ED.para: ED.text("And data with " + num-to-string(raw-array-length(self.provided-row)) + " columns:"),
+                                    horz-list-values(raw-array-to-list(self.provided-row))]]
+              | none =>
+                [ED.para: ED.text("But found data with " + num-to-string(raw-array-length(self.provided-row)) + " columns:"),
+                                   horz-list-values(raw-array-to-list(self.provided-row))]
+            end,
+            ]
+        | none => self.render-reason()
+      end
+    end,
+    method render-reason(self):
+      [ED.error:
+        [ED.para: ED.text("The row could not be constructed because the number of columns didn't match the number of provided values.")],
+        [ED.para: ED.text("Expected " + num-to-string(raw-array-length(self.colnames)) + " columns:")],
+        ED.embed(self.colnames),
+        [ED.para: ED.text("Provided " + num-to-string(raw-array-length(self.provided-vals)) + " values:")],
+        horz-list-values(raw-array-to-list(self.provided-vals))]
+    end
+
 
   | row-length-mismatch(colnames, provided-vals) with:
     method render-fancy-reason(self, maybe-stack-loc, src-available, maybe-ast):

--- a/src/js/trove/ffi.js
+++ b/src/js/trove/ffi.js
@@ -371,6 +371,11 @@
       raise(err("arity-mismatch")(funLoc, arity, args, isMethod));
     }
 
+    function throwHeaderRowMismatch(colnames, origHeaders, providedVals) {
+      runtime.checkArray(providedVals);
+      raise(err("header-row-mismatch")(colnames, origHeaders, providedVals));
+    }
+
     function throwRowLengthMismatch(colnames, providedVals) {
       runtime.checkArray(providedVals);
       raise(err("row-length-mismatch")(colnames, providedVals));
@@ -634,6 +639,7 @@
       throwUninitializedIdMkLoc: throwUninitializedIdMkLoc,
       throwArityError: throwArityError,
       throwArityErrorC: throwArityErrorC,
+      throwHeaderRowMismatch: throwHeaderRowMismatch,
       throwRowLengthMismatch: throwRowLengthMismatch,
       throwColLengthMismatch: throwColLengthMismatch,
       throwConstructorArityErrorC: throwConstructorArityErrorC,

--- a/src/js/trove/table.js
+++ b/src/js/trove/table.js
@@ -165,14 +165,16 @@
 
     function openTable(info) {
       runtime.checkTuple(info);
-      if (info.vals.length != 2) {
-        runtime.ffi.throwMessageException("Expected to find {header; contents} pair, "
+      if (info.vals.length != 3) {
+        runtime.ffi.throwMessageException("Expected to find {header; orig-headers; contents} triple, "
                                           + "but found a tuple of length "
                                           + info.vals.length);
       }
       var headers = info.vals[0];
-      var contents = info.vals[1];
+      var origHeaders = info.vals[1];
+      var contents = info.vals[2];
       runtime.checkArray(headers);
+      // runtime.checkPyretVal(origHeaders); // Can we do better?
       runtime.checkArray(contents);
       var names = [];
       var sanitizers = [];
@@ -194,7 +196,7 @@
           runtime.checkArray(contents[i]);
           if (contents[i].length !== headers.length) {
             if (i === 0) {
-              throw runtime.ffi.throwRowLengthMismatch(names, contents[i]);
+              throw runtime.ffi.throwHeaderRowMismatch(names, origHeaders, contents[i]);
             } else {
               throw runtime.ffi.throwMessageException("Contents must be rectangular");
             }

--- a/tests/pyret/tests/test-tables.arr
+++ b/tests/pyret/tests/test-tables.arr
@@ -90,7 +90,7 @@ check "Basic Table Loading":
       {raw-array-get(titles, 1); sanitizer.sanitizer}]
     contents = [raw-array: [raw-array: DS.c-str(name), DS.c-str("12")],
       [raw-array: DS.c-str("Alice"), DS.c-num(15)]]
-    {headers; contents}
+    {headers; none; contents}
   end
   make-loader = {(x): {load: lam(titles, sanitizer): with-tl(x, titles, sanitizer) end}}
   (load-table: name, age


### PR DESCRIPTION
Currently the error when you have the wrong number of columns listed is better than it was originally (relating to #1779), but it still makes no reference to the headers _in the source itself_. 

In the case that we are loading from a CSV (or, google sheets?) it seems like we should show that header row when we display the error, ideally in a form that could be copied and pasted. 

This is definitely a draft -- it doesn't touch the google sheet code (which I don't know where lives -- CPO?), and I'm not sure if this is the _right_ way to retain that info, but throwing out the header row immediately makes it impossible to report a good error. 

With this change, mismatches report the header columns that showed up in the CSV (if present), as well as the first data row (as an example). The `c-str`s aren't ideal, but I didn't want to spend time refining in case there is another approach that would be better (also, they were already there with current behavior). 

<img width="657" alt="Screenshot 2025-06-27 at 1 14 51 PM" src="https://github.com/user-attachments/assets/1b819571-ca1e-47ad-9ae1-74cf0edef234" />
