### PR TITLE
Fix add-line overlay

### DIFF
--- a/src/js/trove/make-image.js
+++ b/src/js/trove/make-image.js
@@ -818,7 +818,7 @@
         var color = unwrapColor(maybeC);
         var img   = unwrapImage(maybeImg);
         var line  = image.makeLineImage(x2 - x1, y2 - y1, color);
-        return makeImage(image.makeOverlayImage(line, "left", "top", 0, 0, img, "left", "top"));
+        return makeImage(image.makeOverlayImage(line, "left", "top", -x1, -y1, img, "left", "top"));
       });
 
       f("scene-line", function(maybeImg, maybeX1, maybeY1, maybeX2, maybeY2, maybeC) {


### PR DESCRIPTION
The origin for the line should be at x1, y1, but since the arguments to makeOverlayImage move the _background_ right and down, we need to reverse both. This will mean that the background goes left and up and the start of the line is at the right place.

This fixes #1801.