### PR TITLE
browser-test: embed-static env -- pyret-embed driving the built edito…

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,15 +1,18 @@
 name: browser-test (embed + vscode webviews)
 
-# Runs code.pyret.org's editor assertions against four environments via the
+# Runs code.pyret.org's editor assertions against five environments via the
 # single Playwright runner in browser-test/:
-#   cpo         -- the reference (/editor)
-#   embed       -- the embed API's embedded instance
-#   vscode      -- the pyret-parley.cpo webview (headless VS Code for the Web)
-#   vscode-ovsx -- the same webview, but with its assets served the way Open VSX
-#                  / the GitLab Web IDE serve them (text/plain + nosniff + size
-#                  cap) -- the reproduction of pyret-parley issue #21
+#   cpo          -- the reference (/editor)
+#   embed        -- the embed API's embedded instance
+#   embed-static -- the pyret-embed library (embed/dist) driving the BUILT
+#                   editor.embed.html artifact on a plain static server (no
+#                   CPO server) -- the npm-consumer flow
+#   vscode       -- the pyret-parley.cpo webview (headless VS Code for the Web)
+#   vscode-ovsx  -- the same webview, but with its assets served the way Open VSX
+#                   / the GitLab Web IDE serve them (text/plain + nosniff + size
+#                   cap) -- the reproduction of pyret-parley issue #21
 #
-# Shape: build code.pyret.org + the extension ONCE, then fan out the four
+# Shape: build code.pyret.org + the extension ONCE, then fan out the five
 # environments as a parallel matrix (each on its own runner, so chart rendering
 # doesn't contend for CPU).
 
@@ -69,14 +72,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [cpo, embed, vscode, vscode-ovsx]
+        env: [cpo, embed, embed-static, vscode, vscode-ovsx]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      # cpo + embed load /editor from the CPO server; vscode does not.
+      # cpo + embed + embed-static need the CPO build; only cpo + embed need
+      # the CPO *server* (embed-static serves the built artifact itself).
       - name: Restore cpo build
         if: ${{ !startsWith(matrix.env, 'vscode') }}
         uses: actions/download-artifact@v4
@@ -100,13 +104,22 @@ jobs:
           npm ci --ignore-scripts
           npx playwright install --with-deps chromium
 
+      - name: Build pyret-embed library
+        if: ${{ matrix.env == 'embed-static' }}
+        working-directory: ./embed
+        # --ignore-scripts: the code.pyret.org file: devDep would otherwise try
+        # to build all of CPO; webpack only needs embed/src + its own deps.
+        run: |
+          npm ci --ignore-scripts
+          npx webpack
+
       - name: Install CPO server runtime deps
-        if: ${{ !startsWith(matrix.env, 'vscode') }}
+        if: ${{ matrix.env == 'cpo' || matrix.env == 'embed' }}
         working-directory: ./code.pyret.org
         run: npm ci --ignore-scripts
 
       - name: Start CPO server
-        if: ${{ !startsWith(matrix.env, 'vscode') }}
+        if: ${{ matrix.env == 'cpo' || matrix.env == 'embed' }}
         working-directory: ./code.pyret.org
         env:
           BASE_URL: http://localhost:4999

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -7,13 +7,14 @@ suite against the three places the Pyret editor renders. It's a **`node:test`**
 suite (no extra test-framework dependency) driven through **one runner**:
 
 ```
-node run.js --env=cpo|embed|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|check-blocks,errors,...]
+node run.js --env=cpo|embed|embed-static|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|check-blocks,errors,...]
 ```
 
 | `--env` | What it drives |
 |---|---|
 | `cpo` | the reference — `code.pyret.org`'s `/editor` page (reproduces upstream's outcomes) |
 | `embed` | the embed API's embedded instance (`<iframe>` in `/embed/embed1.html`) |
