### PR TITLE
fix(cli): correctly pass extra arguments when using `--run`

### DIFF
--- a/src/arr/compiler/pyret.arr
+++ b/src/arr/compiler/pyret.arr
@@ -28,7 +28,7 @@ fun main(args :: List<String>) -> Number block:
     "port",
     C.next-val-default(C.Str, "1701", none, C.once, "Port to serve on (default 1701, can also be UNIX file socket or windows pipe)"),
     "build-standalone",
-    C.next-val(C.Str, C.once, "Main Pyret (.arr) file to build as a standalone"),
+    C.next-val(C.Str, C.once, "Main Pyret (.arr) file to build as a standalone (deprecated)"),
     "build-runnable",
     C.next-val(C.Str, C.once, "Main Pyret (.arr) file to build as a standalone"),
     "require-config",
@@ -104,7 +104,7 @@ fun main(args :: List<String>) -> Number block:
 
   cases(C.ParsedArguments) params-parsed block:
     | success(r, rest) =>
-      checks = 
+      checks =
         if r.has-key("no-check-mode") or r.has-key("library"): "none"
         else if r.has-key("checks"): r.get-value("checks")
         else: "all" end
@@ -146,125 +146,101 @@ fun main(args :: List<String>) -> Number block:
       if r.has-key("checks") and r.has-key("no-check-mode") and not(r.get-value("checks") == "none") block:
         print-error("Can't use --checks " + r.get-value("checks") + " with -no-check-mode\n")
         failure-code
-      else:
-        if r.has-key("checks") and r.has-key("check-all") and not(r.get-value("checks") == "all") block:
-          print-error("Can't use --checks " + r.get-value("checks") + " with -check-all\n")
+      else if r.has-key("checks") and r.has-key("check-all") and not(r.get-value("checks") == "all"):
+        print-error("Can't use --checks " + r.get-value("checks") + " with -check-all\n")
+        failure-code
+      else if r.has-key("run"):
+        run-args =
+          if is-empty(rest):
+            empty
+          else:
+            rest.rest
+          end
+        result = CLI.run(r.get-value("run"), CS.default-compile-options.{
+            standalone-file: standalone-file,
+            display-progress: display-progress,
+            checks: checks
+          }, run-args)
+        _ = print(result.message + "\n")
+        result.exit-code
+      else if not(is-empty(rest)):
+        print-error("Invalid extra arguments " + to-repr(rest) + ". Option may no longer be supported.\n")
+        failure-code
+      else if r.has-key("build-runnable"):
+        outfile = if r.has-key("outfile"):
+          r.get-value("outfile")
+        else:
+          r.get-value("build-runnable") + ".jarr"
+        end
+        compile-opts = CS.make-default-compile-options(this-pyret-dir)
+        CLI.build-runnable-standalone(
+          r.get-value("build-runnable"),
+          r.get("require-config").or-else(P.resolve(P.join(this-pyret-dir, "config.json"))),
+          outfile,
+          compile-opts.{
+            this-pyret-dir: this-pyret-dir,
+            standalone-file: standalone-file,
+            checks : checks,
+            checks-format: checks-format,
+            type-check : type-check,
+            allow-shadowed : allow-shadowed,
+            collect-all: false,
+            collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
+            ignore-unbound: false,
+            proper-tail-calls: tail-calls,
+            compiled-cache: compiled-dir,
+            compiled-read-only: r.get("compiled-read-only-dir").or-else(empty),
+            display-progress: display-progress,
+            inline-case-body-limit: inline-case-body-limit,
+            deps-file: r.get("deps-file").or-else(compile-opts.deps-file),
+            html-file: html-file,
+            module-eval: module-eval,
+            user-annotations: user-annotations,
+            runtime-annotations: runtime-annotations,
+            url-file-mode: url-file-mode
+          })
+        success-code
+      else if r.has-key("serve"):
+        port = r.get-value("port")
+        S.serve(port, this-pyret-dir)
+        success-code
+      else if r.has-key("build-standalone"):
+        print-error("Use build-runnable instead of build-standalone\n")
+        failure-code
+      else if r.has-key("build"):
+        result = CLI.compile(r.get-value("build"),
+          CS.default-compile-options.{
+            checks : checks,
+            type-check : type-check,
+            allow-shadowed : allow-shadowed,
+            collect-all: false,
+            ignore-unbound: false,
+            proper-tail-calls: tail-calls,
+            compile-module: false,
+            display-progress: display-progress
+          })
+        failures = filter(CS.is-err, result.loadables)
+        if is-link(failures) block:
+          for each(f from failures) block:
+            for lists.each(e from f.errors) block:
+              print-error(tostring(e))
+              print-error("\n")
+            end
+            print-error("There were compilation errors\n")
+          end
           failure-code
         else:
