### PR TITLE
Security: Command Injection via Unsanitized Input in bench-programs.js

### DIFF
--- a/pitometer/bench-programs.js
+++ b/pitometer/bench-programs.js
@@ -9,18 +9,18 @@ define(["child_process", "time-helpers", "fs", "path"], function(childProcess, t
     const programsPath = config.programsPath || "pitometer/programs/";
     const include = config.include || [];
 
-    function echoRun(cmd, opts) {
-      console.log(cmd);
-      return childProcess.execSync(cmd, opts);
+    function echoRun(cmd, args, opts) {
+      console.log([cmd].concat(args).join(" "));
+      return childProcess.execFileSync(cmd, args, opts);
     }
 
 
     function compileAndTimeRun(program) {
       const toBuild = program.replace(/\.arr$/, ".jarr");
       const [compileSuccess, , ] = maybeTime(true, () => echoRun(
-        `env EF="-no-user-annotations" make ${toBuild}`, {stdio: [0, 1, 2]}));
+        "make", [toBuild], {stdio: [0, 1, 2], env: Object.assign({}, process.env, {EF: "-no-user-annotations"})}));
 
-      return maybeTime(compileSuccess, () => echoRun(`node ${toBuild}`));
+      return maybeTime(compileSuccess, () => echoRun("node", [toBuild]));
     }
 
     let paths = fs.readdirSync(programsPath);
@@ -28,7 +28,7 @@ define(["child_process", "time-helpers", "fs", "path"], function(childProcess, t
     paths = paths.filter((p) => p.slice(-4) === ".arr");
     paths = paths.filter((p) => include === "*" || include.some((i) => (p.indexOf(i) !== -1)));
     console.log("Running for these programs after filters: ", paths);
-    echoRun(`make phaseA`);
+    echoRun("make", ["phaseA"]);
     const results = [];
     paths.map((p) => {
       const programPath = path.join(programsPath, p);


### PR DESCRIPTION
## Summary

Security: Command Injection via Unsanitized Input in bench-programs.js

## Problem

**Severity**: `Critical` | **File**: `pitometer/bench-programs.js:L28`

The `echoRun` function in `bench-programs.js` directly interpolates user-controlled input (`program`) into shell commands executed via `childProcess.execSync`. The `program` variable comes from filesystem enumeration but is not sanitized before being used in template literals for `make` and `node` commands. While `path.join` is used, the `program` variable itself can contain shell metacharacters that would be interpreted by the shell. Additionally, the `options` parameter and its `config` property could be attacker-controlled, leading to further command injection through `programsPath`.

## Solution

Use `childProcess.execFileSync` or `childProcess.spawnSync` with array arguments instead of `execSync` with string interpolation. Validate and sanitize all path inputs using `path.resolve()` and ensure no shell metacharacters are present. Consider using a whitelist of allowed program names.

## Changes

- `pitometer/bench-programs.js` (modified)