### PR TITLE
Add image-dot-chart-from-list

### DIFF
--- a/src/arr/trove/charts.arr
+++ b/src/arr/trove/charts.arr
@@ -1246,7 +1246,6 @@ default-dot-plot-series = {
 type CategoricalDotPoint ={
   label :: String,
   category :: String,
-  value :: Number,
   image :: Option<IM.Image>
 }
 
@@ -2152,8 +2151,8 @@ fun labeled-num-dot-chart-from-list(labels :: CL.LoS, x-values :: CL.LoN) -> Dat
   num-dot-chart-from-list(x-values).labels(labels)
 end
 
-fun get-cat-dot-point(value :: Number, label :: String, category :: String, optimg :: Option<IM.Image>) -> CategoricalDotPoint:
-  { value: value, label: label, category: category, image: optimg }
+fun get-cat-dot-point(label :: String, category :: String, optimg :: Option<IM.Image>) -> CategoricalDotPoint:
+  { label: label, category: category, image: optimg }
 end
 fun dot-chart-from-list(categories :: CL.LoS) -> DataSeries block:
   doc: ```
@@ -2165,15 +2164,8 @@ fun dot-chart-from-list(categories :: CL.LoS) -> DataSeries block:
     raise(ERR.message-exception("dot-chart: can't have empty data"))
   end
 
-  # Walk through the (sorted) values, creating lists of labels and counts
-  unique-counts = for fold(acc from [SD.mutable-string-dict: ], label from categories) block:
-    acc.set-now(label, acc.get-now(label).or-else(0) + 1)
-    acc
-  end
-
-  cats = unique-counts.keys-list-now().sort()
   default-categorical-dot-plot-series.{
-    ps: cats.map({(c): build-list(get-cat-dot-point(_, '', c, none), unique-counts.get-value-now(c))}).foldr(_ + _, empty)
+    ps: categories.map(get-cat-dot-point('', _, none))
   } ^ categorical-dot-plot-series
 end
 

--- a/src/arr/trove/charts.arr
+++ b/src/arr/trove/charts.arr
@@ -343,7 +343,7 @@ labels-method = method(self, labels :: CL.LoS):
     when self.obj!ps.length() <> labels.length():
       raise(ERR.message-exception('plot: xs and labels should have the same length'))
     end
-    self.constr()(self.obj.{ps: map2({(arr, label): raw-array-set(arr, 2, label)}, self.obj!ps, labels)})
+    self.constr()(self.obj.{ps: map2({(val, label): val.{label: label}}, self.obj!ps, labels)})
   end
 end
 
@@ -352,7 +352,7 @@ image-labels-method = method(self, images :: CL.LoI):
     when self.obj!ps.length() <> images.length():
       raise(ERR.message-exception('plot: xs and images should have the same length'))
     end
-    self.constr()(self.obj.{ps: map2({(arr, image): raw-array-set(arr, 3, image)}, self.obj!ps, images)})
+    self.constr()(self.obj.{ps: map2({(val, image): val.{image : some(image)}}, self.obj!ps, images)})
   end
 end
 
@@ -1245,18 +1245,22 @@ default-dot-plot-series = {
 
 type CategoricalDotPoint ={
   label :: String,
-  count :: Number
+  category :: String,
+  value :: Number,
+  image :: Option<IM.Image>
 }
 
 type CategoricalDotPlotSeries = {
   ps :: List<CategoricalDotPoint>,
   color :: Option<IS.Color>,
-  legend :: String
+  legend :: String,
+  useImageSizes :: Boolean
 }
 
 default-categorical-dot-plot-series = {
   color: none,
   legend: '',
+  useImageSizes: true,
 }
 
 type IntervalPoint = {
@@ -1622,6 +1626,11 @@ data DataSeries:
     constr: {(): categorical-dot-plot-series},
     color: color-method,
     legend: legend-method,
+    labels: labels-method,
+    image-labels: image-labels-method,
+    method use-image-sizes(self, use-image-sizes :: Boolean):
+      self.constr()(self.obj.{useImageSizes: use-image-sizes})
+    end,
   | function-plot-series(obj :: FunctionPlotSeries) with:
     is-single: false,
     constr: {(): function-plot-series},
@@ -1965,12 +1974,6 @@ fun image-bar-chart-from-list(
        Consume images, labels, a list of string, and values, a list of numbers
        and construct a bar chart using images as bars
        ```
-
-  # Type Checking
-  images.each(check-image)
-  values.each(check-num)
-  labels.each(check-string)
-
   # Constants
   label-length = labels.length()
   value-length = values.length()
@@ -2090,10 +2093,6 @@ fun bar-chart-from-list(labels :: CL.LoS, values :: CL.LoN) -> DataSeries block:
        Consume labels, a list of string, and values, a list of numbers
        and construct a bar chart
        ```
-  # Type Checking
-  values.each(check-num)
-  labels.each(check-string)
-
   # Constants
   label-length = labels.length()
   value-length = values.length()
@@ -2137,65 +2136,53 @@ fun num-dot-chart-from-list(x-values :: CL.LoN) -> DataSeries block:
   } ^ dot-plot-series
 end
 
-fun image-num-dot-chart-from-list(images :: CL.LoI, x-values :: CL.LoN) -> DataSeries block:
+fun image-num-dot-chart-from-list(images :: CL.LoI, x-values :: CL.LoN) -> DataSeries:
   doc: ```
        Consume unordered, possibly-repeating lists of image-labels and numbers, 
        and construct a dot chart
        ```
-  x-values.each(check-num)
-  when x-values.length() == 0:
-    raise(ERR.message-exception("num-dot-chart: can't have empty data"))
-  end
-  images.each(check-image)
-  when images.length() <> x-values.length():
-    raise(ERR.message-exception("num-dot-chart: the lists of numbers and images must have the same length"))
-  end
-  default-dot-plot-series.{
-    ps: map3(get-dot-point, x-values, x-values.map({(_): ''}), images.map(some)),
-  } ^ dot-plot-series
+  num-dot-chart-from-list(x-values).image-labels(images)
 end
 
-fun labeled-num-dot-chart-from-list(labels :: CL.LoS, x-values :: CL.LoN) -> DataSeries block:
+fun labeled-num-dot-chart-from-list(labels :: CL.LoS, x-values :: CL.LoN) -> DataSeries:
   doc: ```
        Consume unordered, possibly-repeating lists of labels and numbers, 
        and construct a dot chart
        ```
-  x-values.each(check-num)
-  when x-values.length() == 0:
-    raise(ERR.message-exception("num-dot-chart: can't have empty data"))
-  end
-  labels.each(check-string)
-  when labels.length() <> x-values.length():
-    raise(ERR.message-exception("num-dot-chart: the lists of numbers and labels must have the same length"))
-  end
-  default-dot-plot-series.{
-    ps: map3(get-dot-point, x-values, labels, x-values.map({(_): none})),
-  } ^ dot-plot-series
+  num-dot-chart-from-list(x-values).labels(labels)
 end
 
-fun dot-chart-from-list(input-labels :: CL.LoS) -> DataSeries block:
+fun get-cat-dot-point(value :: Number, label :: String, category :: String, optimg :: Option<IM.Image>) -> CategoricalDotPoint:
+  { value: value, label: label, category: category, image: optimg }
+end
+fun dot-chart-from-list(categories :: CL.LoS) -> DataSeries block:
   doc: ```
-       Consume a list of string-values and construct a dot chart
+       Consume a list of string categories and construct a dot chart
        ```
 
   # Edge Case Error Checking
-  when input-labels.length() == 0:
+  when categories.length() == 0:
     raise(ERR.message-exception("dot-chart: can't have empty data"))
   end
 
-  # Type Checking
-  input-labels.each(check-string)
-
   # Walk through the (sorted) values, creating lists of labels and counts
-  unique-counts = for fold(acc from [SD.mutable-string-dict: ], label from input-labels) block:
+  unique-counts = for fold(acc from [SD.mutable-string-dict: ], label from categories) block:
     acc.set-now(label, acc.get-now(label).or-else(0) + 1)
     acc
   end
 
-  labels = unique-counts.keys-list-now().sort()
+  cats = unique-counts.keys-list-now().sort()
   default-categorical-dot-plot-series.{
-    ps: labels.map({(l): { label: l, count: unique-counts.get-value-now(l) }})
+    ps: cats.map({(c): build-list(get-cat-dot-point(_, '', c, none), unique-counts.get-value-now(c))}).foldr(_ + _, empty)
   } ^ categorical-dot-plot-series
+end
+
+fun image-dot-chart-from-list(images :: CL.LoI, categories :: CL.LoS) -> DataSeries:
+  doc: ```
+       Consume unordered, possibly-repeating lists of images and categories, 
+       and construct a dot chart
+       ```
+  dot-chart-from-list(categories).image-labels(images)
 end
 
 fun grouped-bar-chart-from-list(
@@ -2227,11 +2214,6 @@ fun grouped-bar-chart-from-list(
     raise(ERR.message-exception('grouped-bar-chart: labels and legends should have the same length'))
   end
   
-  # Typechecking each input
-  value-lists.each(_.each(check-num))
-  labels.each(check-string)
-  legends.each(check-string)
-
  {max-positive-height; max-negative-height} = multi-prep-axis(grouped, rational-values)
 
   # Constructing the Data Series
@@ -2276,11 +2258,6 @@ fun stacked-bar-chart-from-list(
     raise(ERR.message-exception('stacked-bar-chart: labels and legends should have the same length'))
   end
   
-  # Typechecking the input 
-  value-lists.each(_.each(check-num))
-  labels.each(check-string)
-  legends.each(check-string)
-
   {max-positive-height; max-negative-height} = multi-prep-axis(absolute, rational-values)
 
   # Constructing the Data Series
@@ -2443,10 +2420,6 @@ fun image-histogram-from-list(images :: CL.LoI, values :: CL.LoN) -> DataSeries 
        Consume images and numbers, then construct a histogram matching those
        images to the original histogram bricks
        ```
-  # Type Checking
-  images.each(check-image)
-  values.each(check-num)
-
   default-histogram-series.{
     vals: map3(get-histogram-value, values, values.map({(_): ''}), images.map(some))
   } ^ histogram-series
@@ -2938,6 +2911,7 @@ from-list = {
   dot-chart: dot-chart-from-list,
   num-dot-chart: num-dot-chart-from-list,
   image-num-dot-chart: image-num-dot-chart-from-list,
+  image-dot-chart: image-dot-chart-from-list,
   labeled-num-dot-chart: labeled-num-dot-chart-from-list,
   image-bar-chart: image-bar-chart-from-list,
   grouped-bar-chart: grouped-bar-chart-from-list,

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -22,7 +22,7 @@
   theModule: function (RUNTIME, NAMESPACE, uri, IMAGELIB, CHARTSUTILLIB, vega, canvasLib) {
     'use strict';
 
-    var jsnums = RUNTIME.jsnums;
+    const jsnums = RUNTIME.jsnums;
     
     // Default Google Chart Colors for sequential series (Like Multi Bar Charts and Pie Charts) from 
     // https://stackoverflow.com/a/75264589
@@ -146,14 +146,14 @@
           ret[rawVal] = num;
         }
       }
-      if (jsnums.greaterThanOrEqual(ret.xMinValue, ret.xMaxValue)) {
+      if (jsnums.greaterThanOrEqual(ret.xMinValue, ret.xMaxValue, RUNTIME.NumberErrbacks)) {
         raw.xMinValue.addClass('error-bg');
         raw.xMaxValue.addClass('error-bg');
         raw.xMinValue.removeClass('ok-bg');
         raw.xMaxValue.removeClass('ok-bg');
         return null;
       }
-      if (jsnums.greaterThanOrEqual(ret.yMinValue, ret.yMaxValue)) {
+      if (jsnums.greaterThanOrEqual(ret.yMinValue, ret.yMaxValue, RUNTIME.NumberErrbacks)) {
         raw.yMinValue.addClass('error-bg');
         raw.yMaxValue.addClass('error-bg');
         raw.yMinValue.removeClass('ok-bg');
@@ -161,7 +161,7 @@
         return null;
       }
       if (!isTrue(RUNTIME.num_is_integer(ret.numSamples)) ||
-          jsnums.lessThanOrEqual(ret.numSamples, 1)) {
+          jsnums.lessThanOrEqual(ret.numSamples, 1, RUNTIME.NumberErrbacks)) {
         raw.numSamples.addClass('error-bg');
         raw.numSamples.removeClass('ok-bg');
         return null;
@@ -2013,6 +2013,7 @@
       const defaultColor = default_colors[0];
       const color = getColorOrDefault(get(rawData, 'color'), defaultColor);
       const legend = get(rawData, 'legend') || '';
+      const autosizeImage = isTrue(get(rawData, 'useImageSizes'));
 
       const points = RUNTIME.ffi.toArray(get(rawData, 'ps'));
 
@@ -2026,49 +2027,131 @@
 
 
 
+      const rawCounts = new Map();
+      for (const p of points) {
+        const c = get(p, 'category')
+        rawCounts.set(c, (rawCounts.get(c) ?? 0) + 1);
+      }
       const fixedPoints = points.map((p) => ({
         label: get(p, 'label'),
-        count: toFixnum(get(p, 'count'))
+        category: get(p, 'category'),
+        value: toFixnum(get(p, 'value')),
+        count: rawCounts.get(get(p, 'category')),
+        image: cases(RUNTIME.ffi.isOption, 'Option', get(p, 'image'), {
+          none: () => undefined,
+          some: (opaqueImg) => imageToCanvas(opaqueImg.val)
+        }),
+        imageOffsetX: cases(RUNTIME.ffi.isOption, 'Option', get(p, 'image'), {
+          none: () => undefined,
+          some: (opaqueImg) => opaqueImg.val.getPinholeX() / opaqueImg.val.getWidth()
+        }),
+        imageOffsetY: cases(RUNTIME.ffi.isOption, 'Option', get(p, 'image'), {
+          none: () => undefined,
+          some: (opaqueImg) => opaqueImg.val.getPinholeY() / opaqueImg.val.getHeight()
+        }),
       }));
+      const counts = [...rawCounts.entries().map((kv) => ({ category: kv[0], count: kv[1] }))];
+      debugger
       const data = [
         {
-          name: 'bars',
-          values: fixedPoints
+          name: 'rawDotsData',
+          values: fixedPoints,
+          transform: [ { type: 'extent', field: 'value', signal: 'rawDotExtent' } ]
         },
         {
-          name: 'dotsData',
-          values: fixedPoints.flatMap((p) =>
-            Array.from({length: p.count}).map((_, i) => ({ label: p.label, value: i }))
-          )
+          name: `dotsData`,
+          source: `rawDotsData`,
+          transform: [ { type: 'filter', expr: '!isValid(datum.image)' } ]
         },
+        {
+          name: `imagesData`,
+          source: `rawDotsData`,
+          transform: [ { type: 'filter', expr: 'isValid(datum.image)' } ]
+        },
+        {
+          name: 'bars',
+          values: counts
+        }
       ];
       const signals = [
-        { name: 'dotSize', update: "scale('secondary', 1) - scale('secondary', 0)" },
+        { name: 'dotSize', update: "0.8 * (scale('secondary', 1) - scale('secondary', 0))" },
+        { name: 'staggerXAxisLabels', update: false },
+        { name: 'hoveredCategory', update: false,
+          on: [
+            {
+              events: [
+                { markname: 'blocks', type: 'mouseover' },
+                { markname: 'DotMarks', type: 'mouseover' },
+                { markname: 'ImageMarks', type: 'mouseover' }
+              ],
+              force: true,
+              update: 'datum.category'
+            },
+            {
+              events: [
+                { markname: 'blocks', type: 'mouseout' },
+                { markname: 'DotMarks', type: 'mouseout' },
+                { markname: 'ImageMarks', type: 'mouseout' }
+              ],
+              force: true,
+              update: 'null'
+            },            
+          ]},
       ];
       const scales = [
         {
           name: 'primary',
           type: 'band',
           range: 'width',
-          domain: { data: 'bars', field: 'label' }
+          domain: { data: 'rawDotsData', field: 'category' }
         },
         {
           name: 'secondary',
           range: 'height',
           ...yAxisType,
           nice: true, zero: true,
-          domain: { data: 'bars', field: 'count' }
-        }
+          domain: { signal: '[0, rawDotExtent[1] + 1]' },
+        },
       ];
       const axes = [
         { orient: 'bottom', scale: 'primary', zindex: 1, title: xAxisLabel },
         { orient: 'bottom', scale: 'primary', zindex: 0, grid: true, ticks: false, labels: false },
         { orient: 'left', scale: 'secondary', grid: true, ticks: true, labels: true, title: yAxisLabel, zindex: 1 }
       ];
+      const markTooltip = [
+        {
+          test: '!!datum.label',
+          signal: `{ title: datum.label }`
+        },
+        { signal: `{ title: datum.category, Count: datum.count }` }
+      ];
       const marks = [
         {
+          type: 'rect',
+          name: 'blocks',
+          from: { data: 'bars' },
+          encode: {
+            enter: {
+              x: { scale: 'primary', field: 'category', offset: { scale: 'primary', band: 0.25 } },
+              x2: { scale: 'primary', field: 'category', offset: { scale: 'primary', band: 0.75 } },
+              y: { scale: 'secondary', value: 0 },
+              y2: { scale: 'secondary', field: 'count' },
+              tooltip: { signal: `{ title: datum.category, Count: datum.count }`},
+              stroke: { value: 'gray' },
+              strokeWidth: { value: 2 },
+              fill: { value: 'transparent' },
+            },
+            update: {
+              opacity: { signal: 'hoveredCategory == datum.category ? 1 : 0' },
+            },
+            hover: {
+              opacity: { value: 1 }
+            }
+          }
+        },
+        {
           type: 'symbol',
-          name: 'dots',
+          name: 'DotMarks',
           from: { data: 'dotsData' },
           encode: {
             enter: {
@@ -2077,34 +2160,33 @@
               fill: { value: color },
               stroke: { value: 'white' },
               strokeWidth: { value: 0.25 },
-              tooltip: { signal: '{ title: datum.label, Value: datum.value }' },
-              xc: { scale: 'primary', field: 'label', offset: { scale: 'primary', band: 0.5 } },
-              yc: { scale: 'secondary', field: 'value', offset: { signal: '0.5 * dotSize' } },
-              size: { signal: '0.8 * 0.8 * dotSize * dotSize' },
+              tooltip: markTooltip,
+              xc: { scale: 'primary', field: 'category', offset: { scale: 'primary', band: 0.5 } },
+              yc: { scale: 'secondary', field: 'value',
+                    offset: { signal: "scale('secondary', 0.5) - scale('secondary', 0)" } },
+              size: { signal: 'dotSize * dotSize' },
             }
           }
         },
         {
-          type: 'rect',
-          name: 'blocks',
-          from: { data: 'bars' },
+          type: 'image',
+          from: { data: `imagesData` },
+          name: `ImageMarks`,
           encode: {
             enter: {
-              x: { scale: 'primary', field: 'label', offset: { scale: 'primary', band: 0.25 } },
-              x2: { scale: 'primary', field: 'label', offset: { scale: 'primary', band: 0.75 } },
-              y: { scale: 'secondary', value: 0 },
-              y2: { scale: 'secondary', field: 'count' },
-              tooltip: { signal: `{ title: datum.label, Count: datum.count }`},
-              stroke: { value: 'gray' },
-              strokeWidth: { value: 2 },
-              fill: { value: 'transparent' },
+              width: autosizeImage ? undefined : { update: "dotSize" },
+              height: autosizeImage ? undefined : { update: "dotsize" },
+              image: { field: 'image' },
+              tooltip: markTooltip,
             },
             update: {
-              opacity: { value: 0 },
+              xc: { scale: 'primary', field: 'category',
+                    offset: { scale: 'primary', band: 0.5 } },
+              yc: { scale: 'secondary', signal: 'datum.value',
+                    offset: { signal: "scale('secondary', 0.5) - scale('secondary', 0)" } },
+              align: { value: 'center' },
+              baseline: { value: 'middle' }
             },
-            hover: {
-              opacity: { value: 1 }
-            }
           }
         },
       ];

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -2028,14 +2028,10 @@
 
 
       const rawCounts = new Map();
-      for (const p of points) {
-        const c = get(p, 'category')
-        rawCounts.set(c, (rawCounts.get(c) ?? 0) + 1);
-      }
       const fixedPoints = points.map((p) => ({
         label: get(p, 'label'),
         category: get(p, 'category'),
-        value: toFixnum(get(p, 'value')),
+        value: 0, // PLACEHOLDER, updated below
         count: rawCounts.get(get(p, 'category')),
         image: cases(RUNTIME.ffi.isOption, 'Option', get(p, 'image'), {
           none: () => undefined,
@@ -2050,13 +2046,20 @@
           some: (opaqueImg) => opaqueImg.val.getPinholeY() / opaqueImg.val.getHeight()
         }),
       }));
+      for (const p of fixedPoints) {
+        const countForCat = rawCounts.get(p.category) ?? 0;
+        p.value = countForCat;
+        rawCounts.set(p.category, countForCat + 1);
+      }
       const counts = [...rawCounts.entries().map((kv) => ({ category: kv[0], count: kv[1] }))];
-      debugger
       const data = [
         {
           name: 'rawDotsData',
           values: fixedPoints,
-          transform: [ { type: 'extent', field: 'value', signal: 'rawDotExtent' } ]
+          transform: [
+            { type: 'collect', sort: { field: 'category' } },
+            { type: 'extent', field: 'value', signal: 'rawDotExtent' }
+          ]
         },
         {
           name: `dotsData`,

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -2077,7 +2077,7 @@
         }
       ];
       const signals = [
-        { name: 'dotSize', update: "0.8 * (scale('secondary', 1) - scale('secondary', 0))" },
+        { name: 'dotSize', update: "0.8 * abs(scale('secondary', 1) - scale('secondary', 0))" },
         { name: 'staggerXAxisLabels', update: false },
         { name: 'hoveredCategory', update: false,
           on: [
@@ -2177,8 +2177,8 @@
           name: `ImageMarks`,
           encode: {
             enter: {
-              width: autosizeImage ? undefined : { update: "dotSize" },
-              height: autosizeImage ? undefined : { update: "dotsize" },
+              width: autosizeImage ? undefined : { signal: "dotSize" },
+              height: autosizeImage ? undefined : { signal: "dotSize" },
               image: { field: 'image' },
               tooltip: markTooltip,
             },
@@ -2187,8 +2187,8 @@
                     offset: { scale: 'primary', band: 0.5 } },
               yc: { scale: 'secondary', signal: 'datum.value',
                     offset: { signal: "scale('secondary', 0.5) - scale('secondary', 0)" } },
-              align: { value: 'center' },
-              baseline: { value: 'middle' }
+              align: autosizeImage ? { value: 'center' } : undefined,
+              baseline: autosizeImage ? { value: 'middle' } : undefined
             },
           }
         },

--- a/tests/pyret/tests/test-charts.arr
+++ b/tests/pyret/tests/test-charts.arr
@@ -44,3 +44,24 @@ check "render-chart":
     .get-image() does-not-raise
   render-chart(p5) does-not-raise
 end
+
+check "image-dot-chart-from-list ordering invariant":
+  # Each image carries the name of its own category, so a save-image of a
+  # failing run shows exactly which image landed under which column label.
+  ant-img = text("ant", 24, red)
+  bee-img = text("bee", 24, blue)
+  cat-img = text("cat", 24, green)
+
+  # Two inputs encoding the same logical (image, category) bag but in
+  # different input orders. dot-chart-from-list sorts categories internally,
+  # and a categorical chart should depend only on the bag, not the input
+  # order; so both inputs should render to byte-identical images.
+  scrambled = render-chart(from-list.image-dot-chart(
+      [list: bee-img, cat-img, ant-img],
+      [list: "bee", "cat", "ant"])).get-image()
+  pre-sorted = render-chart(from-list.image-dot-chart(
+      [list: ant-img, bee-img, cat-img],
+      [list: "ant", "bee", "cat"])).get-image()
+
+  images-equal(scrambled, pre-sorted) is true
+end

--- a/tests/pyret/tests/test-charts.arr
+++ b/tests/pyret/tests/test-charts.arr
@@ -65,3 +65,18 @@ check "image-dot-chart-from-list ordering invariant":
 
   images-equal(scrambled, pre-sorted) is true
 end
+
+check "image-dot-chart-from-list use-image-sizes(false) actually changes rendering":
+  # use-image-sizes(true) renders images at their natural dimensions;
+  # use-image-sizes(false) is supposed to size them via the chart's dotSize
+  # signal. The two settings must therefore produce visibly different charts.
+  # If they render byte-identically, the use-image-sizes(false) branch is a
+  # no-op (e.g. its width/height encoding form is silently ignored by Vega).
+  ant-img = text("ant", 24, red)
+  data-fn = lam(): from-list.image-dot-chart([list: ant-img], [list: "ant"]) end
+
+  natural = render-chart(data-fn().use-image-sizes(true)).get-image()
+  sized = render-chart(data-fn().use-image-sizes(false)).get-image()
+
+  images-equal(natural, sized) is false
+end


### PR DESCRIPTION
- Update chart-lib.js to the new js-numbers configuration
- Fix a few mistakes in charts.arr where the old rawarray-based methods were not working
- Clean up redundant "type-checking" iterations in charts.arr, since the annotations are doing that in JS
- Simplify image-num-dot-chart-from-list to simply compose image-dot-chart-from-list and the image-labels method
- Same for labeled-num-dot-chart-from-list
- Add image-dot-chart-from-list, and rewrote categoricalDotChart to handle image marks accordingly.

Various examples:
```
include charts
include gdrive-sheets
include table
import csv as csv

animals-url = "https://docs.google.com/spreadsheets/d/1VeR2_bhpLvnRUZslmCAcSRKfZWs_5RNVujtZgEl6umA/export?format=csv"


animals-table =
  load-table: name, species, sex, age, fixed, legs, pounds, weeks
  source: csv.csv-table-url(animals-url, {
    header-row: true,
    infer-content: true
  })
end

dog-img      = text("🐶", 20, "black")
cat-img      = text("😺", 20, "black")
lizard-img   = text("🦎", 20, "black")
tarantula-img= text("🕷️", 20, "black")
snail-img    = text("🐌", 20, "black")
rabbit-img   = text("🐰", 20, "black")


fun animal-img(r): 
  if      (r["species"] == "dog"):       dog-img
  else if (r["species"] == "cat"):       cat-img
  else if (r["species"] == "tarantula"): tarantula-img
  else if (r["species"] == "lizard"):    lizard-img
  else if (r["species"] == "rabbit"):    rabbit-img
  else if (r["species"] == "snail"):     snail-img
  end
end

names   = animals-table.column("name")
ages    = animals-table.column("age")
fixeds  = animals-table.column("fixed")
species = animals-table.column("species")
images  = animals-table.all-rows().map(animal-img)

"Dot charts"
render-chart(from-list.dot-chart(species)).display()
render-chart(from-list.dot-chart(species).labels(names)).display()
render-chart(from-list.dot-chart(species).image-labels(images)).display()
render-chart(from-list.dot-chart(species).labels(names).image-labels(images)).display()
render-chart(from-list.dot-chart(fixeds.map(to-string)).labels(names).image-labels(images)).display()
render-chart(from-list.image-dot-chart(images, species)).display()
render-chart(from-list.image-dot-chart(images, species).labels(names)).display()
"Num dot charts"
render-chart(from-list.num-dot-chart(ages)).display()
render-chart(from-list.num-dot-chart(ages).labels(names)).display()
render-chart(from-list.num-dot-chart(ages).labels(names).image-labels(images)).display()
render-chart(from-list.labeled-num-dot-chart(names, ages)).display()
render-chart(from-list.labeled-num-dot-chart(names, ages).image-labels(images)).display()
"Image num dot charts"
render-chart(from-list.image-num-dot-chart(images, ages)).display()
render-chart(from-list.image-num-dot-chart(images, ages).labels(names)).display()
render-chart(from-list.image-num-dot-chart(images, ages).point-size(40).use-image-sizes(false).labels(names)).display()
```