+| `embed-static` | the **pyret-embed library** (`embed/dist/pyret.js`) driving the **built** `editor.embed.html` artifact on a plain static server — the npm-consumer flow, no CPO server |
 | `vscode` | the `pyret-parley.cpo` webview, in headless VS Code for the Web |
 | `vscode-ovsx` | the same webview, but with its assets served the way **Open VSX** serves them to the **GitLab Web IDE** — reproduces issue #21 |
 
@@ -50,6 +51,25 @@ Env vars: `OVSX_FAITHFUL=1` (correct serving), `OVSX_ASSET_ROOT=<dir>` (override
 the served build; defaults to `vscode/dist/web/build/web`), `OVSX_CAP_MB=<n>`
 (hostile size cap, default 15). A standalone one-shot check that skips the full
 spec suite lives in `smoke-ovsx.js`.
+
+### `embed-static` — pyret-embed driving the built `editor.embed.html` artifact
+
+`--env=embed` drives `/editor#controlled=true` through a running CPO server, so
+it never loads `build/web/editor.embed.html`: the file an embedding host
+actually deploys, rendered once at build time from `src/web/editor.html` +
+`.env.embed` (`BASE_URL="."`, relative asset paths, `POSTMESSAGE_ORIGIN="*"`).
+`embed-static` serves `build/web` from a plain correct-MIME static server
+(`shared/static-server.js`) and embeds it through the **real pyret-embed
+library**: a host page (`pages/embed-static-host.html`, mirroring the package's
+own `embed/src/basic.html` examples) imports `embed/dist/pyret.js` and calls
+`makeEmbedConfig({ src: "/editor.embed.html", ... })` — the exact flow an npm
+consumer of `pyret-embed` runs. It catches breakage that lives only in the
+built artifact or the library: template variables mis-rendered at build time,
+asset references that resolve at a server root but 404 under relative/static
+hosting, and pyret-embed API drift against the editor. Needs the CPO build and
+`embed/dist` (`npm ci --ignore-scripts && npx webpack` in `embed/`) — no
+server, no `code.pyret.org/node_modules`. `EMBED_STATIC_ROOT=<dir>` overrides
+the served build dir.
 
 It is **strictly additive**: nothing under `code.pyret.org/` or `vscode/` is
 modified; the upstream test files are read as-is.
@@ -111,9 +131,13 @@ tests/suite.test.js     the node:test entry: boots one env, one test() per spec
 envs/
   cpo.js                launch chromium, goto /editor
   embed.js              goto /embed/embed1.html, sendReset, find the iframe
