### PR TITLE
Include the ts backend in the pyret-npm tarball

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -5,7 +5,8 @@
   "files": [
     "pyret.js",
     "client-lib.js",
-    "pyret-lang/build/phaseA/*"
+    "pyret-lang/build/phaseA/*",
+    "pyret-lang/build/ts-compiler/*"
   ],
   "dependencies": {
     "ascii-table": "^0.0.9",


### PR DESCRIPTION
Joe says: I missed this, caught in pre-deploy checks. All the CI works but the thing that copied the whole bundle to npm didn't actually copy the TS compiler. Fix that.

Claude said:

npm/package.json's "files" whitelist only listed
pyret-lang/build/phaseA/*, and when "files" is present npm ignores the root .npmignore entirely -- so its !pyret-lang/build/ts-compiler/* negation never applied, and even a PYRET_NPM_TS=1 build published a tarball without the TypeScript backend. Every install would then fail pyret.js's existence check with "The ts backend is not available" whenever --backend ts / PYRET_COMPILER=ts was requested.

Verified with npm pack --dry-run against a mocked build layout: before, ts-compiler/ is dropped; after, the glob includes the directory recursively (pyret.js, libs.jarr, and the js/ runtime tree), matching what build.sh copies. Packages built without PYRET_NPM_TS=1 are unaffected -- the directory simply isn't there to pack.