### PR TITLE
Fixes apparent regression in multi-bar charts

### DIFF
--- a/lang/src/js/trove/charts-lib.js
+++ b/lang/src/js/trove/charts-lib.js
@@ -1180,7 +1180,7 @@
         name: 'secondary',
         range: axesConfig.secondary.range,
         ...(axesConfig.secondary.name === 'x' ? xAxisType : yAxisType),
-        nice: true, zero: false,
+        nice: true, zero: true,
         domain: (axis && isNotFullStacked) ? { signal: 'extent(domain("secondaryLabels"))' } : { data: 'table', field: 'value1' }
       };
       const scales = [


### PR DESCRIPTION
Fixes apparent regression in multi-bar charts, where the horizontal axis did not cross at zero.

Repro code:
```
include charts
import color as C

color-list = [list: C.red, C.green]

shadow tab = table: group, vals
  row: "cat", [list: 4, 7]
  row: "dog", [list: 6, 9]
  row: "lizard", [list: 1, 1]
  row: "rabbit", [list: 1, 1]
  row: "snail", [list: 1, 0]
  row: "tarantula", [list: 1, 0]
end

from-list.stacked-bar-chart(
  tab.get-column("group").map(to-repr),
  tab.get-column("vals"),
  [list: "false", "true"])
  .stacking-type(relative)
  .colors(color-list)
```
Current: 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/6ebe24e2-ff80-4bf2-9e90-a9d696199c40" />
Fixed:
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/c883b317-67e7-4a7b-871d-8ab286071053" />
