### PR TITLE
Avoid iterator helpers in charts-lib for older-Safari compatibility

### DIFF
--- a/lang/src/js/trove/charts-lib.js
+++ b/lang/src/js/trove/charts-lib.js
@@ -2051,7 +2051,7 @@
         p.value = countForCat;
         rawCounts.set(p.category, countForCat + 1);
       }
-      const counts = [...rawCounts.entries().map((kv) => ({ category: kv[0], count: kv[1] }))];
+      const counts = [...rawCounts.entries()].map((kv) => ({ category: kv[0], count: kv[1] }));
       const data = [
         {
           name: 'rawDotsData',
@@ -2950,7 +2950,7 @@
 
       addCrosshairs(prefix, ['Dots'], signals, marks, pointColor);
 
-      const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
+      const samplePoints = [...Array(numSamples).keys()].map((i) => (xMinValue + (fraction * i)));
 
       return recomputePoints(func, samplePoints, (dataValues) => {
         data[0].values = dataValues;
@@ -2968,7 +2968,7 @@
             const xMinValue = globalOptions.xMinValue;
             const xMaxValue = globalOptions.xMaxValue;
             const fraction = (xMaxValue - xMinValue) / (numSamples - 1);
-            const samplePoints = [...Array(numSamples).keys().map((i) => (xMinValue + (fraction * i)))];
+            const samplePoints = [...Array(numSamples).keys()].map((i) => (xMinValue + (fraction * i)));
             RUNTIME.runThunk(() => {
               // NOTE(Ben): We can use view.data(`${prefix}rawTable`, ...newData...)
               // to replace the existing data points in the _current_ view, so that


### PR DESCRIPTION
Three spots in charts-lib.js called `.map()` directly on an iterator (`rawCounts.entries()` in the image-dot-plot code, and `Array(numSamples).keys()` in the function-plot sampling code). That relies on the iterator-helpers proposal (`Iterator.prototype.map`), which Safari only shipped in 18.4 — on Safari 17.6 it throws `TypeError: rawCounts.entries().map is not a function`, which teachers hit on pyret.bootstrapworld.org.

Moving the spread inside the brackets (`[...m.entries()].map(...)`) converts the iterator to an array first, which is functionally identical and works in all browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UukhBiaHkzTeBba8vCojtZ