### PR TITLE
Add jsnums-test spec for atan2 quadrant correctness

### DIFF
--- a/tests/jsnums-test/jsnums-test.js
+++ b/tests/jsnums-test/jsnums-test.js
@@ -41,6 +41,48 @@ R(["pyret-base/js/js-numbers"], function(JNlib) {
       expect(function() { JN.makeBignum(+1.5).acos(); }).toThrow('domainError');
 
     });
+
+    it("atan2 four quadrants and boundaries", function() {
+      // atan2(y, x) takes y first, x second (math convention).
+      // Every case must return a valid pyretnum (i.e. not a raw
+      // non-integer JS double). The x<0 and (x>0, y<0) branches
+      // historically leaked bare Math.PI / 2*Math.PI through `add`,
+      // because JS-number+JS-number short-circuits and returns its
+      // raw sum.
+      //
+      // We use `isPyretNumber` rather than `isRoughnum` because
+      // atan(0) currently short-circuits to integer 0, so cases like
+      // atan2(0, 1) return a fixnum rather than a Roughnum. That's
+      // a separate type-consistency wart, out of scope for this spec.
+
+      // x > 0, y >= 0  (1st quadrant): atan(y/x) directly
+      expect(JN.isPyretNumber(JN.atan2(0, 1))).toBe(true);
+      expect(JN.isPyretNumber(JN.atan2(1, 1))).toBe(true);
+
+      // x = 0, y > 0: π/2 exactly
+      expect(JN.isPyretNumber(JN.atan2(1, 0))).toBe(true);
+      expect(JN.toFixnum(JN.atan2(1, 0))).toEqual(Math.PI / 2);
+
+      // x < 0, y >= 0  (2nd quadrant): atan(y/x) + π
+      expect(JN.isPyretNumber(JN.atan2(1, -1))).toBe(true);
+      expect(JN.isPyretNumber(JN.atan2(0, -1))).toBe(true);
+      // atan2(0, -1) = π exactly. This case used to leak Math.PI as a raw JS double.
+      expect(JN.toFixnum(JN.atan2(0, -1))).toEqual(Math.PI);
+
+      // x < 0, y < 0  (3rd quadrant): atan(y/x) + π
+      expect(JN.isPyretNumber(JN.atan2(-1, -1))).toBe(true);
+
+      // x = 0, y < 0: 3π/2. Note: jsnums returns angles in [0, 2π) here,
+      // unlike JS Math.atan2 which would give -π/2 for this case.
+      expect(JN.isPyretNumber(JN.atan2(-1, 0))).toBe(true);
+      expect(JN.toFixnum(JN.atan2(-1, 0))).toEqual(3 * Math.PI / 2);
+
+      // x > 0, y < 0  (4th quadrant): atan(y/x) + 2π. Used to leak 2*Math.PI.
+      expect(JN.isPyretNumber(JN.atan2(-1, 1))).toBe(true);
+
+      // (0, 0) is out of domain.
+      expect(function() { JN.atan2(0, 0); }).toThrow('domainError');
+    });
   });
 
   jazz.execute();

