### PR TITLE
Tighten isPyretNumber, fix latent leaks (log toFixnum violations for …

### DIFF
--- a/src/js/base/js-numbers.js
+++ b/src/js/base/js-numbers.js
@@ -212,82 +212,101 @@ define("pyret-base/js/js-numbers", function() {
 
 
     // isPyretNumber: any -> boolean
-    // Returns true if the thing is a pyretnum
+    // Pure predicate. Raw JS numbers must be integers (the fixnum
+    // representation) to count as pyretnums; non-integer JS numbers
+    // are not valid pyretnums and return false.
     var isPyretNumber = function(thing) {
-      return (typeof(thing) === 'number'
-              || (thing instanceof Rational ||
-                  thing instanceof Roughnum ||
-                  thing instanceof BigInteger));
+      if (typeof(thing) === 'number') return Number.isInteger(thing);
+      return (thing instanceof Rational ||
+              thing instanceof Roughnum ||
+              thing instanceof BigInteger);
+    };
+
+    // assertPyretNumber: contract check for entry-point operations that
+    // require a pyretnum. Throws a domainError for clearly wrong types
+    // (string, null, etc.). For non-integer JS numbers, logs to
+    // console.error rather than throwing — we don't yet have full
+    // coverage of all call sites that may pass these in, and an
+    // exception in the wild from existing code we haven't audited would
+    // be worse than the current lax behavior. Flip the non-integer
+    // branch to errbacks.throwDomainError once we're confident.
+    var assertPyretNumber = function(thing, callerName) {
+      if (typeof thing === 'number') {
+        if (!Number.isInteger(thing)) {
+          console.error(
+            'js-numbers ' + callerName +
+              ': non-integer JS number leaked into pyretnum: ' + thing,
+            new Error('stack').stack);
+        }
+        return;
+      }
+      if (thing instanceof Rational ||
+          thing instanceof Roughnum ||
+          thing instanceof BigInteger) {
+        return;
+      }
+      errbacks.throwDomainError(
+        callerName + ': arg ' + thing + ' is not a number.');
     };
 
     // isRational: pyretnum -> boolean
     var isRational = function(n) {
-      return (typeof(n) === 'number' ||
-              (isPyretNumber(n) && n.isRational()));
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return true;
+      return n.isRational();
     };
 
     var isExact = isRational;
 
     // isReal: pyretnum -> boolean
     var isReal = function(n) {
-      return (typeof(n) === 'number' ||
-              (isPyretNumber(n) && n.isReal()));
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return true;
+      return n.isReal();
     };
 
     // isInteger: pyretnum -> boolean
     var isInteger = function(n) {
-      if (typeof(n) === 'number') return Number.isInteger(n);
-      if (isPyretNumber(n)) return n.isInteger();
-      return false;
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return true;
+      return n.isInteger();
     };
 
     var isRoughnum = function(n) {
-      if (typeof(n) === 'number') {
-        return false;
-      } else {
-        return (isPyretNumber(n) && n.isRoughnum());
-      }
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return false;
+      return n.isRoughnum();
     };
 
     var isPositive = function(n) {
-      if (typeof(n) === 'number') {
-        return n > 0;
-      } else {
-        return (isPyretNumber(n) && n.isPositive());
-      }
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return n > 0;
+      return n.isPositive();
     };
 
     var isNonPositive = function(n) {
-      if (typeof(n) === 'number') {
-        return n <= 0;
-      } else {
-        return (isPyretNumber(n) && n.isNonPositive());
-      }
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return n <= 0;
+      return n.isNonPositive();
     };
 
     var isNegative = function(n) {
-      if (typeof(n) === 'number') {
-        return n < 0;
-      } else {
-        return (isPyretNumber(n) && n.isNegative());
-      }
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return n < 0;
+      return n.isNegative();
     };
 
     var isNonNegative = function(n) {
-      if (typeof(n) === 'number') {
-        return n >= 0;
-      } else {
-        return (isPyretNumber(n) && n.isNonNegative());
-      }
+      if (!isPyretNumber(n)) return false;
+      if (typeof(n) === 'number') return n >= 0;
+      return n.isNonNegative();
     };
 
     // toFixnum: pyretnum -> javascript-number
     var toFixnum = function(n) {
-      if (typeof(n) === 'number')
-        return n;
-      if (isPyretNumber(n))
-        return n.toFixnum();
-      errbacks.throwDomainError('toFixnum: arg ' + n + ' is not a number.');
+      assertPyretNumber(n, 'toFixnum');
+      if (typeof(n) === 'number') return n;
+      return n.toFixnum();
     };
 
     // toRational: pyretnum -> pyretnum
@@ -875,14 +894,14 @@ define("pyret-base/js/js-numbers", function() {
           return atan(divide(y, x));
         } else { // x > 0, y < 0, 4th qdt
           // atan(y/x) is the 4th qdt and negative, so make it positive by adding 2pi
-          return add(atan(divide(y, x)), 2*Math.PI);
+          return add(atan(divide(y, x)), Roughnum.makeInstance(2*Math.PI));
         }
       } else { // x < 0
         // either x < 0, y >= 0 (2nd qdt), in which case
         //        atan(y/x) must be reflected from 4th to 2nd qdt, by adding pi
         //     or x < 0, y < 0  (3rd qdt), in which case
         //        atan(y/x) must be reflected from 1st to 3rd qdt, again by adding pi
-        return add(atan(divide(y, x)), Math.PI);
+        return add(atan(divide(y, x)), Roughnum.makeInstance(Math.PI));
       }
     };
 

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -2880,14 +2880,14 @@
     function recomputePoints(func, samplePoints, then) {
       return RUNTIME.safeCall(() => {
         return RUNTIME.raw_array_map(RUNTIME.makeFunction((sample) => {
-          return RUNTIME.execThunk(RUNTIME.makeFunction(() => func.app(sample)));
+          return RUNTIME.execThunk(RUNTIME.makeFunction(() => func.app(jsnums.fromFixnum(sample))));
         }), samplePoints);
       }, (funcVals) => {
         const dataValues = [];
         funcVals.forEach((result, idx) => {
           cases(RUNTIME.ffi.isEither, 'Either', result, {
             left: (value) => dataValues.push({
-              x: toFixnum(samplePoints[idx]),
+              x: samplePoints[idx],
               y: toFixnum(value)
             }),
             right: () => {}
@@ -2958,7 +2958,7 @@
 
       addCrosshairs(prefix, ['Dots'], signals, marks, pointColor);
 
-      const samplePoints = [...Array(numSamples).keys().map((i) => jsnums.fromFixnum(xMinValue + (fraction * i)))];
+      const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
 
       return recomputePoints(func, samplePoints, (dataValues) => {
         data[0].values = dataValues;
@@ -2976,7 +2976,7 @@
             const xMinValue = globalOptions.xMinValue;
             const xMaxValue = globalOptions.xMaxValue;
             const fraction = (xMaxValue - xMinValue) / (numSamples - 1);
-            const samplePoints = [...Array(numSamples).keys().map((i) => jsnums.fromFixnum(xMinValue + (fraction * i)))];
+            const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
             RUNTIME.runThunk(() => {
               // NOTE(Ben): We can use view.data(`${prefix}rawTable`, ...newData...)
               // to replace the existing data points in the _current_ view, so that

--- a/src/js/trove/charts-lib.js
+++ b/src/js/trove/charts-lib.js
@@ -2958,7 +2958,7 @@
 
       addCrosshairs(prefix, ['Dots'], signals, marks, pointColor);
 
-      const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
+      const samplePoints = [...Array(numSamples).keys().map((i) => jsnums.fromFixnum(xMinValue + (fraction * i)))];
 
       return recomputePoints(func, samplePoints, (dataValues) => {
         data[0].values = dataValues;
@@ -2976,7 +2976,7 @@
             const xMinValue = globalOptions.xMinValue;
             const xMaxValue = globalOptions.xMaxValue;
             const fraction = (xMaxValue - xMinValue) / (numSamples - 1);
-            const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
+            const samplePoints = [...Array(numSamples).keys().map((i) => jsnums.fromFixnum(xMinValue + (fraction * i)))];
             RUNTIME.runThunk(() => {
               // NOTE(Ben): We can use view.data(`${prefix}rawTable`, ...newData...)
               // to replace the existing data points in the _current_ view, so that
@@ -3316,8 +3316,8 @@
               }
               // Reflect the updated values back into the globalOptions,
               // so that they'll be picked up by the initial computation of function plots
-              globalOptions['x-min'] = RUNTIME.ffi.makeSome(clippedDomain[0]);
-              globalOptions['x-max'] = RUNTIME.ffi.makeSome(clippedDomain[1]);
+              globalOptions['x-min'] = RUNTIME.ffi.makeSome(jsnums.fromFixnum(clippedDomain[0]));
+              globalOptions['x-max'] = RUNTIME.ffi.makeSome(jsnums.fromFixnum(clippedDomain[1]));
               return RUNTIME.safeCall(
                 () => makeFunctionPlots(clippedDomain),
                 (functionPlots) => composeCharts(globalOptions, clippedDomain, {

--- a/src/js/trove/filesystem-internal.js
+++ b/src/js/trove/filesystem-internal.js
@@ -57,8 +57,8 @@
         async function stat(p) {
             const stats = await fsp.stat(p);
             return {
-                ctime: stats.ctimeMs,
-                mtime: stats.mtimeMs,
+                ctime: Math.floor(stats.ctimeMs),
+                mtime: Math.floor(stats.mtimeMs),
                 size: stats.size,
                 native: stats
             };

--- a/src/js/trove/image-lib.js
+++ b/src/js/trove/image-lib.js
@@ -1387,8 +1387,6 @@
     var PointPolygonImage = function(vertices, style, color) {
       BaseImage.call(this);
       for (var v = 0; v < vertices.length; v++) {
-        vertices[v].x = jsnums.toFixnum(vertices[v].x);
-        vertices[v].y = jsnums.toFixnum(vertices[v].y);
         vertices[v].y *= -1;
       }
       


### PR DESCRIPTION
…now)

Joe says:

Medium-interesting finding from Ben noticing a change to `num-to-fixnum` behavior on CPO.

The key thing is NON-integer JS floats. They are *not* supposed to be able to be Pyret numbers. In various places we were lax about this and things worked out because of tostring conversions or === doing the right thing, etc.

This commit tries to make some progress on catching our own mistakes here:

- Correctly return `false` from the widely used `isPyretNumber` for values like 2.3 (~2.3 aka Roughnum.makeInstance(2.3) still returns true)
- Add assertPyretNumber, currently used in one place (toFixnum), which based on its throwing of a DomainError clearly expects to get an actual Pyret number.

The rest of the commit cleans up cases where we made mistakes and returned or passed JS floating-point across the boundary.

assertPyretNumber *should* throw, not just console.error. But I'm too scared to do that because I'm not convinced our tests are exhaustive here at all, and an exception in the wild could be pretty breaking. So we console.error for now.

Claude used this assert on toFixnum to find several errors, all of which come straight from our existing tests/compiler runs.

Claude says:

Specifics of the boundary cleanups, since they're spread across four files:

- js-numbers.js atan2: the y=0 quadrants correctly wrapped Math.PI in a Roughnum, but the x>0 4th-quadrant and x<0 cases passed bare Math.PI and 2*Math.PI to add(), which short-circuits on two JS numbers and returns the raw JS sum. So num-atan2(0, -1) returned the JS double 3.141592653589793 rather than a Roughnum, with branch-dependent type tags visible to user code (num-is-roughnum was false). Wrapping the constants in Roughnum.makeInstance fixes it. Bug present since the original atan2 introduction in 2016.

- filesystem-internal.js stat: mtimeMs/ctimeMs from Node fs.Stats carry sub-millisecond precision on filesystems with ns granularity (APFS, ext4-ns, NTFS), so mtime/ctime were leaking fractional doubles to callers like cli-module-loader.arr's cache-staleness check. Floored to integer ms, matching the documented "in epoch ms" contract.

- charts-lib.js function-plot: sample x-coordinates were built via raw JS arithmetic (xMin + fraction*i) and handed to the user's Pyret function and to toFixnum, both of which expect pyretnums. Wrapped each sample in jsnums.fromFixnum at the JS/Pyret boundary, in both the initial pass and the recompute callback. Same fix for clippedDomain[0/1] before they get stashed back into globalOptions.

- image-lib.js PointPolygonImage: dropped a redundant jsnums.toFixnum(vertices[v].x/y) — unwrapPoint2D already produces fixnums upstream, so the second call was dead under the lax predicate and now (correctly) flags inputs like 2.5 from point(15/6, ...).

assertPyretNumber currently console.error's (with a stack) on non-integer JS numbers rather than throwing, per Joe's caution above; clearly non-numeric inputs still throw the same domainError they did before. Pyret-test suite green.