### PR TITLE
Npm ts artifacts

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Build pyret-lang and stage the build that pyret.js loads
         working-directory: ./npm
+        env:
+          PYRET_NPM_TS: '1'
         run: npm run build
 
       - name: Test the CLI against that build
@@ -23,3 +25,7 @@ jobs:
         run: |
           npm ci
           npm test
+
+      - name: Pack the tarball and smoke both backends from a clean install
+        working-directory: ./npm
+        run: bash test/packaged-cli.test.sh

--- a/npm/build.sh
+++ b/npm/build.sh
@@ -17,4 +17,13 @@ mkdir -p pyret-lang/build
 cp -r ../lang/build/phaseA pyret-lang/build/
 if [ "${PYRET_NPM_TS:-}" = "1" ]; then
   cp -r ../lang/build/ts-compiler pyret-lang/build/
+  mkdir -p pyret-lang/src/js/base pyret-lang/lib/jglr
+  cp ../lang/src/js/base/js-numbers.js \
+     ../lang/src/js/base/type-util.js \
+     ../lang/src/js/base/pyret-tokenizer.js \
+     pyret-lang/src/js/base/
+  cp ../lang/lib/jglr/jglr.js \
+     ../lang/lib/jglr/rnglr.js \
+     ../lang/lib/jglr/cyclicJSON.js \
+     pyret-lang/lib/jglr/
 fi

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -15,6 +15,7 @@
         "command-line-usage": "^5.0.5",
         "mkdirp": "^0.5.1",
         "resolve": "^1.22.10",
+        "source-map": "^0.5.7",
         "strip-ansi": "^4.0.0",
         "vega": "^6.1.2",
         "ws": "^5.2.1"
@@ -6266,10 +6267,9 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6284,6 +6284,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,7 +6,9 @@
     "pyret.js",
     "client-lib.js",
     "pyret-lang/build/phaseA/*",