-          if not(is-empty(rest)) block:
-            print-error("No longer supported\n")
-            failure-code
-          else:
-            if r.has-key("build-runnable") block:
-              outfile = if r.has-key("outfile"):
-                r.get-value("outfile")
-              else:
-                r.get-value("build-runnable") + ".jarr"
-              end
-              compile-opts = CS.make-default-compile-options(this-pyret-dir)
-              CLI.build-runnable-standalone(
-                r.get-value("build-runnable"),
-                r.get("require-config").or-else(P.resolve(P.join(this-pyret-dir, "config.json"))),
-                outfile,
-                compile-opts.{
-                  this-pyret-dir: this-pyret-dir,
-                  standalone-file: standalone-file,
-                  checks : checks,
-                  checks-format: checks-format,
-                  type-check : type-check,
-                  allow-shadowed : allow-shadowed,
-                  collect-all: false,
-                  collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
-                  ignore-unbound: false,
-                  proper-tail-calls: tail-calls,
-                  compiled-cache: compiled-dir,
-                  compiled-read-only: r.get("compiled-read-only-dir").or-else(empty),
-                  display-progress: display-progress,
-                  inline-case-body-limit: inline-case-body-limit,
-                  deps-file: r.get("deps-file").or-else(compile-opts.deps-file),
-                  html-file: html-file,
-                  module-eval: module-eval,
-                  user-annotations: user-annotations,
-                  runtime-annotations: runtime-annotations,
-                  url-file-mode: url-file-mode
-                })
-              success-code
-            else if r.has-key("serve"):
-              port = r.get-value("port")
-              S.serve(port, this-pyret-dir)
-              success-code
-            else if r.has-key("build-standalone"):
-              print-error("Use build-runnable instead of build-standalone\n")
-              failure-code
-              #|
-              CLI.build-require-standalone(r.get-value("build-standalone"),
-                  CS.default-compile-options.{
-                    checks : checks,
-                    type-check : type-check,
-                    allow-shadowed : allow-shadowed,
-                    collect-all: false,
-                    collect-times: r.has-key("collect-times") and r.get-value("collect-times"),
-                    ignore-unbound: false,
-                    proper-tail-calls: tail-calls,
-                    compiled-cache: compiled-dir,
-                    display-progress: display-progress
-                  })
-              |#
-            else if r.has-key("build"):
-              result = CLI.compile(r.get-value("build"),
-                CS.default-compile-options.{
-                  checks : checks,
-                  type-check : type-check,
-                  allow-shadowed : allow-shadowed,
-                  collect-all: false,
-                  ignore-unbound: false,
-                  proper-tail-calls: tail-calls,
-                  compile-module: false,
-                  display-progress: display-progress
-                })
-              failures = filter(CS.is-err, result.loadables)
-              if is-link(failures) block:
-                for each(f from failures) block:
-                  for lists.each(e from f.errors) block:
-                    print-error(tostring(e))
-                    print-error("\n")
-                  end
-                  print-error("There were compilation errors\n")
-                end
-                failure-code
-              else:
-                success-code
-              end
-            else if r.has-key("run"):
-              run-args =
-                if is-empty(rest):
-                  empty
-                else:
-                  rest.rest
-                end
-              result = CLI.run(r.get-value("run"), CS.default-compile-options.{
-                  standalone-file: standalone-file,
-                  display-progress: display-progress,
-                  checks: checks
-                }, run-args)
-              _ = print(result.message + "\n")
-              result.exit-code
-            else:
-              block:
-                print-error(C.usage-info(options).join-str("\n"))
-                print-error("Unknown command line options\n")
-                failure-code
-              end
-            end
-          end
+          success-code
         end
-      end
-    | arg-error(message, partial) =>
-      block:
-        print-error(message + "\n")
+      else:
         print-error(C.usage-info(options).join-str("\n"))
+        print-error("Unknown command line options\n")
         failure-code
       end
+    | arg-error(message, partial) =>
+      print-error(message + "\n")
+      print-error(C.usage-info(options).join-str("\n"))
+      failure-code
   end
 end
 


### PR DESCRIPTION
This ensures that `src/scripts/run-phase` correctly works again (which is referenced in the README of the project.

Also reduce unnecessary nesting and improve error when there are extra unrecognized arguments.