### PR TITLE
browser-test: embed-static env -- test the built editor.embed.html ar…

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,15 +1,17 @@
 name: browser-test (embed + vscode webviews)
 
-# Runs code.pyret.org's editor assertions against four environments via the
+# Runs code.pyret.org's editor assertions against five environments via the
 # single Playwright runner in browser-test/:
-#   cpo         -- the reference (/editor)
-#   embed       -- the embed API's embedded instance
-#   vscode      -- the pyret-parley.cpo webview (headless VS Code for the Web)
-#   vscode-ovsx -- the same webview, but with its assets served the way Open VSX
-#                  / the GitLab Web IDE serve them (text/plain + nosniff + size
-#                  cap) -- the reproduction of pyret-parley issue #21
+#   cpo          -- the reference (/editor)
+#   embed        -- the embed API's embedded instance
+#   embed-static -- the same embed API, against the BUILT editor.embed.html
+#                   artifact on a plain static server (no CPO server)
+#   vscode       -- the pyret-parley.cpo webview (headless VS Code for the Web)
+#   vscode-ovsx  -- the same webview, but with its assets served the way Open VSX
+#                   / the GitLab Web IDE serve them (text/plain + nosniff + size
+#                   cap) -- the reproduction of pyret-parley issue #21
 #
-# Shape: build code.pyret.org + the extension ONCE, then fan out the four
+# Shape: build code.pyret.org + the extension ONCE, then fan out the five
 # environments as a parallel matrix (each on its own runner, so chart rendering
 # doesn't contend for CPU).
 
@@ -69,14 +71,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [cpo, embed, vscode, vscode-ovsx]
+        env: [cpo, embed, embed-static, vscode, vscode-ovsx]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      # cpo + embed load /editor from the CPO server; vscode does not.
+      # cpo + embed + embed-static need the CPO build; only cpo + embed need
+      # the CPO *server* (embed-static serves the built artifact itself).
       - name: Restore cpo build
         if: ${{ !startsWith(matrix.env, 'vscode') }}
         uses: actions/download-artifact@v4
@@ -101,12 +104,12 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Install CPO server runtime deps
-        if: ${{ !startsWith(matrix.env, 'vscode') }}
+        if: ${{ matrix.env == 'cpo' || matrix.env == 'embed' }}
         working-directory: ./code.pyret.org
         run: npm ci --ignore-scripts
 
       - name: Start CPO server
-        if: ${{ !startsWith(matrix.env, 'vscode') }}
+        if: ${{ matrix.env == 'cpo' || matrix.env == 'embed' }}
         working-directory: ./code.pyret.org
         env:
           BASE_URL: http://localhost:4999

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -7,13 +7,14 @@ suite against the three places the Pyret editor renders. It's a **`node:test`**
 suite (no extra test-framework dependency) driven through **one runner**:
 
 ```
-node run.js --env=cpo|embed|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|check-blocks,errors,...]
+node run.js --env=cpo|embed|embed-static|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|check-blocks,errors,...]
 ```
 
 | `--env` | What it drives |
 |---|---|
 | `cpo` | the reference — `code.pyret.org`'s `/editor` page (reproduces upstream's outcomes) |
 | `embed` | the embed API's embedded instance (`<iframe>` in `/embed/embed1.html`) |
+| `embed-static` | the same embed API, but against the **built** `editor.embed.html` artifact on a plain static server — no CPO server |
 | `vscode` | the `pyret-parley.cpo` webview, in headless VS Code for the Web |
 | `vscode-ovsx` | the same webview, but with its assets served the way **Open VSX** serves them to the **GitLab Web IDE** — reproduces issue #21 |
 
@@ -50,6 +51,22 @@ Env vars: `OVSX_FAITHFUL=1` (correct serving), `OVSX_ASSET_ROOT=<dir>` (override
 the served build; defaults to `vscode/dist/web/build/web`), `OVSX_CAP_MB=<n>`
 (hostile size cap, default 15). A standalone one-shot check that skips the full
 spec suite lives in `smoke-ovsx.js`.
+
+### `embed-static` — the built `editor.embed.html` artifact
+
+`--env=embed` drives `/editor#controlled=true` through a running CPO server, so
+it never loads `build/web/editor.embed.html`: the file an embedding host
+actually deploys, rendered once at build time from `src/web/editor.html` +
+`.env.embed` (`BASE_URL="."`, relative asset paths, `POSTMESSAGE_ORIGIN="*"`).
+`embed-static` serves `build/web` from a plain correct-MIME static server
+(`shared/static-server.js`), aliases `/editor` to `/editor.embed.html`, and
+loads the same `test-util/embed/embed1.html` host page — so the embed flow is
+identical, but every byte comes from the built artifact. It catches breakage
+that lives only in that artifact: template variables mis-rendered at build
+time, and asset references that resolve at a server root but 404 under
+relative/static hosting. Needs only the CPO build (no server, no
+`code.pyret.org/node_modules`). `EMBED_STATIC_ROOT=<dir>` overrides the served
+build dir.
 
 It is **strictly additive**: nothing under `code.pyret.org/` or `vscode/` is
 modified; the upstream test files are read as-is.
