### PR TITLE
Fix line plot labels

### DIFF
--- a/lang/src/arr/trove/charts.arr
+++ b/lang/src/arr/trove/charts.arr
@@ -59,9 +59,6 @@ end
 # HELPERS
 ################################################################################
 
-fun check-num(v :: Number) -> Nothing: nothing end
-fun check-string(v :: String) -> Nothing: nothing end
-fun check-image(v :: IM.Image) -> Nothing: nothing end
 
 fst = raw-array-get(_, 0)
 snd = raw-array-get(_, 1)
@@ -1887,8 +1884,6 @@ fun line-plot-from-list(xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
   when xs.length() <> ys.length():
     raise(ERR.message-exception('line-plot: xs and ys should have the same length'))
   end
-  xs.each(check-num)
-  ys.each(check-num)
   default-line-plot-series.{
     ps: map4(get-scatter-point, xs, ys, xs.map({(_): ''}), xs.map({(_): none}))
   } ^ line-plot-series
@@ -1909,8 +1904,6 @@ fun scatter-plot-from-list(xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
   when xs.length() <> ys.length():
     raise(ERR.message-exception('scatter-plot: xs and ys should have the same length'))
   end
-  xs.each(check-num)
-  ys.each(check-num)
   default-scatter-plot-series.{
     ps: map4(get-scatter-point, xs, ys, xs.map({(_): ''}), xs.map({(_): none}))
   } ^ scatter-plot-series
@@ -1924,11 +1917,7 @@ fun image-scatter-plot-from-list(images :: CL.LoI, xs :: CL.LoN, ys :: CL.LoN) -
   scatter-plot-from-list(xs, ys).image-labels(images)
 end
 
-fun image-bar-chart-from-list(
-  images :: CL.LoI, 
-  labels :: CL.LoS, 
-  values :: CL.LoN) -> DataSeries block:
-
+fun image-bar-chart-from-list(images :: CL.LoI, labels :: CL.LoS, values :: CL.LoN) -> DataSeries block:
   doc: ```
        Consume images, labels, a list of string, and values, a list of numbers
        and construct a bar chart using images as bars
@@ -1988,9 +1977,6 @@ fun exploding-pie-chart-from-list(
       raise(ERR.message-exception('exploding-pie-chart: offset must be between 0 and 1'))
     end
   end
-  values.each(check-num)
-  offsets.each(check-num)
-  labels.each(check-string)
   default-pie-chart-series.{
     tab: to-table3-n(labels, values, offsets)
   } ^ pie-chart-series
@@ -2014,8 +2000,6 @@ fun pie-chart-from-list(labels :: CL.LoS, values :: CL.LoN) -> DataSeries block:
   when label-length == 0:
     raise(ERR.message-exception('pie-chart: need at least one data'))
   end
-  values.each(check-num)
-  labels.each(check-string)
   default-pie-chart-series.{
     tab: to-table3-n(labels, values, labels.map({(_): 0}))
   } ^ pie-chart-series
@@ -2039,9 +2023,6 @@ fun image-pie-chart-from-list(images :: CL.LoI, labels :: CL.LoS, values :: CL.L
   when label-length == 0:
     raise(ERR.message-exception('pie-chart: need at least one data'))
   end
-  images.each(check-image)
-  values.each(check-num)
-  labels.each(check-string)
   default-pie-chart-series.{
     tab: to-table4(labels, values, labels.map({(_): 0}), images)
   } ^ pie-chart-series
@@ -2086,7 +2067,6 @@ fun num-dot-chart-from-list(x-values :: CL.LoN) -> DataSeries block:
        Consume a (possibly repeating, unordered) list of numbers
        and construct a dot chart
        ```
-  x-values.each(check-num)
   when x-values.length() == 0:
     raise(ERR.message-exception("num-dot-chart: can't have empty data"))
   end
@@ -2264,9 +2244,6 @@ fun labeled-interval-chart-from-list(
   when xs-length == 0:
     raise(ERR.message-exception('interval-chart: need at least one datum'))
   end
-  xs.each(check-num)
-  ys.each(check-num)
-  deltas.each(check-num)
 
   default-interval-chart-series.{
     ps: map5(get-interval-point, xs, ys, deltas, labels, xs.map({(_): none}))
@@ -2299,14 +2276,12 @@ fun labeled-box-plot-from-list(
   when label-length == 0:
     raise(ERR.message-exception('labeled-box-plot: expect at least one box'))
   end
-  values.each(_.each(check-num))
   values.each(
     lam(lst):
       when lst.length() <= 1:
         raise(ERR.message-exception('labeled-box-plot: the list length should be at least 2'))
       end
     end)
-  labels.each(check-string)
 
   max-height = for fold(cur from values.first.first, lst from values):
     num-max(lst.rest.foldl(num-max, lst.first), cur)
@@ -2345,7 +2320,6 @@ fun histogram-from-list(values :: CL.LoN) -> DataSeries block:
   doc: ```
        Consume a list of numbers and construct a histogram
        ```
-  values.each(check-num)
   default-histogram-series.{
     vals: map3(get-histogram-value, values, values.map({(_): ''}), values.map({(_): none})),
   } ^ histogram-series
@@ -2360,8 +2334,6 @@ fun labeled-histogram-from-list(labels :: CL.LoS, values :: CL.LoN) -> DataSerie
   when label-length <> value-length:
     raise(ERR.message-exception('labeled-histogram: labels and values should have the same length'))
   end
-  values.each(check-num)
-  labels.each(check-string)
   default-histogram-series.{
     vals: map3(get-histogram-value, values, labels, values.map({(_): none})),
   } ^ histogram-series

--- a/lang/src/arr/trove/charts.arr
+++ b/lang/src/arr/trove/charts.arr
@@ -1150,7 +1150,7 @@ type LinePlotSeries = {
   trendlineDegree :: NumInteger, 
   dashedLine :: Boolean, 
   dashlineStyle :: RawArray<NumInteger>, 
-  point-size :: Number,
+  point-size :: Option<Number>,
   useImageSizes :: Boolean,
   pointshapeType :: String, 
   pointshapeSides :: NumInteger, 
@@ -1171,7 +1171,7 @@ default-line-plot-series = {
   trendlineDegree: 3,  
   dashedLine: false,
   dashlineStyle: [raw-array: 2, 2],
-  point-size: 0,
+  point-size: none,
   useImageSizes: true,
   pointshapeType: 'circle', 
   pointshapeSides: 5,
@@ -1570,13 +1570,21 @@ data DataSeries:
     dashed-line: dashed-line-method, 
     dashline-style: dashed-line-style-method,
     point-shape: pointshape-method, 
-    labels: labels-method,
+    method labels(self, labels :: CL.LoS) block:
+      when self.obj!ps.length() <> labels.length():
+        raise(ERR.message-exception('plot: xs and labels should have the same length'))
+      end
+      self.constr()(self.obj.{
+          ps: map2({(val, label): val.{label: label}}, self.obj!ps, labels),
+          point-size: self.obj.point-size.or-else(some(default-scatter-plot-series.point-size))
+        })
+    end,
     image-labels: image-labels-method,
     method point-size(self, point-size :: Number) block:
       when point-size < 0: 
         raise(ERR.message-exception("point-size: Point Size must be non-negative"))
       end
-      self.constr()(self.obj.{point-size: point-size})
+      self.constr()(self.obj.{point-size: some(point-size)})
     end,
     method use-image-sizes(self, use-image-sizes :: Boolean):
       self.constr()(self.obj.{useImageSizes: use-image-sizes})
@@ -1886,32 +1894,12 @@ fun line-plot-from-list(xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
   } ^ line-plot-series
 end
 
-fun labeled-line-plot-from-list(labels :: CL.LoS, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
-  when xs.length() <> ys.length():
-    raise(ERR.message-exception('labeled-line-plot: xs and ys should have the same length'))
-  end
-  when xs.length() <> labels.length():
-    raise(ERR.message-exception('labeled-line-plot: xs and labels should have the same length'))
-  end
-  xs.each(check-num)
-  ys.each(check-num)
-  default-line-plot-series.{
-    ps: map4(get-scatter-point, xs, ys, labels, xs.map({(_): none}))
-  } ^ line-plot-series
+fun labeled-line-plot-from-list(labels :: CL.LoS, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries:
+  line-plot-from-list(xs, ys).labels(labels)
 end
 
-fun image-line-plot-from-list(images :: CL.LoI, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
-  when xs.length() <> ys.length():
-    raise(ERR.message-exception('image-line-plot: xs and ys should have the same length'))
-  end
-  when xs.length() <> images.length():
-    raise(ERR.message-exception('image-line-plot: xs and images should have the same length'))
-  end
-  xs.each(check-num)
-  ys.each(check-num)
-  default-line-plot-series.{
-    ps: map4(get-scatter-point, xs, ys, xs.map({(_): ''}), images.map(some))
-  } ^ line-plot-series
+fun image-line-plot-from-list(images :: CL.LoI, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries:
+  line-plot-from-list(xs, ys).image-labels(images)
 end
 
 fun get-scatter-point(x :: Number, y :: Number, label :: String, optimg :: Option<IM.Image>) -> ScatterPoint:
@@ -1928,40 +1916,12 @@ fun scatter-plot-from-list(xs :: CL.LoN, ys :: CL.LoN) -> DataSeries block:
   } ^ scatter-plot-series
 end
 
-fun labeled-scatter-plot-from-list(
-  labels :: CL.LoS,
-  xs :: CL.LoN,
-  ys :: CL.LoN) -> DataSeries block:
-  when xs.length() <> ys.length():
-    raise(ERR.message-exception('labeled-scatter-plot: xs and ys should have the same length'))
-  end
-  when xs.length() <> labels.length():
-    raise(ERR.message-exception('labeled-scatter-plot: xs and labels should have the same length'))
-  end
-  xs.each(check-num)
-  ys.each(check-num)
-  labels.each(check-string)
-  default-scatter-plot-series.{
-    ps: map4(get-scatter-point, xs, ys, labels, xs.map({(_): none}))
-  } ^ scatter-plot-series
+fun labeled-scatter-plot-from-list(labels :: CL.LoS, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries:
+  scatter-plot-from-list(xs, ys).labels(labels)
 end
 
-fun image-scatter-plot-from-list(
-  images :: CL.LoI,
-  xs :: CL.LoN,
-  ys :: CL.LoN) -> DataSeries block:
-  when xs.length() <> ys.length():
-    raise(ERR.message-exception('labeled-scatter-plot: xs and ys should have the same length'))
-  end
-  when xs.length() <> images.length():
-    raise(ERR.message-exception('labeled-scatter-plot: xs and images should have the same length'))
-  end
-  xs.each(check-num)
-  ys.each(check-num)
-  images.each(check-image)
-  default-scatter-plot-series.{
-    ps: map4(get-scatter-point, xs, ys, xs.map({(_): ''}), images.map(some))
-  } ^ scatter-plot-series
+fun image-scatter-plot-from-list(images :: CL.LoI, xs :: CL.LoN, ys :: CL.LoN) -> DataSeries:
+  scatter-plot-from-list(xs, ys).image-labels(images)
 end
 
 fun image-bar-chart-from-list(

--- a/lang/src/arr/trove/charts.arr
+++ b/lang/src/arr/trove/charts.arr
@@ -1573,7 +1573,7 @@ data DataSeries:
       end
       self.constr()(self.obj.{
           ps: map2({(val, label): val.{label: label}}, self.obj!ps, labels),
-          point-size: self.obj.point-size.or-else(some(default-scatter-plot-series.point-size))
+          point-size: some(self.obj.point-size.or-else(default-scatter-plot-series.point-size))
         })
     end,
     image-labels: image-labels-method,

--- a/lang/src/js/trove/charts-lib.js
+++ b/lang/src/js/trove/charts-lib.js
@@ -2663,17 +2663,10 @@
       const defaultColor = config.defaultColor || default_colors[0];
       const lineWidth = toFixnum(get(rawData, 'lineWidth'));
       const color = getColorOrDefault(get(rawData, 'color'), defaultColor);
-      const asScatterPlot = scatterPlot(globalOptions, rawData, config);
+      debugger
+      const pointSize = getNumOrDefault(get(rawData, 'point-size'), 0);
+      const asScatterPlot = scatterPlot(globalOptions, rawData.extendWith({'point-size': pointSize}), config);
       const marks = asScatterPlot.marks;
-      const markShapeMarks = marks.find((m) => m.name === `${prefix}ShapeMarks`);
-      if (markShapeMarks) {
-        markShapeMarks.encode.enter.size.value = Math.max(40, markShapeMarks.encode.enter.size.value);
-        markShapeMarks.encode.hover = markShapeMarks.encode.update;
-        markShapeMarks.encode.update = {
-          fill: { signal: `${prefix}crosshair === datum ? '${color}' : 'transparent'` },
-          stroke: { signal: `${prefix}crosshair === datum ? '${color}' : 'transparent'` },
-        }
-      }
       marks.push({
         type: 'line',
         from: { data: `${prefix}rawTable` },

--- a/lang/src/js/trove/charts-lib.js
+++ b/lang/src/js/trove/charts-lib.js
@@ -2663,7 +2663,6 @@
       const defaultColor = config.defaultColor || default_colors[0];
       const lineWidth = toFixnum(get(rawData, 'lineWidth'));
       const color = getColorOrDefault(get(rawData, 'color'), defaultColor);
-      debugger
       const pointSize = getNumOrDefault(get(rawData, 'point-size'), 0);
       const asScatterPlot = scatterPlot(globalOptions, rawData.extendWith({'point-size': pointSize}), config);
       const marks = asScatterPlot.marks;

--- a/lang/tests/pyret/tests/test-charts.arr
+++ b/lang/tests/pyret/tests/test-charts.arr
@@ -45,6 +45,17 @@ check "render-chart":
   render-chart(p5) does-not-raise
 end
 
+check "line-plot point-size composes with labels in either order":
+  xs = [list: 1, 2, 3, 4]
+  ys = [list: 1, 4, 9, 16]
+  labels = [list: "a", "b", "c", "d"]
+
+  render-chart(from-list.line-plot(xs, ys).point-size(10).labels(labels)).get-image()
+    does-not-raise
+  render-chart(from-list.line-plot(xs, ys).labels(labels).point-size(10)).get-image()
+    does-not-raise
+end
+
 check "image-dot-chart-from-list ordering invariant":
   # Each image carries the name of its own category, so a save-image of a
   # failing run shows exactly which image landed under which column label.


### PR DESCRIPTION
> is `from-list.labeled-line-plot` supposed to show labels onHover?
>
> It doesn’t right now. I can easily duplicate the behavior by overlaying it atop a labeled-scatter-plot, and the labeled-line-plot method isn’t even documented so maybe we should remove it and I can use the overlayed plot instead?

This would _almost_ work, except that it would create *two* plots and therefore affect the legend.  It also means that `line-plot().labels()` was also broken and should be fixed.

This PR fixes labels to work properly by ensuring that the dots will be visible.  It also cleans up some redundant list-element checks (that our chart-utils annotations already check for us)