### PR TITLE
Vscode url file e2e tests

### DIFF
--- a/code.pyret.org/src/web/arr/cpo.arr
+++ b/code.pyret.org/src/web/arr/cpo.arr
@@ -146,7 +146,7 @@ end
 fun compile-ast(ast, runtime, finder, options) -> E.Either:
   uri = ast.l.source
   locator = ast-locator(uri, ast)
-  wl = CL.compile-worklist(finder, locator, {})
+  wl = CL.compile-worklist(finder, locator, {load-path: "."})
   cases(E.Either) CL.compile-standalone(wl, SD.make-mutable-string-dict(), options):
     | left(problems) => E.left(problems)
     | right(standalone) => E.right(standalone.js-ast.to-ugly-source())
@@ -159,6 +159,6 @@ end
 
 fun make-repl(builtin-mods, runtime, realm, finder):
   modules = get-builtin-modules(builtin-mods)
-  repl = R.make-repl(runtime, modules, realm, "cpo-context-currently-unused", finder)
+  repl = R.make-repl(runtime, modules, realm, {load-path: "."}, finder)
   repl
 end

--- a/code.pyret.org/src/web/js/cpo-main.js
+++ b/code.pyret.org/src/web/js/cpo-main.js
@@ -141,10 +141,65 @@
       return new URL(path, base).href;
     }
 
+    // Module resolution is context-aware: a (url-)file import resolves relative
+    // to the directory of the importing module, NOT the open editor tab. We
+    // thread that directory as a "load-path" (kept relative to the tab, which is
+    // the base the embedding host resolves every fs path against, so no host-side
+    // change is needed to land on the right file).
+    //
+    // All path arithmetic goes through the same filesystem-internal RPC the
+    // running program uses (read-file / image-file / ...), so that
+    // `import url-file(...)` and runtime file operations resolve a given path
+    // identically -- one source of truth, in the embedding host. This mirrors
+    // get-real-path / locate-file in cli-module-loader.arr (which thread a
+    // current-load-path through the `filesystem` module the same way).
+    function getLoadPath(context) {
+      if (context && runtime.hasField(context, "load-path")) {
+        return runtime.getField(context, "load-path");
+      }
+      return ".";
+    }
+    function makeContext(loadPath) {
+      return runtime.makeObject({ "load-path": loadPath });
+    }
+    // get-real-path: an absolute REL is honored as-is, otherwise it is joined
+    // onto the importer's load-path. Returns a Promise (the path ops are RPCs).
+    function getRealPath(context, rel) {
+      return fsInternal.isAbsolute(rel).then(function(abs) {
+        if (abs) { return rel; }
+        return fsInternal.join(getLoadPath(context), rel);
+      });
+    }
+    // For a dependency, compute a Promise of { path, context }: the path to feed
+    // the file locator (null for non-file protocols) and the context to thread
+    // to that module when its own dependencies are resolved.
+    function dependencyResolveInfo(context, dependency) {
+      return runtime.ffi.cases(gmf(compileStructs, "is-Dependency"), "Dependency", dependency,
+        {
+          builtin: function(name) { return Promise.resolve({ path: null, context: context }); },
+          dependency: function(protocol, args) {
+            var arr = runtime.ffi.toArray(args);
+            var rel = null;
+            if (protocol === "file" || protocol === "js-file") { rel = arr[0]; }
+            else if (protocol === "url-file") { rel = arr[1]; }
+            if (rel === null) {
+              // builtin/gdrive/url and remote url-file: nothing local to track,
+              // thread the importer's context through unchanged.
+              return Promise.resolve({ path: null, context: context });
+            }
+            return getRealPath(context, rel).then(function(realPath) {
+              return fsInternal.dirname(realPath).then(function(dir) {
+                return { path: realPath, context: makeContext(dir) };
+              });
+            });
+          }
+        });
+    }
+
     // NOTE(joe/ben): this function _used_ to be trivially stack safe, but files
     // need to resolve their absolute path to calculate their URI, which
     // requires an RPC, so this function is no-longer trivially flat
