### PR TITLE
Add jsnums-test spec for canonical BigInteger representation (re-do)

### DIFF
--- a/tests/jsnums-test/jsnums-test.js
+++ b/tests/jsnums-test/jsnums-test.js
@@ -41,6 +41,26 @@ R(["pyret-base/js/js-numbers"], function(JNlib) {
       expect(function() { JN.makeBignum(+1.5).acos(); }).toThrow('domainError');
 
     });
+
+    it("BigInteger uses a canonical representation (toEqual works)", function() {
+      // BigIntegers are stored as variable-length digit arrays. Operations
+      // that produce a result with fewer significant words than the
+      // operands historically left "phantom" enumerable slots beyond the
+      // canonical word count `t`, so jasmine's `toEqual` (deep structural
+      // compare) would distinguish two BigIntegers that JN.equals says
+      // are the same number. bnpClamp() normalizes by deleting those
+      // slots so structural equality matches numeric equality.
+
+      // Same number via different parse paths should be structurally equal.
+      expect(JN.fromString("1e5")).toEqual(JN.makeBignum("1e5"));
+      expect(JN.fromString("1e30")).toEqual(JN.makeBignum("1e30"));
+      expect(JN.fromString("1e140")).toEqual(JN.makeBignum("1e140"));
+      expect(JN.fromString("1e309")).toEqual(JN.makeBignum("1e309"));
+
+      // Different surface forms of the same number should also be equal.
+      expect(JN.makeBignum("1e1")).toEqual(JN.makeBignum("10"));
+      expect(JN.makeBignum("1e3")).toEqual(JN.makeBignum("1000"));
+    });
   });
 
   jazz.execute();


### PR DESCRIPTION
Supersedes #1867, which I closed after Copilot mis-resolved the conflict by merging `master` into the branch (the PR is based on `horizon`). Same single commit, this time merged from `horizon` so the only diff is the new `it(...)` block.

Joe says:

Trying to work my way through different image library tests in orthogonal easy-to-review commits. @blerner let me know if this is helpful as a workflow.

Claude says:

Adds an `it("BigInteger uses a canonical representation (toEqual works)")` block that pins down the invariant established by the bnpClamp delete-loop in eb0d52437: two BigIntegers representing the same number, built via different paths, must be structurally equal (jasmine `toEqual`), not just numerically equal (`JN.equals`).

Verified the spec catches the regression: temporarily short-circuiting the bnpClamp delete-loop fails with "Expected object not to have properties: 18: 33554432" — the phantom-slot symptom the fix addresses.