-    "pyret-lang/build/ts-compiler/*"
+    "pyret-lang/build/ts-compiler/*",
+    "pyret-lang/src/js/base/*",
+    "pyret-lang/lib/jglr/*"
   ],
   "dependencies": {
     "ascii-table": "^0.0.9",
@@ -15,6 +17,7 @@
     "command-line-usage": "^5.0.5",
     "mkdirp": "^0.5.1",
     "resolve": "^1.22.10",
+    "source-map": "^0.5.7",
     "strip-ansi": "^4.0.0",
     "vega": "^6.1.2",
     "ws": "^5.2.1"

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -56,38 +56,46 @@ const parse_file_for_expected_std = (f) => {
 
 
 
-describe("IO Tests", () => {
-  let server;
-  glob.sync(`test/tests/test-*.arr`, {}).forEach(f => {
-    describe("Testing " + f, () => {
-      const {stdioExpected, stdInToInject, stderrExpected, compilestderrExpected, extraArgs} = parse_file_for_expected_std(f);
+const registerIOTests = (suiteName, backendArgs, testFn) => {
+  describe(suiteName, () => {
+    glob.sync(`test/tests/test-*.arr`, {}).forEach(f => {
+      describe("Testing " + f, () => {
+        const {stdioExpected, stdInToInject, stderrExpected, compilestderrExpected, extraArgs} = parse_file_for_expected_std(f);
 
-      test(`it should return io that is expected: ${stdioExpected}`, () => {  
-        const args = [ "pyret.js", ...extraArgs, f ];
-        const pyretProcess = cp.spawnSync(
-          "node",
-          args,
-          {stdio: "pipe", stderr: "pipe", timeout: COMPILER_TIMEOUT});
-         
-        if(compilestderrExpected === "") {
-          expect(pyretProcess.stderr.toString()).toEqual(EMPTY_MESSAGE);
-          expect(pyretProcess.status).toEqual(SUCCESS_EXIT_CODE);
-        }
-        else {
-          expect(pyretProcess.stderr.toString()).toContain(compilestderrExpected);
-          expect(pyretProcess.status).not.toEqual(SUCCESS_EXIT_CODE);
-          return; // Don't try to run the program if an error was expected
-        }
+        testFn(`it should return io that is expected: ${stdioExpected}`, () => {
+          const args = [ "pyret.js", ...backendArgs, ...extraArgs, f ];
+          const pyretProcess = cp.spawnSync(
+            "node",
+            args,
+            {stdio: "pipe", stderr: "pipe", timeout: COMPILER_TIMEOUT});
 
-        if (stderrExpected !== EMPTY_MESSAGE) {
-          expect(pyretProcess.status).not.toEqual(SUCCESS_EXIT_CODE);
-          expect(pyretProcess.stderr.toString()).toMatch(new RegExp(stderrExpected));
-        } 
-        else {
-          expect(pyretProcess.status).toEqual(SUCCESS_EXIT_CODE);
-          expect(pyretProcess.stdout.toString()).toMatch(new RegExp(stdioExpected));
-        }
+          if(compilestderrExpected === "") {
+            expect(pyretProcess.stderr.toString()).toEqual(EMPTY_MESSAGE);
+            expect(pyretProcess.status).toEqual(SUCCESS_EXIT_CODE);
+          }
+          else {
+            expect(pyretProcess.stderr.toString()).toContain(compilestderrExpected);
+            expect(pyretProcess.status).not.toEqual(SUCCESS_EXIT_CODE);
+            return; // Don't try to run the program if an error was expected
+          }
+
+          if (stderrExpected !== EMPTY_MESSAGE) {
+            expect(pyretProcess.status).not.toEqual(SUCCESS_EXIT_CODE);
+            expect(pyretProcess.stderr.toString()).toMatch(new RegExp(stderrExpected));
+          }
+          else {
+            expect(pyretProcess.status).toEqual(SUCCESS_EXIT_CODE);
+            expect(pyretProcess.stdout.toString()).toMatch(new RegExp(stdioExpected));
+          }
+        });
       });
     });
   });
-});
+};
+
+registerIOTests("IO Tests", [], test);
+registerIOTests(
+  "IO Tests (ts backend)",
+  ["--backend", "ts"],
+  fs.existsSync("pyret-lang/build/ts-compiler/pyret.js") ? test : test.skip
+);

--- a/npm/test/packaged-cli.test.sh
+++ b/npm/test/packaged-cli.test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tarball="$PWD/$(npm pack --silent | tail -n 1)"
+smokedir=$(mktemp -d)
+trap 'rm -rf "$smokedir" "$tarball"' EXIT
+
+cd "$smokedir"
+npm init -y > /dev/null
+npm install --no-audit --no-fund "$tarball" > /dev/null
+
+cat > smoke.arr <<'ARR'
+check "smoke":
+  1 + 1 is 2
+end
+ARR
+
+run_backend() {
+  local backend="$1"
+  local sock="$smokedir/comm-$backend.sock"
+  local out="$smokedir/out-$backend.log"
+  local status
+  set +e
+  node node_modules/pyret-npm/pyret.js --backend "$backend" --port "$sock" smoke.arr > "$out" 2>&1
+  status=$?
+  set -e
+  node node_modules/pyret-npm/pyret.js --backend "$backend" --port "$sock" -s > /dev/null 2>&1 || true
+  if [ "$status" -ne 0 ] || ! grep -q "Looks shipshape" "$out"; then
+    echo "packaged cli failed for backend $backend (exit $status):"
+    cat "$out"
+    exit 1
+  fi
+  echo "packaged cli: backend $backend is shipshape"
+}
+
+run_backend pyret
+if [ -e node_modules/pyret-npm/pyret-lang/build/ts-compiler/pyret.js ]; then
+  run_backend ts
+else
+  echo "packaged cli: ts backend not in package, skipped"
+fi


### PR DESCRIPTION
Make sure to actually ship all the files TS mode uses at the CLI
The TS mode loads a few files by path that are bundled by the mainline
compiler; things like js-numbers and parser support. The test scripts have
those floating around, so nothing noticed that they didn't make it into the
bundle until deploy.

This commit:

- Adds the necessary files
- Adds tests to make sure the server gets tested in ts mode
- Adds a test that runs from the result of `npm pack` to make sure it has the
  right stuff
