### PR TITLE
Resolve editor image paths in all host contexts (web, VScode, embed)

### DIFF
--- a/code.pyret.org/src/web/blocks.html
+++ b/code.pyret.org/src/web/blocks.html
@@ -22,7 +22,7 @@
   <link rel="stylesheet" href="/css/themes/panda-syntax.css" />
   <link rel="stylesheet" href="/css/themes/high-contrast-light.css" />
   <link rel="stylesheet" href="/css/themes/high-contrast-dark.css" />
-  <link rel="icon" type="image/png" href="/img/pyret-icon.png" />
+  <link rel="icon" type="image/png" href="{{ &BASE_URL }}/img/pyret-icon.png" />
   <style id="highlight-styles"></style>
   <script src="{{ &BASE_URL }}/js/vega.min.js"></script>
   <script src="{{ &BASE_URL }}/js/vega-tooltip.min.js"></script>
@@ -99,7 +99,7 @@
                     tabindex="-1"
                     class="blueButton focusable">
               <span>▾</span>
-              <img class="logo" src="/img/pyret-logo.png" />
+              <img class="logo" src="{{ &BASE_URL }}/img/pyret-logo.png" />
             </button>
           </div>
           <ul id="bonniemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"

--- a/code.pyret.org/src/web/css/editor.css
+++ b/code.pyret.org/src/web/css/editor.css
@@ -2629,8 +2629,8 @@ table.pyret-row {
    z-index: 1;
    vertical-align: baseline;
    display: inline-block;
-   -webkit-mask-image: url(/img/paint.svg);
-   mask-image: url(/img/paint.svg);
+   -webkit-mask-image: url(../img/paint.svg);
+   mask-image: url(../img/paint.svg);
    -webkit-mask-size: contain;
    mask-size: 100% 100%;
    mask-type: luminance;
@@ -2640,7 +2640,7 @@ table.pyret-row {
    width: 2.5em;
    height: 1.5em;
    position: relative;
-   background-image: url(/img/checkers.svg);
+   background-image: url(../img/checkers.svg);
    background-size: 2.5em 1.5em;
    display: inline-block;
 }

--- a/code.pyret.org/src/web/css/shared.css
+++ b/code.pyret.org/src/web/css/shared.css
@@ -356,7 +356,7 @@ nav > div > ul ul a, nav > div > ul ul button {
 
 #logo{
   height:100%;
-  background: url("/img/pyret-logo.png") 15px 5px no-repeat;
+  background: url("../img/pyret-logo.png") 15px 5px no-repeat;
   background-size: 30px 30px;
   display:block;
   float:left;

--- a/code.pyret.org/src/web/js/beforeBlocks.js
+++ b/code.pyret.org/src/web/js/beforeBlocks.js
@@ -248,7 +248,7 @@ $(function() {
       gutterTooltip.className = "gutter-question-tooltip";
       gutterTooltip.innerText = "The use context line tells Pyret to load tools for a specific class context. It can be changed through the main Pyret menu. Most of the time you won't need to change this at all.";
       const gutterQuestion = document.createElement("img");
-      gutterQuestion.src = "/img/question.png";
+      gutterQuestion.src = window.APP_BASE_URL + "/img/question.png";
       gutterQuestion.className = "gutter-question";
       gutterQuestionWrapper.appendChild(gutterQuestion);
       gutterQuestionWrapper.appendChild(gutterTooltip);

--- a/code.pyret.org/src/web/js/output-ui.js
+++ b/code.pyret.org/src/web/js/output-ui.js
@@ -1262,7 +1262,7 @@
         var container = $("<span>").addClass("replToggle replOutput replCycle");
         var renderings = [];
 
-        var brush = $("<img>").addClass("paintBrush").attr("src", "/img/brush.svg");
+        var brush = $("<img>").addClass("paintBrush").attr("src", window.APP_BASE_URL + "/img/brush.svg");
         var raw_r = runtime.unwrap(runtime.getField(val, "red"));
         var raw_g = runtime.unwrap(runtime.getField(val, "green"));
         var raw_b = runtime.unwrap(runtime.getField(val, "blue"));
@@ -1348,7 +1348,7 @@
           var scaled = image.makeScaleImage(scaleFactor, scaleFactor, img);
           imageDom = scaled.toDomNode();
           container.append(imageDom);
-          container.append($("<img>").attr("src", "/img/magnifier.gif").addClass("info-icon"));
+          container.append($("<img>").attr("src", window.APP_BASE_URL + "/img/magnifier.gif").addClass("info-icon"));
           $(imageDom).trigger({type: 'afterAttach'});
           $('*', imageDom).trigger({type : 'afterAttach'});
           var originalImageDom = img.toDomNode();
@@ -1531,7 +1531,7 @@
         var valueContainer = $("<span>").addClass("replRef")
         container.append(valueContainer.append(top.done[0]));
         var warning = $("<img>")
-          .attr("src", "/img/warning.gif")
+          .attr("src", window.APP_BASE_URL + "/img/warning.gif")
           .attr("title", "May be stale! Click to refresh")
           .addClass("info-icon");
         container.append(warning);

--- a/code.pyret.org/src/web/js/repl-ui.js
+++ b/code.pyret.org/src/web/js/repl-ui.js
@@ -795,7 +795,7 @@
           // Note: renderedLocs is one element shorter than rendered
           var renderedLocs = locs.map(repl.runtime.makeSrcloc);
           var spyBlock = $("<div>").addClass("spy-block");
-          spyBlock.append($("<img>").addClass("spyglass").attr("src", "/img/spyglass.gif"));
+          spyBlock.append($("<img>").addClass("spyglass").attr("src", window.APP_BASE_URL + "/img/spyglass.gif"));
           if (message !== "") {
             spyBlock.append($("<div>").addClass("spy-title").append(message));
           }


### PR DESCRIPTION
I am pretty sure (as in, I think I did a visual check of them all) that this resolves all the broken image for magnifying glass, paintbrush, etc across all the different contexts that use them.