### PR TITLE
This is a stopgap implementation to permit stagger-offsetting every other x-axis label, to help prevent overlaps

### DIFF
--- a/src/arr/trove/charts.arr
+++ b/src/arr/trove/charts.arr
@@ -508,6 +508,10 @@ x-axis-method = method(self, x-axis :: String):
   self.constr()(self.obj.{x-axis: x-axis})
 end
 
+x-axis-stagger-labels-method = method(self, stagger :: Boolean):
+  self.constr()(self.obj.{x-axis-stagger-labels: stagger})
+end
+
 y-axis-method = method(self, y-axis :: String):
   self.constr()(self.obj.{y-axis: y-axis})
 end
@@ -1355,6 +1359,7 @@ type BoxChartWindowObject = {
   borderSize :: Number, 
   borderColor :: Option<IS.Color>, 
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1366,6 +1371,7 @@ type BoxChartWindowObject = {
 default-box-plot-chart-window-object :: BoxChartWindowObject = default-chart-window-object.{
   x-axis: '',
   y-axis: '',
+  x-axis-stagger-labels: false,
   x-axis-type: at-linear,
   y-axis-type: at-linear,
   min: none,
@@ -1393,6 +1399,7 @@ type DotChartWindowObject = {
   borderColor :: Option<IS.Color>, 
   render :: ( -> IM.Image),
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1402,6 +1409,7 @@ type DotChartWindowObject = {
 
 default-dot-chart-window-object :: DotChartWindowObject = default-chart-window-object.{
   x-axis: '',
+  x-axis-stagger-labels: false,
   y-axis: '',
   x-axis-type: at-linear,
   y-axis-type: at-linear,
@@ -1418,6 +1426,7 @@ type BarChartWindowObject = {
   borderColor :: Option<IS.Color>, 
   render :: ( -> IM.Image),
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1427,6 +1436,7 @@ type BarChartWindowObject = {
 
 default-bar-chart-window-object :: BarChartWindowObject = default-chart-window-object.{
   x-axis: '',
+  x-axis-stagger-labels: false,
   y-axis: '',
   x-axis-type: at-linear,
   y-axis-type: at-linear,
@@ -1443,6 +1453,7 @@ type IntervalChartWindowObject = {
   borderColor :: Option<IS.Color>,
   render :: ( -> IM.Image),
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1452,6 +1463,7 @@ type IntervalChartWindowObject = {
 
 default-interval-chart-window-object :: IntervalChartWindowObject = default-chart-window-object.{
   x-axis: '',
+  x-axis-stagger-labels: false,
   y-axis: '',
   x-axis-type: at-linear,
   y-axis-type: at-linear,
@@ -1468,6 +1480,7 @@ type HistogramChartWindowObject = {
   borderColor :: Option<IS.Color>, 
   render :: ( -> IM.Image),
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1479,6 +1492,7 @@ type HistogramChartWindowObject = {
 default-histogram-chart-window-object :: HistogramChartWindowObject =
   default-chart-window-object.{
     x-axis: '',
+    x-axis-stagger-labels: false,
     y-axis: '',
     x-axis-type: at-linear,
     y-axis-type: at-linear,
@@ -1502,6 +1516,7 @@ type PlotChartWindowObject = {
   minorGridlineColor :: Option<IS.Color>, 
   minorGridlineMinspacing :: Number, 
   x-axis :: String,
+  x-axis-stagger-labels :: Boolean,
   y-axis :: String,
   x-axis-type :: AxisType,
   y-axis-type :: AxisType,
@@ -1515,6 +1530,7 @@ type PlotChartWindowObject = {
 
 default-plot-chart-window-object :: PlotChartWindowObject = default-chart-window-object.{
   x-axis: '',
+  x-axis-stagger-labels: false,
   y-axis: '',
   x-axis-type: at-linear,
   y-axis-type: at-linear,
@@ -1744,6 +1760,7 @@ data ChartWindow:
   | dot-chart-window(obj :: DotChartWindowObject) with:
     constr: {(): dot-chart-window},
     x-axis: x-axis-method,
+    x-axis-stagger-labels: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-min: x-min-method,
     x-max: x-max-method,
@@ -1752,6 +1769,7 @@ data ChartWindow:
   | box-plot-chart-window(obj :: BoxChartWindowObject) with:
     constr: {(): box-plot-chart-window},
     x-axis: x-axis-method,
+    x-axis-stagger: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-axis-type: x-axis-type-method,
     y-axis-type: y-axis-type-method,
@@ -1760,6 +1778,7 @@ data ChartWindow:
   | bar-chart-window(obj :: BarChartWindowObject) with:
     constr: {(): bar-chart-window},
     x-axis: x-axis-method,
+    x-axis-stagger: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-axis-type: x-axis-type-method,
     y-axis-type: y-axis-type-method,
@@ -1768,6 +1787,7 @@ data ChartWindow:
   | interval-chart-window(obj :: IntervalChartWindowObject) with:
     constr: {(): interval-chart-window},
     x-axis: x-axis-method,
+    x-axis-stagger: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-axis-type: x-axis-type-method,
     y-axis-type: y-axis-type-method,
@@ -1776,6 +1796,7 @@ data ChartWindow:
   | histogram-chart-window(obj :: HistogramChartWindowObject) with:
     constr: {(): histogram-chart-window},
     x-axis: x-axis-method,
+    x-axis-stagger: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-axis-type: x-axis-type-method,
     y-axis-type: y-axis-type-method,
@@ -1791,6 +1812,7 @@ data ChartWindow:
     # minor-gridlines-color: minor-gridlines-color-method, 
     # minor-gridlines-minspacing: minor-gridlines-min-spacing-method, 
     x-axis: x-axis-method,
+    x-axis-stagger: x-axis-stagger-labels-method,
     y-axis: y-axis-method,
     x-axis-type: x-axis-type-method,
     y-axis-type: y-axis-type-method,

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -300,7 +300,7 @@
         { name: 'collapseThreshold', update: `${collapseThreshold}` },
         {
           name: 'hoveredId',
-          value: 'null',
+          update: 'null',
           on: [
             {
               events: [
@@ -319,7 +319,8 @@
               update: 'null'
             },
           ]
-        }
+        },
+        { name: 'staggerXAxisLabels', update: false },
       );
 
       const dataTable = {
@@ -937,7 +938,7 @@
         name: 'xAxisLabelOffsets',
         values: []
       });
-      signals.push({name: 'staggerXAxisLabels', update: false});
+      signals.push({name: 'staggerXAxisLabels', value: false});
     }
     
     function barChart(globalOptions, rawData) {
@@ -1147,7 +1148,7 @@
       const signals = [
         {
           name: 'hoveredSeries',
-          value: 'null',
+          update: 'null',
           on: [
             {
               events: [
@@ -1421,7 +1422,8 @@
         { name: 'minValue',
           update: 'extent(pluck(data("table"), "minVal"))[0]' },
         { name: 'maxValue',
-          update: 'extent(pluck(data("table"), "maxVal"))[1]' }
+          update: 'extent(pluck(data("table"), "maxVal"))[1]' },
+        { name: 'staggerXAxisLabels', update: false },
       ];
       const outlierTooltip = `, 'bottom whisker': datum.lowWhisker, 'top whisker': datum.highWhisker`;
       const tooltip = `{
@@ -1908,6 +1910,7 @@
         { name: 'wrapMaxY', update: 'floor(domain("dotScale")[1] * (1 - headspace))' },
         { name: 'xMinValue', value: xMinValue },
         { name: 'xMaxValue', value: xMaxValue },
+        { name: 'staggerXAxisLabels', update: false },
       ];
       const scales = [
         {
@@ -2481,11 +2484,7 @@
             y: { scale: `yscale`, field: 'y', offset: { signal: `${imageScaleFactorY} * datum.imageOffsetY` } },
             stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${color}'` },
             strokeWidth: { signal: `(hoveredLegend === '${prefix}' ? 1 : 0)` },
-            zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
           },
-          hover: {
-            zindex: { value: 1 }
-          }
         }
       });
       if (pointshapeType === 'circle') {
@@ -2505,11 +2504,9 @@
               y: { scale: `yscale`, field: 'y' },
               fill: { value: color },
               stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${color}'` },
-              zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
             },
             hover: {
               stroke: { value: color },
-              zindex: { value: 1 }
             }
           }
         });
@@ -2605,11 +2602,9 @@
             x: { scale: `xscale`, field: 'x' },
             y: { scale: `yscale`, field: 'y' },
             strokeWidth: { signal: `(hoveredLegend === '${prefix}' ? 2 : 1) * ${lineWidth}` },
-            zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
           },
           hover: {
             strokeWidth: { value: 2 * lineWidth },
-            zindex: { value: 1 }
           }
         }
       });
@@ -2723,11 +2718,7 @@
               y: { scale: `yscale`, field: 'y', offset: { signal: `${-pointSize} * datum.imageOffsetY` } },
               stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${dataColor}'` },
               strokeWidth: { signal: `(hoveredLegend === '${prefix}' ? 1 : 0)` },
-              zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
             },
-            hover: {
-              zindex: { value: 1 }
-            }
           }
         },
         {
@@ -2746,11 +2737,7 @@
               yc: { scale: `yscale`, field: 'y' },
               fill: { value: dataColor },
               stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${dataColor}'` },
-              zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
             },
-            hover: {
-              zindex: { value: 1 }
-            }
           }
         },
         {
@@ -2784,10 +2771,6 @@
               xc: { scale: `xscale`, field: 'x' },
               yc: { scale: `yscale`, field: 'yprime' },
               stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${intervalColor}'` },
-              zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
-            },
-            hover: {
-              zindex: { value: 1 }
             }
           }
         },