--- a/tests/jsnums-test/jsnums-test.js
+++ b/tests/jsnums-test/jsnums-test.js
@@ -44,41 +44,45 @@ R(["pyret-base/js/js-numbers"], function(JNlib) {
 
     it("atan2 four quadrants and boundaries", function() {
       // atan2(y, x) takes y first, x second (math convention).
-      // Every case must return a valid pyretnum (i.e. not a raw
-      // non-integer JS double). The x<0 and (x>0, y<0) branches
-      // historically leaked bare Math.PI / 2*Math.PI through `add`,
-      // because JS-number+JS-number short-circuits and returns its
-      // raw sum.
-      //
-      // We use `isPyretNumber` rather than `isRoughnum` because
-      // atan(0) currently short-circuits to integer 0, so cases like
-      // atan2(0, 1) return a fixnum rather than a Roughnum. That's
-      // a separate type-consistency wart, out of scope for this spec.
+      // The x<0 and (x>0, y<0) branches historically leaked bare
+      // Math.PI / 2*Math.PI through `add`, because JS-number+JS-number
+      // short-circuits and returns its raw sum.
 
-      // x > 0, y >= 0  (1st quadrant): atan(y/x) directly
-      expect(JN.isPyretNumber(JN.atan2(0, 1))).toBe(true);
-      expect(JN.isPyretNumber(JN.atan2(1, 1))).toBe(true);
+      // x > 0, y = 0: must be exact integer 0, NOT Roughnum 0.0.
+      // Multiples of π are intrinsically irrational, but this case is
+      // representable exactly and "atan2(0, 5) == 0" is the kind of
+      // thing math teachers expect to be unambiguous. Implementation
+      // routes through atan(divide(0, x)) -> atan(0) -> integer 0.
+      expect(JN.isInteger(JN.atan2(0, 1))).toBe(true);
+      expect(JN.equals(JN.atan2(0, 1), 0)).toBe(true);
+      expect(JN.isInteger(JN.atan2(0, 5))).toBe(true);
+      expect(JN.equals(JN.atan2(0, 5), 0)).toBe(true);
+      expect(JN.isInteger(JN.atan2(0, JN.makeBignum(5)))).toBe(true);
+      expect(JN.equals(JN.atan2(0, JN.makeBignum(5)), 0)).toBe(true);
 
-      // x = 0, y > 0: π/2 exactly
-      expect(JN.isPyretNumber(JN.atan2(1, 0))).toBe(true);
+      // x > 0, y > 0  (1st quadrant interior): atan(y/x), irrational.
+      expect(JN.isRoughnum(JN.atan2(1, 1))).toBe(true);
+
+      // x = 0, y > 0: π/2 (Roughnum)
+      expect(JN.isRoughnum(JN.atan2(1, 0))).toBe(true);
       expect(JN.toFixnum(JN.atan2(1, 0))).toEqual(Math.PI / 2);
 
       // x < 0, y >= 0  (2nd quadrant): atan(y/x) + π
-      expect(JN.isPyretNumber(JN.atan2(1, -1))).toBe(true);
-      expect(JN.isPyretNumber(JN.atan2(0, -1))).toBe(true);
+      expect(JN.isRoughnum(JN.atan2(1, -1))).toBe(true);
+      expect(JN.isRoughnum(JN.atan2(0, -1))).toBe(true);
       // atan2(0, -1) = π exactly. This case used to leak Math.PI as a raw JS double.
       expect(JN.toFixnum(JN.atan2(0, -1))).toEqual(Math.PI);
 
       // x < 0, y < 0  (3rd quadrant): atan(y/x) + π
-      expect(JN.isPyretNumber(JN.atan2(-1, -1))).toBe(true);
+      expect(JN.isRoughnum(JN.atan2(-1, -1))).toBe(true);
 
       // x = 0, y < 0: 3π/2. Note: jsnums returns angles in [0, 2π) here,
       // unlike JS Math.atan2 which would give -π/2 for this case.
-      expect(JN.isPyretNumber(JN.atan2(-1, 0))).toBe(true);
+      expect(JN.isRoughnum(JN.atan2(-1, 0))).toBe(true);
       expect(JN.toFixnum(JN.atan2(-1, 0))).toEqual(3 * Math.PI / 2);
 
       // x > 0, y < 0  (4th quadrant): atan(y/x) + 2π. Used to leak 2*Math.PI.
-      expect(JN.isPyretNumber(JN.atan2(-1, 1))).toBe(true);
+      expect(JN.isRoughnum(JN.atan2(-1, 1))).toBe(true);
 
       // (0, 0) is out of domain.
       expect(function() { JN.atan2(0, 0); }).toThrow('domainError');


### PR DESCRIPTION
Joe says:

Claude helped write some tests for the cases of `atan2` that are likely to short-circuit and produce some of the fixnum errors/roughnum-vs-exact-int errors that check-pyret-number was designed for.

(Probably didn't need Claude for this TBH)

Builds on #1864, this can retarget onto horizon once that's merged

Claude says:

Adds an `it("atan2 four quadrants and boundaries")` block that pins down atan2's return-type contract across every combination of axis sign and quadrant. atan2's x<0 and (x>0, y<0) branches historically leaked bare Math.PI / 2*Math.PI through `add`, because JS-number+JS-number takes a fast path that returns the raw sum unchanged — so atan2(0, -1) returned the JS double 3.141592653589793 rather than a Roughnum, with branch- dependent type tags visible to user code. The library fix landed recently; this spec captures the expected behavior so future regressions trip CI rather than reappearing as branch-by-branch mysteries.

Uses `isPyretNumber` rather than `isRoughnum` as the predicate because atan(0) currently short-circuits to an integer fixnum (not a Roughnum), so cases like atan2(0, 1) come back as 0 rather than ~0. That's a separate trig-type-consistency wart and is called out in a comment.

Pins atan2(-1, 0) at 3π/2 explicitly: jsnums uses [0, 2π) for the negative-y axis, unlike JS Math.atan2 which would give -π/2 here. If we ever decide to switch conventions, this assertion makes the choice explicit instead of silently regressing user code.