-    function uriFromDependency(dependency) {
+    function uriFromDependency(dependency, info) {
       return runtime.ffi.cases(gmf(compileStructs, "is-Dependency"), "Dependency", dependency,
         {
           builtin: function(name) {
@@ -166,8 +221,10 @@
                 console.error("Unknown import: ", dependency);
                 return protocol + "://" + arr.join(":");
               }
+              // Identity uses the importer-relative path (info.path) so a
+              // module's URI matches the file actually loaded.
               return runtime.pauseStack((restarter) => {
-                const realpath = window.MESSAGES.sendRpc('path', 'resolve', [arr[0]]);
+                const realpath = window.MESSAGES.sendRpc('path', 'resolve', [info.path]);
                 realpath.then((realpath) => {
                   restarter.resume(`js-file://${realpath}`);
                 });
@@ -179,7 +236,7 @@
                 return protocol + "://" + arr.join(":");
               }
               return runtime.pauseStack((restarter) => {
-                const realpath = window.MESSAGES.sendRpc('path', 'resolve', [arr[0]]);
+                const realpath = window.MESSAGES.sendRpc('path', 'resolve', [info.path]);
                 realpath.then((realpath) => {
                   restarter.resume(`file://${realpath}`);
                 });
@@ -203,12 +260,23 @@
       // The locatorCache memoizes locators for the duration of an
       // interactions run
       var locatorCache = {};
-      function findModule(contextIgnored, dependency) {
+      function findModule(context, dependency) {
+        return runtime.safeCall(function() {
+          // Resolve the import path via the host's filesystem RPC (a Promise),
+          // pausing the Pyret stack until it settles.
+          return runtime.pauseStack(function(restarter) {
+            dependencyResolveInfo(context, dependency).then(function(info) {
+              restarter.resume(info);
+            }, function(err) {
+              restarter.error(runtime.ffi.makeMessageException("Error resolving import path: " + String(err)));
+            });
+          });
+        }, function(info) {
         return runtime.safeCall(() => {
-          return uriFromDependency(dependency);
+          return uriFromDependency(dependency, info);
         }, function(uri) {
           if(locatorCache.hasOwnProperty(uri)) {
-            return gmf(compileLib, "located").app(locatorCache[uri], runtime.nothing);
+            return gmf(compileLib, "located").app(locatorCache[uri], info.context);
           }
           return runtime.safeCall(function() {
             return runtime.ffi.cases(gmf(compileStructs, "is-Dependency"), "Dependency", dependency,
@@ -234,11 +302,11 @@
                     return constructors.makeGDriveJSLocator(arr[0], arr[1]);
                   }
                   else if (protocol === "js-file" && window.MESSAGES) {
-                    return gmf(jsfile, "make-jsfile-locator").app(arr[0]);
+                    return gmf(jsfile, "make-jsfile-locator").app(info.path);
                   }
                   else if (protocol === "file" && window.MESSAGES) {
                     var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
-                    return fileLocatorConstructor.makeFileLocator(arr[0]);
+                    return fileLocatorConstructor.makeFileLocator(info.path);
                   }
                   else if (protocol === "url") {
                     fetch(arr[0]).then(async (response) => {
@@ -255,23 +323,23 @@
                         });
                         return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals);
                       case "all-local":
-                        fsInternal.readFile(fullUrl).then((contents) => {
+                        fsInternal.readFile(info.path).then((contents) => {
                           const strContents = Buffer.from(contents).toString('utf8');
                           CPO.documents.set(fullUrl, new CodeMirror.Doc(strContents, "pyret"));
                         });
                         var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
-                        return fileLocatorConstructor.makeFileLocator(arr[1]);
+                        return fileLocatorConstructor.makeFileLocator(info.path);
                       case "local-if-present":
                         return runtime.pauseStack(async (restarter) => {
-                          const exists = await fsInternal.exists(arr[1]);
+                          const exists = await fsInternal.exists(info.path);
                           if(exists) {
-                            fsInternal.readFile(fullUrl).then((contents) => {
+                            fsInternal.readFile(info.path).then((contents) => {
                               const strContents = Buffer.from(contents).toString('utf8');
                               CPO.documents.set(fullUrl, new CodeMirror.Doc(strContents, "pyret"));
                             });
                             return runtime.runThunk(() => {
                               var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
-                              return fileLocatorConstructor.makeFileLocator(arr[1]);
+                              return fileLocatorConstructor.makeFileLocator(info.path);
                             }, (result) => {
                               if(runtime.isSuccessResult(result)) {
                                 restarter.resume(result.result);
@@ -298,9 +366,10 @@
             });
           }, function(l) {
               locatorCache[uri] = l;
-              return gmf(compileLib, "located").app(l, runtime.nothing);
+              return gmf(compileLib, "located").app(l, info.context);
           }, "findModule");
         });
+        }, "findModule-info");
       }
       return runtime.makeFunction(findModule, "cpo-find-module");
     }

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -3,3 +3,6 @@
 out
 dist
 node_modules
+build
+test/fixtures/**/*-out.txt
+test/fixtures/**/result-*.txt

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -12,6 +12,7 @@
 				"mustache": "^4.2.0"
 			},
 			"devDependencies": {
+				"@types/mocha": "^10.0.6",
 				"@types/mustache": "^4.2.5",
 				"@types/node": "^18",
 				"@types/vscode": "^1.73.0",
@@ -19,9 +20,11 @@
 				"@typescript-eslint/parser": "^7.14.0",
 				"@vscode/test-web": "^0.0.65",
 				"@vscode/vsce": "^3.6.0",
+				"assert": "^2.1.0",
 				"copy-webpack-plugin": "^13.0.0",
 				"eslint": "^8.26.0",
 				"generator-code": "^1.11.5",
+				"mocha": "^10.4.0",
 				"path-browserify": "^1.0.1",
 				"ts-loader": "^9.5.2",
 				"typescript": "^5.5.2",
@@ -1978,6 +1981,13 @@
 				"@types/lodash": "*"
 			}
 		},
+		"node_modules/@types/mocha": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/mustache": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.5.tgz",
@@ -3292,6 +3302,16 @@
 				"string-width": "^4.1.0"
 			}
 		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3345,6 +3365,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/are-we-there-yet": {
@@ -3409,6 +3443,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/assert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-nan": "^1.3.2",
+				"object-is": "^1.1.5",
+				"object.assign": "^4.1.4",
+				"util": "^0.12.5"
+			}
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3432,6 +3480,22 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/azure-devops-node-api": {
 			"version": "12.5.0",
@@ -3959,6 +4023,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/browserify-zlib": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
@@ -4171,6 +4242,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4359,6 +4449,44 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/chownr": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -4468,6 +4596,36 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/clone": {
@@ -6366,6 +6524,22 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/foreachasync": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
@@ -6708,6 +6882,16 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-east-asian-width": {
@@ -7173,6 +7357,16 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
 			}
 		},
 		"node_modules/hosted-git-info": {
@@ -7686,12 +7880,55 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/is-arguments": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-ci": {
 			"version": "2.0.0",
@@ -7879,6 +8116,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-nan": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-npm": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -8025,6 +8279,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typedarray": {
@@ -9650,6 +9920,142 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/mocha": {
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+			"integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha.js"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/diff": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/mocha/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mocha/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/mocha/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/morgan": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -10404,6 +10810,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/object-is": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -10412,6 +10835,27 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0",
+				"has-symbols": "^1.1.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/on-finished": {
@@ -11549,6 +11993,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/postcss-selector-parser": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -12248,6 +12702,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -12344,6 +12811,16 @@
 			"integrity": "sha512-bH6E4PMmsEXYrLX6Kr1vu+xI3HproB1vECAwaPSJeroLE1kpWE3HR27uB4icx+6YORu1ajqBJXxuedv8ZQg5Lw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
@@ -12921,6 +13398,24 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -15167,6 +15662,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15716,6 +16225,28 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/widest-line": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -15745,6 +16276,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/workerpool": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "6.2.0",
@@ -15890,12 +16428,41 @@
 				"node": ">=0.4"
 			}
 		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/yargs-parser": {
 			"version": "10.1.0",
@@ -15905,6 +16472,68 @@
 			"license": "ISC",
 			"dependencies": {
 				"camelcase": "^4.1.0"
+			}
+		},
+		"node_modules/yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/yauzl": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -108,11 +108,17 @@
 	"scripts": {
 		"link-pyret": "ln -s node_modules/code.pyret.org/build build",
 		"vscode:prepublish": "npm run compile",
-		"compile": "webpack --mode production"
+		"compile": "webpack --mode production",
+		"compile-tests": "webpack --config webpack.test.config.js --mode development",
+		"pretest": "npm run compile && npm run compile-tests",
+		"test": "vscode-test-web --browserType=chromium --headless --esm --extensionDevelopmentPath=. --extensionTestsPath=./dist/web/test/index.js ./test/fixtures/spell-checker"
 	},
 	"devDependencies": {
+		"@types/mocha": "^10.0.6",
 		"@types/mustache": "^4.2.5",
 		"@types/node": "^18",
+		"assert": "^2.1.0",
+		"mocha": "^10.4.0",
 		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^7.14.0",
 		"@typescript-eslint/parser": "^7.14.0",

--- a/vscode/src/pyretCPOWebEditor.ts
+++ b/vscode/src/pyretCPOWebEditor.ts
@@ -150,17 +150,22 @@ export function makePyretPane(
   document: vscode.TextDocument,
   type: PyretPaneType
 ): PyretPane {
+    // Single source of truth for path resolution: every fs path that arrives
+    // over the RPC is resolved against the open document's directory with
+    // vscode-uri, so imports (`import url-file(...)`) and runtime file ops
+    // (read-file, image-file, ...) resolve a given path identically. The pure
+    // lexical helpers (join/dirname/...) use the bundled posix `path`, which
+    // matches vscode-uri's posix semantics on every platform.
+    const docDir = () => Utils.dirname(document.uri);
+    const resolveAgainstDoc = (p: string) => Utils.resolvePath(docDir(), p);
     const knownModules = {
       'fs': {
         'writeFile': async (p: string, buffer : Buffer) => {
-          const pathUri = Utils.resolvePath(Utils.dirname(document.uri), p);
-          await vscode.workspace.fs.writeFile(pathUri, buffer);
+          await vscode.workspace.fs.writeFile(resolveAgainstDoc(p), buffer);
           return;
         },
         'readFile': async (p: string, opts : ReadFileOpts) => {
-          const pathUri = Utils.resolvePath(Utils.dirname(document.uri), p);
-          console.log("ReadFile: ", pathUri, p, document.uri);
-          const contents = await vscode.workspace.fs.readFile(pathUri);
+          const contents = await vscode.workspace.fs.readFile(resolveAgainstDoc(p));
           if(opts && (opts === 'utf8' || opts.encoding === 'utf8')) {
             return Buffer.from(contents).toString('utf8');
           }
@@ -169,8 +174,7 @@ export function makePyretPane(
           }
         },
         'stat': async (p: string) => {
-          const pathUri = vscode.Uri.joinPath(Utils.dirname(document.uri), p);
-          const stat = await vscode.workspace.fs.stat(pathUri);
+          const stat = await vscode.workspace.fs.stat(resolveAgainstDoc(p));
           return {
             mtime: stat.mtime,
             ctime: stat.ctime,
@@ -179,23 +183,22 @@ export function makePyretPane(
           };
         },
         'createDir': async (p: string) => {
-          const pathUri = Utils.resolvePath(Utils.dirname(document.uri), p);
-          await vscode.workspace.fs.createDirectory(pathUri);
+          await vscode.workspace.fs.createDirectory(resolveAgainstDoc(p));
           return;
         }
       },
       'path': {
         'join': path.join,
-        'resolve': (p : string) => {
-          const docUri = Utils.dirname(document.uri);
-          const answer = path.resolve(docUri.fsPath, p);
-          return answer;
-        },
+        // Resolve against the document dir with the SAME mechanism as the fs
+        // methods above (vscode-uri), returning the absolute path string.
+        'resolve': (p : string) => resolveAgainstDoc(p).path,
         'basename': (p: string) => path.basename(p),
         'dirname': (p: string) => path.dirname(p),
         'extname': (p: string) => path.extname(p),
         'relative': (from: string, to: string) => path.relative(knownModules.path.resolve(from), knownModules.path.resolve(to)),
-        'is-absolute': (p: string) => path.isAbsolute(p),
+        // camelCase to match the method name filesystem-internal.js sends over
+        // the RPC (sendRpc('path', 'isAbsolute', ...)).
+        'isAbsolute': (p: string) => path.isAbsolute(p),
       },
       'process': {
         'cwd': () => process.cwd()

--- a/vscode/test/README.md
+++ b/vscode/test/README.md
@@ -1,0 +1,79 @@
+# VS Code extension end-to-end tests
+
+These tests exercise the Pyret VS Code mode the way a user does — open an `.arr`
+tab, hit Run — and check **what actually happened on the filesystem**. The VS
+Code filesystem is the interesting part: in the webview the editor is the same
+code.pyret.org editor, but file operations are routed over a `postMessage` RPC
+to the extension host, which talks to `vscode.workspace.fs`. Path resolution
+there is subtly different from a normal disk, and that is what these tests pin
+down.
+
+## How it works
+
+We run Mocha **inside the (web) extension host** via
+`@vscode/test-web --extensionTestsPath`. That host has the full `vscode` API but
+cannot see the webview DOM — which is fine, because we don't need it. Instead:
+
+1. The test opens an `.arr` file as a text editor and invokes
+   `pyret-parley.run-file` (the editor-tab Run button). That spins up the REPL
+   webview, which auto-runs the program.
+2. The program writes a file (via Pyret's `filesystem` module →
+   `filesystem-internal` → the extension's `pyret-rpc` `fs.writeFile` →
+   `vscode.workspace.fs`).
+3. The test polls `vscode.workspace.fs` for that file and asserts on its
+   contents.
+
+The workspace filesystem is `@vscode/test-web`'s in-memory provider, seeded
+read-only from the mounted fixtures folder and writable as an overlay — so
+program writes are visible to the test within the run, with no disk side effects.
+
+No browser DOM, no network: `url-file` mode is `all-local` (see
+`fixtures/spell-checker/.vscode/settings.json`).
+
+## Running
+
+```sh
+# from vscode/
+npm test            # pretest compiles the extension + the test bundle, then runs
+```
+
+Prerequisites (one-time):
+
+- `code.pyret.org` web assets built and symlinked in as `build/`
+  (`ln -s ../code.pyret.org/build build`); the webview loads
+  `build/web/js/cpo-main.jarr.js` and `build/web/views/editor.html` from there.
+- A Chromium for `@vscode/test-web`: `npx playwright install chromium`.
+
+## What the fixtures model
+
+A minimized version of the Bootstrap "Spell Checker" starter files, which import
+a helper library that in turn imports `core.arr` via `url-file`:
+
+```
+fixtures/spell-checker/
+  ai/         plain.arr, starter-ok.arr, starter-bug.arr   <- the open "tabs"
+  libraries/  core.arr, lib-ok.arr, lib-bug.arr            <- the helper library
+```
+
+## The finding these tests encode
+
+`url-file(BASE, REL)` in `all-local` mode uses `REL` as the local path, and that
+path is resolved **against the directory of the open editor tab**
+(`dirname(document.uri)`), not against the directory of the module doing the
+import. So a library in `libraries/` that imports its sibling with
+`url-file(base, "core.arr")` actually looks for `core.arr` next to the *starter
+file's tab* (`ai/`), and fails. The working version has to climb back out with
+`url-file(base, "../libraries/core.arr")` — the "`../` nonsense".
+
+The three tests:
+
+| Test | Fixture | Expectation |
+| --- | --- | --- |
+| working-dir probe | `ai/plain.arr` | **passes** — relative output lands next to the tab (`ai/`), not at the workspace root |
+| starter chain (workaround) | `ai/starter-ok.arr` → `lib-ok.arr` (`../libraries/core.arr`) | **passes** — value flows starter → Lib → Core and is written out |
+| DESIRED (the wish) | `ai/starter-bug.arr` → `lib-bug.arr` (`core.arr`) | **fails today** — a library should resolve its sibling as `core.arr`, but resolution against the tab dir makes it not-found |
+
+The last test is intentionally red: it's the "before" of the workaround diff and
+captures the behavior we'd want if `url-file`'s local path were resolved relative
+to the importing module (likely by threading the importer's location through
+`compile-lib` instead of always using `document.uri`).

--- a/vscode/test/fixtures/spell-checker/.vscode/settings.json
+++ b/vscode/test/fixtures/spell-checker/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "pyret-parley.urlFileMode": "all-local",
+  "pyret-parley.defaultContext": "starter2024"
+}

--- a/vscode/test/fixtures/spell-checker/ai/plain.arr
+++ b/vscode/test/fixtures/spell-checker/ai/plain.arr
@@ -1,0 +1,12 @@
+use context starter2024
+
+# Sanity / working-directory probe (no imports).
+#
+# A relative output path is resolved against the directory of THIS open tab
+# (ai/), not the workspace root. Running this should produce ai/plain-out.txt.
+# write-file-string goes through the `filesystem` module -> filesystem-internal
+# -> the extension's pyret-rpc `fs.writeFile` -> vscode.workspace.fs.
+
+import filesystem as FS
+
+FS.write-file-string("plain-out.txt", "hello-from-tab")

--- a/vscode/test/fixtures/spell-checker/ai/starter-bug.arr
+++ b/vscode/test/fixtures/spell-checker/ai/starter-bug.arr
@@ -1,0 +1,16 @@
+use context starter2024
+
+# Stand-in for "Spell Checker Starter File.arr" — the natural ("BEFORE") version
+# that we WISH worked.
+#
+# Identical to starter-ok.arr except it imports lib-bug.arr, whose internal
+# import of core.arr is written the intuitive way ("core.arr", relative to the
+# library). Because url-file's local path is resolved against THIS tab's
+# directory (ai/) rather than the library's directory (libraries/), the nested
+# load of core.arr fails, the program never runs, and result-bug.txt is never
+# written.
+
+import filesystem as FS
+import url-file("https://example.org/starter-files/libraries", "../libraries/lib-bug.arr") as Lib
+
+FS.write-file-string("result-bug.txt", num-to-string(Lib.lib-answer))

--- a/vscode/test/fixtures/spell-checker/ai/starter-ok.arr
+++ b/vscode/test/fixtures/spell-checker/ai/starter-ok.arr
@@ -1,0 +1,13 @@
+use context starter2024
+
+# Stand-in for "Spell Checker Starter File.arr" — the working ("AFTER") version.
+#
+# This tab lives in ai/. It imports the library from libraries/, and the library
+# in turn imports core.arr using the "../libraries/core.arr" workaround. The
+# whole chain resolves, the program runs, and it writes the answer pulled all the
+# way through Lib -> Core out to a file we can observe from the test.
+
+import filesystem as FS
+import url-file("https://example.org/starter-files/libraries", "../libraries/lib-ok.arr") as Lib
+
+FS.write-file-string("result-ok.txt", num-to-string(Lib.lib-answer))

--- a/vscode/test/fixtures/spell-checker/libraries/core.arr
+++ b/vscode/test/fixtures/spell-checker/libraries/core.arr
@@ -1,0 +1,10 @@
+use context starter2024
+
+# Minimal stand-in for the Bootstrap "Core" library.
+# In the real starter files this is loaded by spell-checker-library.arr via
+#   import url-file(".../libraries", "<core>") as Core
+# and the path it uses is the crux of the test.
+
+provide *
+
+the-answer = 42

--- a/vscode/test/fixtures/spell-checker/libraries/lib-bug.arr
+++ b/vscode/test/fixtures/spell-checker/libraries/lib-bug.arr
@@ -1,0 +1,16 @@
+use context starter2024
+
+# Stand-in for spell-checker-library.arr — the "BEFORE" of the diff, and the
+# behavior we WISH worked.
+#
+# core.arr is a sibling of this file (both in libraries/), so the natural thing
+# to write is just "core.arr". A reader of this library would expect that to
+# resolve relative to the library itself. It does NOT today: the local path is
+# resolved against the open tab's directory (ai/), so "core.arr" is looked up at
+# ai/core.arr, which does not exist, and the load fails.
+
+provide *
+
+import url-file("https://example.org/starter-files/libraries", "core.arr") as Core
+
+lib-answer = Core.the-answer

--- a/vscode/test/fixtures/spell-checker/libraries/lib-ok.arr
+++ b/vscode/test/fixtures/spell-checker/libraries/lib-ok.arr
@@ -1,0 +1,16 @@
+use context starter2024
+
+# Stand-in for spell-checker-library.arr — the "AFTER" of the diff.
+#
+# core.arr sits RIGHT NEXT TO this file (both in libraries/). But url-file's
+# local path (the second argument) is resolved against the directory of the
+# OPEN EDITOR TAB (ai/), not the directory of this importing module. So to
+# reach the sibling core.arr we have to climb back out with "../libraries/".
+# This is the "../ nonsense" — it works, but only because it is written
+# relative to the tab, not relative to this library.
+
+provide *
+
+import url-file("https://example.org/starter-files/libraries", "../libraries/core.arr") as Core
+
+lib-answer = Core.the-answer

--- a/vscode/test/host/index.ts
+++ b/vscode/test/host/index.ts
@@ -1,0 +1,33 @@
+// Entry point for `vscode-test-web --extensionTestsPath`.
+//
+// This module runs INSIDE the (web) extension host, with the full `vscode` API
+// available. It boots Mocha's browser build, pulls in every *.test.ts in this
+// directory (bundled by webpack via require.context), and runs them. The final
+// Promise resolves on success and rejects on any failure, which is what
+// vscode-test-web uses to set the process exit code.
+
+import 'mocha/mocha';
+
+declare const mocha: any;
+
+export function run(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    mocha.setup({ ui: 'bdd', reporter: undefined, color: true, timeout: 240000 });
+
+    // Bundle and register all test files in this directory.
+    const context = (require as any).context('.', true, /\.test$/);
+    context.keys().forEach(context);
+
+    try {
+      mocha.run((failures: number) => {
+        if (failures > 0) {
+          reject(new Error(`${failures} test(s) failed.`));
+        } else {
+          resolve();
+        }
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/vscode/test/host/urlfile.test.ts
+++ b/vscode/test/host/urlfile.test.ts
@@ -118,25 +118,22 @@ describe('vscode url-file / working-directory resolution', function () {
     );
   });
 
-  // The "before" of the diff, and the behavior we wish worked: a library should
-  // be able to import its sibling core.arr as just "core.arr". Today the local
-  // path is resolved against the open tab's directory (ai/) rather than the
-  // library's own directory (libraries/), so the nested load fails and nothing
-  // is written. This test is EXPECTED TO FAIL until url-file resolution is made
-  // relative to the importing module.
-  it('DESIRED: a library imports its sibling core.arr without ../ (currently fails)', async () => {
+  // The payoff of the fix: a library imports its sibling core.arr as just
+  // "core.arr", and it resolves relative to the LIBRARY (libraries/core.arr),
+  // not the open tab (ai/). Before the context-aware finder this failed; now the
+  // value flows starter -> Lib -> Core and is written out.
+  it('a library imports its sibling core.arr without ../ (module-relative)', async () => {
     const out = fixture('ai', 'result-bug.txt');
     await tryDelete(out);
 
     await runStarter('ai/starter-bug.arr');
 
-    const contents = await awaitFileContents(out, 120000);
+    const contents = await awaitFileContents(out, 180000);
     assert.strictEqual(
       contents?.trim(),
       '42',
-      'lib-bug.arr imports url-file(base, "core.arr"); we want that to resolve relative ' +
-        'to the library (libraries/core.arr), but it is resolved against the tab dir ' +
-        '(ai/core.arr) and is not found, so the program never runs and nothing is written',
+      'lib-bug.arr imports url-file(base, "core.arr"); it should resolve relative to ' +
+        'the library (libraries/core.arr) via the context-aware finder',
     );
   });
 });

--- a/vscode/test/host/urlfile.test.ts
+++ b/vscode/test/host/urlfile.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+// These tests run in the (web) extension host. They drive the extension exactly
+// the way the editor "Run" button does — by invoking the `pyret-parley.run-file`
+// command on an open .arr tab — and then use the WORKSPACE FILESYSTEM as the
+// oracle: a Pyret program that writes a file lets us observe, without ever
+// touching the webview DOM, whether file paths (and url-file imports) resolved
+// the way we expect.
+//
+// The workspace is the mounted fixtures folder (test/fixtures/spell-checker):
+//
+//   ai/        plain.arr, starter-ok.arr, starter-bug.arr   <- the open "tabs"
+//   libraries/ core.arr, lib-ok.arr, lib-bug.arr            <- the helper library
+//
+// url-file mode is "all-local" (see .vscode/settings.json), so imports resolve
+// against the workspace filesystem with no network access.
+
+const EXTENSION_ID = 'PyretProgrammingLanguage.pyret-parley';
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+
+function root(): vscode.Uri {
+  const folders = vscode.workspace.workspaceFolders;
+  assert.ok(folders && folders.length > 0, 'expected a workspace folder (run with --folderPath)');
+  return folders![0].uri;
+}
+
+function fixture(...segments: string[]): vscode.Uri {
+  return vscode.Uri.joinPath(root(), ...segments);
+}
+
+async function exists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tryDelete(uri: vscode.Uri): Promise<void> {
+  try {
+    await vscode.workspace.fs.delete(uri);
+  } catch {
+    /* fine if it isn't there */
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Poll until `uri` exists with non-empty contents, or until `timeoutMs` elapses.
+// Returns the decoded contents, or null on timeout.
+async function awaitFileContents(uri: vscode.Uri, timeoutMs: number): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      if (bytes.byteLength > 0) {
+        return dec(bytes);
+      }
+    } catch {
+      /* not written yet */
+    }
+    await sleep(500);
+  }
+  return null;
+}
+
+// Open an .arr file as a text editor (so it is the active text editor, which the
+// run-file command keys off of) and trigger a run, exactly like the editor-tab
+// Run button. The program runs in the REPL webview the command spins up.
+async function runStarter(relPath: string): Promise<void> {
+  const uri = fixture(relPath);
+  const doc = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(doc, { preview: false });
+  await vscode.commands.executeCommand('pyret-parley.run-file');
+}
+
+describe('vscode url-file / working-directory resolution', function () {
+  this.timeout(240000);
+
+  before(async () => {
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `extension ${EXTENSION_ID} not found`);
+    await ext!.activate();
+  });
+
+  it('resolves a relative output path against the open tab\'s directory', async () => {
+    const out = fixture('ai', 'plain-out.txt');
+    await tryDelete(out);
+
+    await runStarter('ai/plain.arr');
+
+    const contents = await awaitFileContents(out, 180000);
+    assert.strictEqual(
+      contents?.trim(),
+      'hello-from-tab',
+      'expected output-file("plain-out.txt") to be written next to the open tab (ai/)',
+    );
+    // And NOT at the workspace root, confirming "working dir" == tab dir.
+    assert.strictEqual(await exists(fixture('plain-out.txt')), false,
+      'output must not land at the workspace root');
+  });
+
+  it('runs the full starter -> library -> core chain (../libraries workaround)', async () => {
+    const out = fixture('ai', 'result-ok.txt');
+    await tryDelete(out);
+
+    await runStarter('ai/starter-ok.arr');
+
+    const contents = await awaitFileContents(out, 180000);
+    assert.strictEqual(
+      contents?.trim(),
+      '42',
+      'expected the value to flow starter -> Lib -> Core and be written to result-ok.txt',
+    );
+  });
+
+  // The "before" of the diff, and the behavior we wish worked: a library should
+  // be able to import its sibling core.arr as just "core.arr". Today the local
+  // path is resolved against the open tab's directory (ai/) rather than the
+  // library's own directory (libraries/), so the nested load fails and nothing
+  // is written. This test is EXPECTED TO FAIL until url-file resolution is made
+  // relative to the importing module.
+  it('DESIRED: a library imports its sibling core.arr without ../ (currently fails)', async () => {
+    const out = fixture('ai', 'result-bug.txt');
+    await tryDelete(out);
+
+    await runStarter('ai/starter-bug.arr');
+
+    const contents = await awaitFileContents(out, 120000);
+    assert.strictEqual(
+      contents?.trim(),
+      '42',
+      'lib-bug.arr imports url-file(base, "core.arr"); we want that to resolve relative ' +
+        'to the library (libraries/core.arr), but it is resolved against the tab dir ' +
+        '(ai/core.arr) and is not found, so the program never runs and nothing is written',
+    );
+  });
+});

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -8,6 +8,6 @@
 		"strict": true,
 		"rootDir": "src",
 	},
-	"exclude": ["node_modules", ".vscode-test", "media", "code.pyret.org", "build"],
+	"exclude": ["node_modules", ".vscode-test", "media", "code.pyret.org", "build", "test"],
 	
 }

--- a/vscode/tsconfig.test.json
+++ b/vscode/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021", "WebWorker"],
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["mocha", "node"],
+    "rootDir": "test"
+  },
+  "include": ["test/**/*.ts"]
+}

--- a/vscode/webpack.test.config.js
+++ b/vscode/webpack.test.config.js
@@ -1,0 +1,60 @@
+//@ts-check
+'use strict';
+
+// Bundles the extension-host test suite into a single web-worker module that
+// `vscode-test-web --extensionTestsPath` can load. Mirrors webpack.config.js
+// (the extension bundle) but targets test/host/index.ts and uses
+// tsconfig.test.json.
+
+const path = require('path');
+const webpack = require('webpack');
+
+/** @type {import('webpack').Configuration} */
+const testConfig = {
+  mode: 'none',
+  target: 'webworker',
+  entry: {
+    index: './test/host/index.ts',
+  },
+  output: {
+    filename: '[name].js',
+    path: path.join(__dirname, './dist/web/test'),
+    libraryTarget: 'commonjs',
+    devtoolModuleFilenameTemplate: '../../[resource-path]',
+  },
+  resolve: {
+    mainFields: ['browser', 'module', 'main'],
+    extensions: ['.ts', '.js'],
+    fallback: {
+      assert: require.resolve('assert'),
+      path: require.resolve('path-browserify'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: { configFile: 'tsconfig.test.json' },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
+  ],
+  externals: {
+    vscode: 'commonjs vscode',
+  },
+  performance: { hints: false },
+  devtool: 'nosources-source-map',
+};
+
+module.exports = [testConfig];


### PR DESCRIPTION
This is something I've wanted for a while – automated UI tests on the extension. There's a bunch of infrastructure to fire that up, plus an actual bug fix.

The actual bug is that the context of the working directory was *not* being tracked correctly across nested imports in the extension, which made for some strange `local-if-present` flows for `url-file` when I was debugging Bootstrap starter files. They all work on the web just fine (the urls are canonical), but not through local files.

The strategy here is very MVP-ish; it seemed like a lot of plumbing to get the same selenium-drill-down into the DOM (because it's going through the VScode window and the tab and the extension wrapper ....) so this just uses the filesystem to write test output with write-file.

A second try at this would extract DOM stuff from the REPL in the web view; this is the basics to get *something* automated running over the extension to verify basics (and verify a real bug fix)



Claude below:

Adds headless end-to-end tests for VSCode url-file import resolution, plus the supporting changes:
- Context-aware CPO module finder for (url-)file imports
- Single source of truth for extension-host path resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)