@@ -111,9 +128,11 @@ tests/suite.test.js     the node:test entry: boots one env, one test() per spec
 envs/
   cpo.js                launch chromium, goto /editor
   embed.js              goto /embed/embed1.html, sendReset, find the iframe
+  embed-static.js       the same embed flow against the built editor.embed.html (no CPO server)
   vscode.js             boot @vscode/test-web, open the custom editor, find the webview
   vscode-ovsx.js        serve the webview via a simulated Open VSX (issue #21 repro)
 shared/
+  static-server.js      plain correct-MIME static server (multi-root + aliases)
   ovsx-server.js        static server that mimics Open VSX serving (text/plain+nosniff, size cap)
   load-cpo-specs.js     extract exact specs from code.pyret.org/test/*.js (no copying)
   page-assertions.js    in-page DOM port of util.js predicates (window.PA)

--- a/browser-test/envs/embed-static.js
+++ b/browser-test/envs/embed-static.js
@@ -1,0 +1,93 @@
+/*
+ * Environment adapter: the embed API against the BUILT static embed artifact,
+ * build/web/editor.embed.html -- no CPO server.
+ *
+ * --env=embed drives /editor#controlled=true through a running CPO server, so
+ * it never loads editor.embed.html: the file an embedding host actually
+ * deploys, rendered at build time from .env.embed (BASE_URL=".", relative
+ * asset paths, POSTMESSAGE_ORIGIN="*"; see code.pyret.org/make-template.js).
+ * This env serves code.pyret.org/build/web from a plain correct-MIME static
+ * server (shared/static-server.js) and loads the same test-util embed host
+ * page the embed env uses, with /editor aliased to /editor.embed.html so
+ * embed1.html works unmodified.
+ *
+ * What this catches that --env=embed can't: breakage that lives only in the
+ * built artifact -- template variables mis-rendered at build time, and asset
+ * references that resolve at a server root but 404 under relative/static
+ * hosting (e.g. a root-absolute /img/... sneaking back into editor css).
+ *
+ * Env vars:
+ *   EMBED_STATIC_ROOT  override the served build dir
+ *                      (default code.pyret.org/build/web)
+ */
+const path = require("path");
+const fs = require("fs");
+const { launchChromium } = require("../shared/browser");
+const { findEditorFrame } = require("../shared/find-frame");
+const { startStaticServer } = require("../shared/static-server");
+
+const CPO_DIR = path.resolve(__dirname, "..", "..", "code.pyret.org");
+const BUILD_ROOT = process.env.EMBED_STATIC_ROOT || path.join(CPO_DIR, "build", "web");
+const HOST_PAGES_ROOT = path.join(CPO_DIR, "test-util");
+
+async function setup() {
+  const artifact = path.join(BUILD_ROOT, "editor.embed.html");
+  if (!fs.existsSync(artifact)) {
+    throw new Error(
+      "embed-static: " + artifact + " not found -- is code.pyret.org built? " +
+        "(`npm run build` / `make web` produce it from src/web/editor.html + .env.embed)"
+    );
+  }
+
+  const server = await startStaticServer({
+    roots: [BUILD_ROOT, HOST_PAGES_ROOT],
+    // embed1.js points its iframe at `${BASE_URL}/editor#controlled=true`;
+    // here "the editor" is the static artifact.
+    aliases: { "/editor": "/editor.embed.html" },
+  });
+
+  const browser = await launchChromium();
+  const page = await browser.newPage();
+  page.setDefaultTimeout(60000);
+
+  // Same flow as envs/embed.js, but the host page and the iframe both come
+  // from the static server (same origin, so embed-util's same-origin
+  // postMessage default works).
+  await page.goto(server.origin + "/embed/embed1.html?" + server.origin, {
+    waitUntil: "domcontentloaded",
+    timeout: 120000,
+  });
+
+  // Wait for the embedded instance to announce itself (pyret-init).
+  await page.waitForFunction(
+    () => window.messages &&
+      window.messages.filter((m) => m.data.protocol === "pyret" && m.data.data.type === "pyret-init").length === 1,
+    undefined,
+    { timeout: 60000, polling: 200 }
+  );
+
+  // Initialize the controlled editor with a runnable starter context.
+  await page.evaluate(() =>
+    window.embedAPI.sendReset({
+      definitionsAtLastRun: false,
+      editorContents: "use context starter2024\n\n",
+      replContents: "",
+      interactionsSinceLastRun: [],
+    })
+  );
+
+  const frame = await findEditorFrame(page);
+  return {
+    page,
+    frame,
+    cleanup: async () => {
+      await browser.close();
+      await server.close();
+    },
+  };
+}
+
+module.exports = {
+  setup,
+  label: "embed API against the static editor.embed.html artifact (no CPO server)",
+};

--- a/browser-test/run.js
+++ b/browser-test/run.js
@@ -30,8 +30,8 @@ function arg(name) {
 }
 
 const env = arg("env");
-if (!env || !["cpo", "embed", "vscode", "vscode-ovsx"].includes(env)) {
-  console.error("usage: node run.js --env=cpo|embed|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|a,b] [--reporter=spec|tap|dot]");
+if (!env || !["cpo", "embed", "embed-static", "vscode", "vscode-ovsx"].includes(env)) {
+  console.error("usage: node run.js --env=cpo|embed|embed-static|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|a,b] [--reporter=spec|tap|dot]");
   process.exit(2);
 }
 const grep = arg("grep");

--- a/browser-test/shared/static-server.js
+++ b/browser-test/shared/static-server.js
@@ -1,0 +1,84 @@
+/*
+ * static-server.js -- a minimal correct-MIME static file server, for envs that
+ * exercise BUILT artifacts directly instead of going through the CPO server.
+ *
+ * Serves one or more root directories (first root containing the file wins)
+ * plus explicit path aliases (e.g. "/editor" -> "/editor.embed.html"), on an
+ * ephemeral localhost port.
+ */
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const TYPES = {
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".wasm": "application/wasm",
+  ".ico": "image/x-icon",
+  ".xml": "application/xml",
+  ".arr": "text/plain",
+};
+
+function contentType(p) {
+  return TYPES[path.extname(p).toLowerCase()] || "application/octet-stream";
+}
+
+/*
+ * opts:
+ *   roots    - array of directories to serve, searched in order
+ *   aliases  - {urlPath: urlPath} rewrites applied before the root lookup
+ * returns { origin, close }
+ */
+async function startStaticServer(opts) {
+  const roots = opts.roots.map((r) => path.resolve(r));
+  const aliases = opts.aliases || {};
+
+  const server = http.createServer((req, res) => {
+    let pathname;
+    try {
+      pathname = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+    } catch (e) {
+      res.writeHead(400).end("bad request");
+      return;
+    }
+    if (pathname in aliases) pathname = aliases[pathname];
+    const rel = pathname.replace(/^\/+/, "");
+
+    for (const root of roots) {
+      const filePath = path.resolve(root, rel);
+      if (filePath !== root && !filePath.startsWith(root + path.sep)) continue;
+      let st;
+      try {
+        st = fs.statSync(filePath);
+      } catch (e) {
+        continue;
+      }
+      if (!st.isFile()) continue;
+      res.writeHead(200, { "Content-Type": contentType(filePath) });
+      fs.createReadStream(filePath).pipe(res);
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "text/plain" }).end("not found: " + pathname);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    origin: "http://127.0.0.1:" + server.address().port,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+module.exports = { startStaticServer };

--- a/browser-test/tests/suite.test.js
+++ b/browser-test/tests/suite.test.js
@@ -25,8 +25,8 @@ const SUITES = {
   "tables": "tables.js",
 };
 
-if (!ENV || !["cpo", "embed", "vscode", "vscode-ovsx"].includes(ENV)) {
-  throw new Error("PYRET_ENV must be one of cpo | embed | vscode | vscode-ovsx (got " + JSON.stringify(ENV) + ")");
+if (!ENV || !["cpo", "embed", "embed-static", "vscode", "vscode-ovsx"].includes(ENV)) {
+  throw new Error("PYRET_ENV must be one of cpo | embed | embed-static | vscode | vscode-ovsx (got " + JSON.stringify(ENV) + ")");
 }
 const chosen =
   !process.env.PYRET_SUITES || process.env.PYRET_SUITES === "all"


### PR DESCRIPTION
…tifact

Joe says:

Completing the set of environments under headless test. We now have:

- Plain HTML/self-host embedded (e.g. the pyret-embed npm package)

In addition to:

- Server-direct-served (e.g. code.pyret.org/editor)
- Server-iframe-embedded (e.g. the VMT use case)
- VScode-in-browser
- VScode-in-browser with a GitLab-simulating server that breaks various things

--env=embed drives /editor#controlled=true through a running CPO server, so the file an embedding host actually deploys -- editor.embed.html, rendered once at build time from src/web/editor.html + .env.embed (BASE_URL=".", relative asset paths, POSTMESSAGE_ORIGIN="*") -- was never loaded by any test.

embed-static serves code.pyret.org/build/web from a plain correct-MIME static server (new shared/static-server.js: multi-root + path aliases), aliases /editor to /editor.embed.html, and loads the same test-util/embed/embed1.html host page the embed env uses -- so the embed flow is byte-for-byte the existing one, but every asset comes from the built artifact. Catches breakage only visible there: template variables mis-rendered at build time, and asset references that resolve at a server root but 404 under relative/static hosting (the bug class of 21dbeb9b5).

Strictly additive: nothing under code.pyret.org/ changes. In CI it's a fifth matrix entry needing only the cpo-build artifact -- no CPO server, no code.pyret.org node_modules (those steps now run for cpo|embed only).

Verified locally: all five suites (check-blocks, errors, type-check, charts, tables) pass against the static artifact -- 236 tests, 0 failures.