### PR TITLE
js-numbers.js: log() for nonintegral rational arguments = log(numr) - log(denr)

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -826,6 +826,11 @@ define("pyret-base/js/js-numbers", function() {
     if (typeof(n) === 'number') {
       return Roughnum.makeInstance(Math.log(n), errbacks);
     }
+    if (isRational(n) && !isInteger(n)) {
+      return subtract(log(numerator(n, errbacks)),
+        log(denominator(n, errbacks)),
+        errbacks);
+    }
     var nFix = n.toFixnum();
     if (typeof(nFix) === 'number' && nFix !== Infinity) {
       return Roughnum.makeInstance(Math.log(nFix), errbacks);

--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -827,8 +827,8 @@ define("pyret-base/js/js-numbers", function() {
       return Roughnum.makeInstance(Math.log(n), errbacks);
     }
     if (isRational(n) && !isInteger(n)) {
-      return subtract(log(numerator(n, errbacks)),
-        log(denominator(n, errbacks)),
+      return subtract(log(numerator(n, errbacks), errbacks),
+        log(denominator(n, errbacks), errbacks),
         errbacks);
     }
     var nFix = n.toFixnum();

--- a/tests/pyret/tests/test-numbers.arr
+++ b/tests/pyret/tests/test-numbers.arr
@@ -185,6 +185,9 @@ check:
   # Racket gives ~84709.80298615794, Wolfram ~84709.80298615795
   num-log(1e36789) is-roughly ~84709.80298615796
 
+  # Racket gives ~-171658.17010439213, Wolfram 171658.170104392139
+  num-log(1 / num-expt(9, num-expt(5, 7))) is-roughly ~-171658.17010439216
+
   # Racket, Wolfram match
   # commenting because arg calculation takes much time
   # num-log(num-expt(10, 1e5)) is-roughly ~230258.50929940457


### PR DESCRIPTION
Add an additional conditional for non-integral rationals before trying its fixnum equivalent or its large-positive-number equivalent.  For `p/q`, this calculates `log(p) - log(q)`, where `p` and/or `q` can be very large. 

I.e., we don't want to immediately find the fixnum equivalent of `p/q` which could cause roughnum underflow. (Or overflow -- but we already took care of the roughnum overflow by next viewing `p/q` as a large bigint, for which we do have a good log approximation.)

Test:
```
# Racket gives ~-171658.17010439213, Wolfram 171658.170104392139
num-log(1 / num-expt(9, num-expt(5, 7))) is-roughly ~-171658.17010439216
```