@@ -2883,10 +2866,6 @@
               yc: { scale: `yscale`, field: 'y' },
               stroke: { signal: `hoveredLegend === '${prefix}' ? 'white' : '${pointColor}'` },
               strokeWidth: { signal: `(hoveredLegend === '${prefix}' ? 1 : 0)` },
-              zindex: { signal: `hoveredLegend === '${prefix}' ? 1 : null` }
-            },
-            hover: {
-              zindex: { value: 1 }
             }
           }
         }
@@ -3070,7 +3049,7 @@
         });
         signals.push({
           name: 'hoveredLegend',
-          value: 'null',
+          update: 'null',
           on: [
             {
               events: [
@@ -3093,7 +3072,7 @@
       } else {
         signals.push({
           name: 'hoveredLegend',
-          value: 'null'
+          update: 'null'
         });
       }
 

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -916,7 +916,29 @@
           }
         }
       );
-    }      
+    }
+
+    function prepareAxisForOffsets(dir, axis, scales, data, signals) {
+      axis.encode = {
+        labels: {
+          name: `${dir}AxisLabels`,
+          update: {
+            dy: { scale: 'xAxisYOffsets', signal: 'datum.index' }
+          }
+        }
+      };
+      scales.push({
+        name: 'xAxisYOffsets',
+        type: 'ordinal',
+        domain: { data: 'xAxisLabelOffsets', field: 'index' },
+        range: { data: 'xAxisLabelOffsets', field: 'offset' },
+      });
+      data.push({
+        name: 'xAxisLabelOffsets',
+        values: []
+      });
+      signals.push({name: 'staggerXAxisLabels', update: false});
+    }
     
     function barChart(globalOptions, rawData) {
       // Variables and constants 
@@ -1004,6 +1026,9 @@
           grid: true, ticks: false, labels: false }
       ];
 