+  embed-static.js       pyret-embed (embed/dist) against the built editor.embed.html (no CPO server)
   vscode.js             boot @vscode/test-web, open the custom editor, find the webview
   vscode-ovsx.js        serve the webview via a simulated Open VSX (issue #21 repro)
+pages/
+  embed-static-host.html  host page embedding the artifact via pyret-embed's makeEmbedConfig
 shared/
+  static-server.js      plain correct-MIME static server (multi-root)
   ovsx-server.js        static server that mimics Open VSX serving (text/plain+nosniff, size cap)
   load-cpo-specs.js     extract exact specs from code.pyret.org/test/*.js (no copying)
   page-assertions.js    in-page DOM port of util.js predicates (window.PA)
@@ -154,6 +178,10 @@ BASE_URL=http://localhost:4999 node run.js --env=embed
 
 # vscode needs no CPO server (assets come from the built extension):
 node run.js --env=vscode
+
+# embed-static needs no CPO server either (build the library once:
+#   cd embed && npm ci --ignore-scripts && npx webpack):
+node run.js --env=embed-static
 
 # everything (starts the CPO server if needed):
 ./run-all.sh

--- a/browser-test/envs/embed-static.js
+++ b/browser-test/envs/embed-static.js
@@ -1,0 +1,86 @@
+/*
+ * Environment adapter: the pyret-embed library driving the BUILT static embed
+ * artifact, code.pyret.org/build/web/editor.embed.html -- no CPO server.
+ *
+ * --env=embed drives /editor#controlled=true through a running CPO server via
+ * code.pyret.org's test-util host page, so it never loads editor.embed.html:
+ * the file an embedding host actually deploys, rendered at build time from
+ * .env.embed (BASE_URL=".", relative asset paths, POSTMESSAGE_ORIGIN="*"; see
+ * code.pyret.org/make-template.js). This env serves that artifact from a plain
+ * correct-MIME static server (shared/static-server.js) and embeds it through
+ * the real pyret-embed library (embed/dist/pyret.js) from a host page that
+ * mirrors the package's own examples (pages/embed-static-host.html) -- the
+ * exact flow an npm consumer of pyret-embed runs.
+ *
+ * What this catches that --env=embed can't: breakage that lives only in the
+ * built artifact or the library -- template variables mis-rendered at build
+ * time, asset references that resolve at a server root but 404 under
+ * relative/static hosting (e.g. a root-absolute /img/... sneaking back into
+ * editor css), and pyret-embed API drift against the editor.
+ *
+ * Env vars:
+ *   EMBED_STATIC_ROOT  override the served build dir
+ *                      (default code.pyret.org/build/web)
+ */
+const path = require("path");
+const fs = require("fs");
+const { launchChromium } = require("../shared/browser");
+const { findEditorFrame } = require("../shared/find-frame");
+const { startStaticServer } = require("../shared/static-server");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const BUILD_ROOT = process.env.EMBED_STATIC_ROOT || path.join(REPO_ROOT, "code.pyret.org", "build", "web");
+const EMBED_DIST = path.join(REPO_ROOT, "embed", "dist");
+const PAGES_ROOT = path.resolve(__dirname, "..", "pages");
+
+async function setup() {
+  const artifact = path.join(BUILD_ROOT, "editor.embed.html");
+  if (!fs.existsSync(artifact)) {
+    throw new Error(
+      "embed-static: " + artifact + " not found -- is code.pyret.org built? " +
+        "(`npm run build` / `make web` produce it from src/web/editor.html + .env.embed)"
+    );
+  }
+  const library = path.join(EMBED_DIST, "pyret.js");
+  if (!fs.existsSync(library)) {
+    throw new Error(
+      "embed-static: " + library + " not found -- is pyret-embed built? " +
+        "(`npm ci --ignore-scripts && npx webpack` in embed/ produce it)"
+    );
+  }
+
+  const server = await startStaticServer({
+    roots: [BUILD_ROOT, EMBED_DIST, PAGES_ROOT],
+  });
+
+  const browser = await launchChromium();
+  const page = await browser.newPage();
+  page.setDefaultTimeout(60000);
+
+  await page.goto(server.origin + "/embed-static-host.html", {
+    waitUntil: "domcontentloaded",
+    timeout: 120000,
+  });
+
+  // makeEmbedConfig resolves (and the host page sets window.embedAPI) once the
+  // editor announces pyret-init and the initial state reset has been sent.
+  await page.waitForFunction(() => !!window.embedAPI, undefined, {
+    timeout: 60000,
+    polling: 200,
+  });
+
+  const frame = await findEditorFrame(page);
+  return {
+    page,
+    frame,
+    cleanup: async () => {
+      await browser.close();
+      await server.close();
+    },
+  };
+}
+
+module.exports = {
+  setup,
+  label: "pyret-embed library against the static editor.embed.html artifact (no CPO server)",
+};

--- a/browser-test/pages/embed-static-host.html
+++ b/browser-test/pages/embed-static-host.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<!--
+  Host page for the embed-static env: embeds the BUILT editor.embed.html
+  artifact through the real pyret-embed library (embed/dist/pyret.js), the way
+  an actual embedding host does -- makeEmbedConfig with a src URL pointing at
+  the statically served artifact. Compare embed/src/basic.html (the package's
+  own examples), which this mirrors.
+
+  Served by envs/embed-static.js alongside code.pyret.org/build/web (the
+  artifact) and embed/dist (the library), all same-origin.
+-->
+<html>
+<head>
+<style>
+  html, body { height: 100%; margin: 0; }
+  #container { width: 100%; height: 100%; }
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script type="module">
+  import { makeEmbedConfig } from "/pyret.js";
+  makeEmbedConfig({
+    container: document.getElementById("container"),
+    src: "/editor.embed.html",
+    // Same initial state the embed env resets to (envs/embed.js).
+    state: {
+      definitionsAtLastRun: false,
+      editorContents: "use context starter2024\n\n",
+      replContents: "",
+      interactionsSinceLastRun: [],
+    },
+    options: {},
+  }).then((api) => { window.embedAPI = api; });
+</script>
+</body>
+</html>

--- a/browser-test/run.js
+++ b/browser-test/run.js
@@ -30,8 +30,8 @@ function arg(name) {
 }
 
 const env = arg("env");
-if (!env || !["cpo", "embed", "vscode", "vscode-ovsx"].includes(env)) {
-  console.error("usage: node run.js --env=cpo|embed|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|a,b] [--reporter=spec|tap|dot]");
+if (!env || !["cpo", "embed", "embed-static", "vscode", "vscode-ovsx"].includes(env)) {
+  console.error("usage: node run.js --env=cpo|embed|embed-static|vscode|vscode-ovsx [--grep=<regex>] [--suites=all|a,b] [--reporter=spec|tap|dot]");
   process.exit(2);
 }
 const grep = arg("grep");

--- a/browser-test/shared/static-server.js
+++ b/browser-test/shared/static-server.js
@@ -1,0 +1,80 @@
+/*
+ * static-server.js -- a minimal correct-MIME static file server, for envs that
+ * exercise BUILT artifacts directly instead of going through the CPO server.
+ *
+ * Serves one or more root directories (first root containing the file wins)
+ * on an ephemeral localhost port.
+ */
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const TYPES = {
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".wasm": "application/wasm",
+  ".ico": "image/x-icon",
+  ".xml": "application/xml",
+  ".arr": "text/plain",
+};
+
+function contentType(p) {
+  return TYPES[path.extname(p).toLowerCase()] || "application/octet-stream";
+}
+
+/*
+ * opts:
+ *   roots  - array of directories to serve, searched in order
+ * returns { origin, close }
+ */
+async function startStaticServer(opts) {
+  const roots = opts.roots.map((r) => path.resolve(r));
+
+  const server = http.createServer((req, res) => {
+    let pathname;
+    try {
+      pathname = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+    } catch (e) {
+      res.writeHead(400).end("bad request");
+      return;
+    }
+    const rel = pathname.replace(/^\/+/, "");
+
+    for (const root of roots) {
+      const filePath = path.resolve(root, rel);
+      if (filePath !== root && !filePath.startsWith(root + path.sep)) continue;
+      let st;
+      try {
+        st = fs.statSync(filePath);
+      } catch (e) {
+        continue;
+      }
+      if (!st.isFile()) continue;
+      res.writeHead(200, { "Content-Type": contentType(filePath) });
+      fs.createReadStream(filePath).pipe(res);
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "text/plain" }).end("not found: " + pathname);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    origin: "http://127.0.0.1:" + server.address().port,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+module.exports = { startStaticServer };

--- a/browser-test/tests/suite.test.js
+++ b/browser-test/tests/suite.test.js
@@ -25,8 +25,8 @@ const SUITES = {
   "tables": "tables.js",
 };
 
-if (!ENV || !["cpo", "embed", "vscode", "vscode-ovsx"].includes(ENV)) {
-  throw new Error("PYRET_ENV must be one of cpo | embed | vscode | vscode-ovsx (got " + JSON.stringify(ENV) + ")");
+if (!ENV || !["cpo", "embed", "embed-static", "vscode", "vscode-ovsx"].includes(ENV)) {
+  throw new Error("PYRET_ENV must be one of cpo | embed | embed-static | vscode | vscode-ovsx (got " + JSON.stringify(ENV) + ")");
 }
 const chosen =
   !process.env.PYRET_SUITES || process.env.PYRET_SUITES === "all"

--- a/embed/package-lock.json
+++ b/embed/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@zenfs/core": "^2.2.3",
+        "buffer": "^6.0.3",
         "mustache": "^4.2.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -38,6 +39,7 @@
         "bootstrap": "^4.6.2",
         "browserify": "^17.0.1",
         "buffer": "^6.0.3",
+        "canvas": "^3.1.0",
         "codemirror": "~5.58.2",
         "colorspaces": "0.1.4",
         "cookie-parser": "^1.4.6",
@@ -88,10 +90,11 @@
         "url-loader": "^0.6.2",
         "url.js": "^1.0.3",
         "vega": "^6.1.2",
+        "vega-tooltip": "^1.0.0",
         "webpack": "^5.89.0"
       },
       "devDependencies": {
-        "chromedriver": "^146.0.4",
+        "chromedriver": "^148.0.4",
         "selenium-webdriver": "^3.6.0",
         "webpack-cli": "^5.1.4"
       }
@@ -411,30 +414,6 @@
         "url": "https://github.com/sponsors/james-pre"
       }
     },
-    "node_modules/@zenfs/core/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/@zenfs/core/node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -613,6 +592,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {

--- a/embed/package.json
+++ b/embed/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@zenfs/core": "^2.2.3",
+    "buffer": "^6.0.3",
     "mustache": "^4.2.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/embed/webpack.config.js
+++ b/embed/webpack.config.js
@@ -17,7 +17,8 @@ module.exports = {
         extensions: ['.ts', '.js'],
         fallback: {
             'fs': require.resolve('@zenfs/core'),
-            'path': require.resolve('path-browserify')
+            'path': require.resolve('path-browserify'),
+            'buffer': require.resolve('buffer/')
         }
     },
     output: {


### PR DESCRIPTION
…r.embed.html artifact

Completing the set of environments under headless test. We now have:

- Plain HTML/self-host embedded (e.g. the pyret-embed npm package)

In addition to:

- Server-direct-served (e.g. code.pyret.org/editor)
- Server-iframe-embedded (e.g. the VMT use case)
- VScode-in-browser
- VScode-in-browser with a GitLab-simulating server that breaks various things

Claude says:

embed-static serves code.pyret.org/build/web from a minimal correct-MIME static server (new shared/static-server.js: multi-root, ephemeral port, no dependencies) and embeds the artifact through the real library: a host page (browser-test/pages/embed-static-host.html, mirroring embed/src/basic.html) imports embed/dist/pyret.js and calls
makeEmbedConfig({src: "/editor.embed.html", state: ...}) -- the exact flow a pyret-embed consumer runs, gainControl handshake and all. The env waits for the API promise, finds the editor frame, and runs the same five suites as every other env.

Catches breakage only visible there: template variables mis-rendered at build time, asset references that resolve at a server root but 404 under relative/static hosting (the bug class of 21dbeb9b5), and pyret-embed API drift against the editor.

embed/ build fix, needed to build dist/pyret.js in CI: zenfs (via string_decoder) requires the buffer browser polyfill; add it to deps and webpack resolve.fallback. Before this `npx webpack` failed on the default-rpcs entry.

Strictly additive: nothing under code.pyret.org/ changes. In CI it's a fifth matrix entry needing the cpo-build artifact plus a cheap library build (`npm ci --ignore-scripts && npx webpack` in embed/; the code.pyret.org file: devDep is a bare symlink under --ignore-scripts) -- no CPO server, no code.pyret.org node_modules (those steps now run for cpo|embed only).

Verified locally: all five suites (check-blocks, errors, type-check, charts, tables) pass against the static artifact through pyret-embed, and the embed/ build recipe validated from a clean npm ci.


