### PR TITLE
fix(scripts/show-compilation): use `default-start-context`

### DIFF
--- a/src/scripts/show-compilation.arr
+++ b/src/scripts/show-compilation.arr
@@ -41,7 +41,7 @@ parsed-options = C.parse-cmdline(cl-options)
 
 compile-str = lam(filename, options):
   base-module = CS.dependency("file-no-cache", [list: filename])
-  base = CLI.module-finder({current-load-path:"./", cache-base-dir: "./compiled"}, base-module)
+  base = CLI.module-finder(CLI.default-start-context, base-module)
   wlist = CL.compile-worklist(CLI.module-finder, base.locator, base.context)
   traces = SD.make-mutable-string-dict()
   result = CL.compile-program(wlist, options.{


### PR DESCRIPTION
Previously running the script resulted in:

```
❯ node ./show-compilation.jarr examples/ahoy-world.arr
Success
File is examples/ahoy-world.arr
The run ended in error:

The CLIContext annotation at file:///home/ironmoon/projects/pyret-lang/src/arr/compiler/cli-module-loader.arr:321:26-321:36 failed on this value:
{current-load-path: ./, cache-base-dir: ./compiled}

Because:
* 
Missing field `url-file-mode`is required at file:///home/ironmoon/projects/pyret-lang/src/arr/compiler/cli-module-loader.arr:300:2-300:33
Pyret stack:
  file:///home/ironmoon/projects/pyret-lang/src/scripts/show-compilation.arr: line 44, column 9
  file:///home/ironmoon/projects/pyret-lang/src/scripts/show-compilation.arr: line 125, column 19
```