### PR TITLE
Make $app_fields honor the refmask it is handed

### DIFF
--- a/lang/src/arr/compiler/anf-loop-compiler.arr
+++ b/lang/src/arr/compiler/anf-loop-compiler.arr
@@ -1903,14 +1903,21 @@ compiler-visitor = {
         end
 
       refl-fields-id = js-id-of(compiler-name(string-append(vname, "_getfields")))
+      refmask-id = const-id("refmask")
+      # refmask says which fields the caller wants dereferenced: `cases` passes
+      # the fields its branch bound with `ref`, and _match passes the mutable
+      # ones.  derefField also raises if that disagrees with the field itself.
       refl-fields =
         cases(N.AVariant) v:
           | a-variant(_, _, _, members, _) =>
-            j-fun(J.next-j-fun-id(), "singleton_variant",
-              [clist: const-id("f")], j-block1(j-return(j-app(j-id(f-id),
-                    CL.map_list(lam(m):
-                        get-dict-field(THIS, j-str(m.bind.id.toname()))
-                      end, members)))))
+            j-fun(J.next-j-fun-id(), "variant",
+              [clist: f-id, refmask-id], j-block1(j-return(j-app(j-id(f-id),
+                    for CL.map_list_n(i from 0, m from members):
+                        field = get-dict-field(THIS, j-str(m.bind.id.toname()))
+                        mask = j-bracket(j-id(refmask-id), j-num(i))
+                        rt-method("derefField",
+                          [clist: field, j-bool(N.is-a-mutable(m.member-type)), mask])
+                      end))))
           | a-singleton-variant(_, _, _) =>
             j-fun(J.next-j-fun-id(), "variant",
               [clist: const-id("f")], j-block1(j-return(j-app(j-id(f-id), cl-empty))))

--- a/lang/tests/pyret/tests/test-cases.arr
+++ b/lang/tests/pyret/tests/test-cases.arr
@@ -2,6 +2,49 @@ data MutCar:
   | mpair(ref car, cdr)
 end
 
+# _match hands its fields to the handler through the same applier cases uses,
+# with the mutable fields as the mask -- so a visitor sees the contents of a
+# ref field, not the ref.
+data MutBox:
+  | mbox(ref v) with:
+    method visit(self, visitor):
+      self._match(visitor, lam(): raise("no branch for mbox") end)
+    end
+end
+
+fun slow(n :: Number) -> Number:
+  if n <= 0: 0 else: slow(n - 1) end
+end
+
+# A branch whose body needs more steps than inline-case-body-limit is compiled
+# as its own function rather than inlined into the cases, which used to skip
+# dereferencing the ref fields (and the checks on `ref` in the bindings).
+fun big-branch-ref(m :: MutCar) -> String:
+  cases(MutCar) m:
+    | mpair(ref car, cdr) =>
+      a = slow(1)
+      b = slow(a)
+      c = slow(b)
+      d = slow(c)
+      e = slow(d)
+      f = slow(e)
+      car + cdr
+  end
+end
+
+fun big-branch-no-ref(m :: MutCar) -> String:
+  cases(MutCar) m:
+    | mpair(car, cdr) =>
+      a = slow(1)
+      b = slow(a)
+      c = slow(b)
+      d = slow(c)
+      e = slow(d)
+      f = slow(e)
+      car + cdr
+  end
+end
+
 check:
   m1 = mpair("a", "b")
 
@@ -20,5 +63,11 @@ check:
   cases(MutCar) m1:
     | mpair(ref car, ref cdr) => car + cdr
   end raises "non-ref field"
+
+  big-branch-ref(m1) is "ab"
+
+  big-branch-no-ref(m1) raises "ref field"
+
+  mbox(5).visit({ mbox: lam(x): x + 1 end }) is 6
 
 end


### PR DESCRIPTION


`$app_fields` is a reflective callback that gets a `refmask` – an array of booleans indicating which fields are `refs` that should be `derefed`. It is used in _match and cases to yank out an array of fields for a data value. A couple of combined compiler changes (a decade ago!) regressed this.

We didn't notice because our tests were very short, and when cases branches are *inlined*, the behavior is correct because the field lookups and derefs are also inlined. When $app_fields is used, in "longer" cases branches (not that long, just >5 steps), an intervening commit (26a35491d) had shifted how the callbacks were set up so the cases branch was called with the *raw* field values.

This commit fixes app_fields to always consult the refmask. There are no consumers that *shouldn't* honor the refmask.

