### PR TITLE
Fix dot-plot's binSize computation

### DIFF
--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -1860,7 +1860,7 @@
       ];
       const signals = [
         { name: 'dotSize', value: pointSize },
-        { name: 'binSize', update: 'invert("binScale", dotSize)' },
+        { name: 'binSize', update: 'abs(dotSize * (domain("binScale")[1] - domain("binScale")[0]) / (range("binScale")[1] - range("binScale")[0]))' },
         { name: 'actualDotSize', update: 'scale("dotScale", 0) - scale("dotScale", 1)' },
         { name: 'headspace', value: '0.25' },
         { name: 'wrapMaxY', update: 'floor(domain("dotScale")[1] * (1 - headspace))' },


### PR DESCRIPTION
The `invert` Vega function doesn't seem to do what I expect, when the axis domain doesn't contain zero.  (This zero-behavior changed in https://github.com/brownplt/pyret-lang/commit/3c03f196a0b3c94402c5b56c8e5e1405808e600f.)  This fix changes the formula to compute a bin size of "how wide does the dot appear in terms of actual x-axis units?" by explicitly inverting Δrange / Δdomain