+      // TODO: change this to affect the horizontal axis even if it's a horizontal bar chart?
+      prepareAxisForOffsets(axesConfig.primary.dir, axes[0], scales, data, signals);
+      
       if (axis) {
         axes[1].values = axis.domainRaw;
         axes[1].encode = {
@@ -1197,6 +1222,9 @@
       ];
       // set the axis with the ticks to have the title, so they don't overlap
       axes[isNotFullStacked ? 1 : 2].title = axisLabels[axesConfig.secondary.dir];
+
+      // TODO: change this to affect the horizontal axis even if it's a horizontal bar chart?
+      prepareAxisForOffsets(axesConfig.primary.dir, axes[0], scales, data, signals);
       
       if (axis) {
         axes[1].values = axis.domainRaw;
@@ -1788,7 +1816,8 @@
         { orient: 'left', scale: 'countScale', grid: true, title: yAxisLabel }
       ];
       
-
+      prepareAxisForOffsets('x', axes[0], scales, data, signals);
+      
       return {
         "$schema": "https://vega.github.io/schema/vega/v6.json",
         description: title,
@@ -2936,6 +2965,7 @@
       const gridlines = getGridlines({}, globalOptions);
       const scales = charts.flatMap((c) => c.scales || []);
       const signals = charts.flatMap((c) => c.signals || []);
+      const data = charts.flatMap((c) => c.data || []);
       // NOTE: must compute these before updating the scales array...or else the new scales will
       // become part of the signal definition, which is incorrect!
       signals.push(
@@ -2980,6 +3010,8 @@
         },
       ];
 
+      prepareAxisForOffsets('x', axes[2], scales, data, signals);
+      
       const marks = [
         {
           type: 'group',
@@ -3141,7 +3173,7 @@
         padding: 0,
         autosize: 'fit',
         background,
-        data: charts.flatMap((c) => c.data || []),
+        data,
         signals,
         scales,
         axes,
@@ -3266,6 +3298,7 @@
       const externalContext = canvas.getContext('2d');
       view.width(width).height(height).signal('titleText', 'spacer').resize()
       return view.runAsync()
+        .then(() => rebuildAxisLabels(view))
         .then(() => view.signal('titleText', view.description()).toCanvas(1, { externalContext }))
         .then(() => externalContext.getImageData(0, 0, width, height));
     }
@@ -3292,6 +3325,7 @@
         return canvasLib && canvasLib.Canvas && v instanceof canvasLib.Canvas;
       }
       const isVegaString = isTrue(globalOptions['vega']);
+      const staggerXAxisLabels = isTrue(globalOptions['x-axis-stagger-labels']);
       return RUNTIME.pauseStack(restarter => {
         try {
           if (isVegaString) {
@@ -3300,6 +3334,7 @@
           const width = toFixnum(globalOptions['width']);
           const height = toFixnum(globalOptions['height']);
           const view = new vega.View(vega.parse(processed));
+          view.signal('staggerXAxisLabels', staggerXAxisLabels);
           return renderToCanvas(view, width, height).then((data) => imageDataReturn(data, restarter));
         } catch(e) {
           return restarter.error(e);
@@ -3307,6 +3342,18 @@
       });
     }
 
+    function rebuildAxisLabels(view) {
+      // const { data: { xAxisLabels } } = view.getState({data: (name) => name === "xAxisLabels"});
+      try {
+        if (!view.signal('staggerXAxisLabels')) return view;
+        const xAxisLabels = view.data("xAxisLabels");
+        const offsets = xAxisLabels.map((mark, i) => ({ index: mark.datum.index, offset: (i % 2) * 25 }));
+        return view.data('xAxisLabelOffsets', offsets).runAsync();
+      } catch(e) {
+        return view;
+      }
+    }
+    
     function renderInteractiveChart(processed, globalOptions, rawData) {
       return RUNTIME.pauseStack(restarter => {
         const root = $('<div/>');
@@ -3336,13 +3383,18 @@
             return ans;
           }
         });
+        const staggerXAxisLabels = isTrue(globalOptions['x-axis-stagger-labels']);
         const view = new vega.View(vega.parse(processed), {
           container: chart[0],
           renderer: 'svg',
           hover: true,
           tooltip: vegaTooltipHandler.call
         });
-        view.width(width).height(height).signal('titleText', view.description()).resize();
+        view.width(width)
+          .height(height)
+          .signal('staggerXAxisLabels', staggerXAxisLabels)
+          .signal('titleText', view.description())
+          .resize();
 
         var tmp = processed;
         tmp.view = view;
@@ -3360,6 +3412,7 @@
         const result = tmp;
         try {
           view.runAsync()
+            .then(() => rebuildAxisLabels(view))
             .then(() => {
               if (processed.addControls) {
                 processed.addControls(view, overlay);
@@ -3429,7 +3482,6 @@
             return RUNTIME.safeCall(() => f(globalOptions, rawData), (chart) => {
               return renderInteractiveChart(chart, globalOptions, rawData);
             }, 'render-interactive-chart');
-            return renderInteractiveChart(f(globalOptions, rawData), globalOptions, rawData);
           } else {
             return RUNTIME.ffi.throwMessageException('Cannot display interactive charts headlessly');
           }


### PR DESCRIPTION
This is a stopgap implementation to permit stagger-offsetting every other x-axis label, to help prevent overlaps

The approach is awkward, and should be reverted once https://github.com/vega/vega/issues/4238 is implemented.  Until then, this approach:

Starts in `prepareAxisForOffsets`, which
* Creates an empty data table named `xAxisLabelOffsets`, to be filled in later
* Creates an ordinal scale named `xAxisYOffsets`, derived from the `xAxisLabelOffsets` table
* Adds an encoding step to the xAxis that
  - names the labels `xAxisLabels` (so they appear as a data set via the view API)
  - updates the dy offset based on the xAxisYOffset scale
* We render the graph once, and then in the continuation, we call `rebuildAxisLabels`, in which we
  - extract the `xAxisLabels` dataset,
  - extract their `index` property -- which is a fraction between 0--1, rather than an integer
  - compute a discrete lookup table from index to (their position % 2) * 25
  - shove that lookup table back int othe empty `xAxisLabelOffsets` table
  - rerender the graph

The preparation step sets up the necessary dataflow; the first render lets Vega compute which labels are going to exist; then the rebuilding step computes the desired offsets and causes the dataflow to propagate that information back through.