### PR TITLE
This fixes https://github.com/brownplt/pyret-lang/issues/1858 :

### DIFF
--- a/src/arr/trove/charts.arr
+++ b/src/arr/trove/charts.arr
@@ -2426,7 +2426,7 @@ fun image-histogram-from-list(images :: CL.LoI, values :: CL.LoN) -> DataSeries 
   values.each(check-num)
 
   default-histogram-series.{
-    vals: map3(get-histogram-value, values, values.map({(_): ''}), images)
+    vals: map3(get-histogram-value, values, values.map({(_): ''}), images.map(some))
   } ^ histogram-series
 end
 

--- a/src/arr/trove/charts.arr
+++ b/src/arr/trove/charts.arr
@@ -369,10 +369,10 @@ explode-method = method(self, offsets :: CL.LoN) block:
 end
 
 histogram-label-method = method(self, labels :: CL.LoS) block:
-    when raw-array-length(self.obj!tab) <> labels.length():
+    when self.obj.vals.length() <> labels.length():
       raise(ERR.message-exception('histogram: xs and labels should have the same length'))
     end
-  self.constr()(self.obj.{tab: raw-array-from-list(map2({(arr, label): raw-array-set(arr, 0, label)}, raw-array-to-list(self.obj!tab), labels))})
+  self.constr()(self.obj.{vals: map2({(v, l): v.{label: l} }, self.obj.vals, labels)})
 end
 
 box-labels-method = method(self, labels :: CL.LoS) block:
@@ -1111,9 +1111,15 @@ default-multi-bar-chart-series = {
   bandwidth: 0.8,
   default-interval-color: none
 }
+
+type HistogramValue = {
+  value :: Number,
+  label :: String,
+  image :: Option<IM.Image>
+}
   
 type HistogramSeries = {
-  tab :: TableIntern,
+  vals :: List<HistogramValue>,
   bin-width :: Option<Number>,
   max-num-bins :: Option<Number>,
   min-num-bins :: Option<Number>,
@@ -2380,13 +2386,17 @@ fun freq-bar-chart-from-list(label :: CL.LoS) -> DataSeries:
   bar-chart-from-list(ls.reverse(), vs.reverse())
 end
 
+fun get-histogram-value(value :: Number, label :: String, optimg :: Option<IM.Image>) -> HistogramValue:
+  { value: value, label: label, image: optimg }
+end
+
 fun histogram-from-list(values :: CL.LoN) -> DataSeries block:
   doc: ```
        Consume a list of numbers and construct a histogram
        ```
   values.each(check-num)
   default-histogram-series.{
-    tab: to-table2(values.map({(_): ''}), values),
+    vals: map3(get-histogram-value, values, values.map({(_): ''}), values.map({(_): none})),
   } ^ histogram-series
 end
 
@@ -2402,7 +2412,7 @@ fun labeled-histogram-from-list(labels :: CL.LoS, values :: CL.LoN) -> DataSerie
   values.each(check-num)
   labels.each(check-string)
   default-histogram-series.{
-    tab: to-table2(labels, values),
+    vals: map3(get-histogram-value, values, labels, values.map({(_): none})),
   } ^ histogram-series
 end
 
@@ -2416,7 +2426,7 @@ fun image-histogram-from-list(images :: CL.LoI, values :: CL.LoN) -> DataSeries 
   values.each(check-num)
 
   default-histogram-series.{
-    tab: to-table3(values.map({(_): ''}), values, images),
+    vals: map3(get-histogram-value, values, values.map({(_): ''}), images)
   } ^ histogram-series
 end
 
@@ -2517,6 +2527,7 @@ fun render-chart(s :: DataSeries) -> ChartWindow:
           shadow self = self.{y-min: none}
           _ = check-render-x-axis(self)
           _ = check-render-y-axis(self)
+          _ = check-data-range(self.x-min, self.x-max, obj.vals)
           CL.histogram(self, obj)
         end
       } ^ histogram-chart-window

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -211,7 +211,8 @@
 
     const chartFontConfig = {
       signals: [
-        { name: 'fontSizeScale', value: 14 }
+        { name: 'fontSizeScale', value: 14 },
+        { name: 'titleText', value: '' },
       ],
       mark: {
         fontSize: { signal: 'fontSizeScale' }
@@ -469,7 +470,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -1032,7 +1033,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -1320,7 +1321,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -1596,7 +1597,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -1791,7 +1792,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -1960,7 +1961,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -2079,7 +2080,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -3134,7 +3135,7 @@
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
-        title: title ? { text: title } : '',
+        title: title && { text: { signal: 'titleText' } },
         width,
         height,
         padding: 0,
@@ -3263,9 +3264,9 @@
       // NOTE(Ben): this externalContext *should* be unnecessary, but for some reason,
       // vega-as-bundled-in-a-jarr doesn't seem to notice NodeCanvas correctly
       const externalContext = canvas.getContext('2d');
-      view.width(width).height(height).resize()
+      view.width(width).height(height).signal('titleText', 'spacer').resize()
       return view.runAsync()
-        .then(() => view.toCanvas(1, { externalContext }))
+        .then(() => view.signal('titleText', view.description()).toCanvas(1, { externalContext }))
         .then(() => externalContext.getImageData(0, 0, width, height));
     }
 
@@ -3341,7 +3342,7 @@
           hover: true,
           tooltip: vegaTooltipHandler.call
         });
-        view.width(width).height(height).resize();
+        view.width(width).height(height).signal('titleText', view.description()).resize();
 
         var tmp = processed;
         tmp.view = view;


### PR DESCRIPTION
- ensures (in charts.arr) that the chosen range does not truncate any data
- revises (in charts.arr) the table from an inconsistent 2d raw-array to a consistent list-of-records
- passes on the x-min and x-max values to the horizontal axis range
- recomputes the tick marks for histograms to stay aligned with the bin boundaries but also extend outward to the selected x-min/x-max range