### PR TITLE
Pause schedules: configurable initial GAS/RUNGAS for stack-capture te…

### DIFF
--- a/lang/.gitignore
+++ b/lang/.gitignore
@@ -35,6 +35,8 @@ build/docs
 build/phaseA
 build/phaseB
 build/phaseC
+build/phaseB-ts
+build/phaseC-ts
 build/phase1
 build/phase2
 build/phase3

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -697,6 +697,59 @@ $(PHASECTS)/config.json: src/scripts/node_modules-config.json
 #   * phaseB    == phaseB-ts  (headline: TS compiler is a byte-exact drop-in)
 # Prints sha256 of all four and a PASS/FAIL line per invariant; exits
 # nonzero if any invariant fails.
+# ============================================================
+# Pause schedules: run the main2 suite with varied initial GAS/RUNGAS
+# (see tests/pause-schedules/). Each scheduled run's output must match
+# the unscheduled baseline run, and the rand-small build is repeated
+# with the TS compiler (same compiled cache) and must be byte-identical
+# to the .arr build.
+# ============================================================
+
+PAUSE_SCHEDULES := const-small const-medium rand-small rand-wide alternate sawtooth
+
+tests/pyret/main2-ps-%.jarr: phaseA tests/pyret/main2.arr $(TEST_FILES) tests/pause-schedules/%.js
+	$(TEST_BUILD) \
+		--outfile $@ \
+		--build-runnable tests/pyret/main2.arr \
+		--pause-schedule tests/pause-schedules/$*.js \
+		-check-all
+
+# Shares tests/compiled with the .arr builds: cached module code depends on
+# the worklist that warmed the cache (gensym numbering), so a byte-equal
+# standalone needs both compilers reading the same cache. Module-codegen
+# parity itself is covered by ts-parity-test / bootstrap-converge.
+tests/pyret/main2-ps-ts-rand-small.jarr: ts-compiler $(CONFIGA_RUNTIME_FILES) tests/pyret/main2-ps-rand-small.jarr tests/pyret/main2.arr $(TEST_FILES) tests/pause-schedules/rand-small.js
+	$(TS_PYRET) \
+		--builtin-js-dir src/js/trove/ \
+		--builtin-arr-dir src/arr/trove/ \
+		--require-config src/scripts/standalone-configA.json \
+		--compiled-dir tests/compiled/ \
+		--outfile $@ \
+		--build-runnable tests/pyret/main2.arr \
+		--pause-schedule tests/pause-schedules/rand-small.js \
+		-check-all
+
+.PHONY : pause-schedule-test
+pause-schedule-test: phaseA tests/pyret/main2.jarr $(patsubst %,tests/pyret/main2-ps-%.jarr,$(PAUSE_SCHEDULES)) tests/pyret/main2-ps-ts-rand-small.jarr
+	cmp tests/pyret/main2-ps-rand-small.jarr tests/pyret/main2-ps-ts-rand-small.jarr
+	$(NODE) tests/pyret/main2.jarr > build/pause-schedule-baseline.out
+	set -e; for s in $(PAUSE_SCHEDULES); do \
+	  echo "== pause schedule: $$s"; \
+	  $(NODE) tests/pyret/main2-ps-$$s.jarr > build/pause-schedule-$$s.out; \
+	  diff build/pause-schedule-baseline.out build/pause-schedule-$$s.out; \
+	  echo "ok $$s"; \
+	done
+
+.PHONY : pause-schedule-clean
+pause-schedule-clean:
+	$(call RM,tests/pyret/main2-ps-const-small.jarr)
+	$(call RM,tests/pyret/main2-ps-const-medium.jarr)
+	$(call RM,tests/pyret/main2-ps-rand-small.jarr)
+	$(call RM,tests/pyret/main2-ps-rand-wide.jarr)
+	$(call RM,tests/pyret/main2-ps-alternate.jarr)
+	$(call RM,tests/pyret/main2-ps-sawtooth.jarr)
+	$(call RM,tests/pyret/main2-ps-ts-rand-small.jarr)
+
 .PHONY : bootstrap-converge
 bootstrap-converge: phaseB phaseC phaseB-ts phaseC-ts
 	@B=$(PHASEB)/pyret.jarr; C=$(PHASEC)/pyret.jarr; \

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -697,6 +697,22 @@ $(PHASECTS)/config.json: src/scripts/node_modules-config.json
 #   * phaseB    == phaseB-ts  (headline: TS compiler is a byte-exact drop-in)
 # Prints sha256 of all four and a PASS/FAIL line per invariant; exits
 # nonzero if any invariant fails.
+.PHONY : bootstrap-converge
+bootstrap-converge: phaseB phaseC phaseB-ts phaseC-ts
+	@B=$(PHASEB)/pyret.jarr; C=$(PHASEC)/pyret.jarr; \
+	 BT=$(PHASEBTS)/pyret.jarr; CT=$(PHASECTS)/pyret.jarr; \
+	 echo "=== bootstrap convergence ==="; \
+	 sha256sum $$B $$C $$BT $$CT; \
+	 echo "---"; \
+	 fail=0; \
+	 if cmp -s $$B  $$C;  then echo "PASS  .arr fixpoint       phaseB    == phaseC";    else echo "FAIL  .arr fixpoint       phaseB    != phaseC";    fail=1; fi; \
+	 if cmp -s $$BT $$CT; then echo "PASS  ts   fixpoint       phaseB-ts == phaseC-ts"; else echo "FAIL  ts   fixpoint       phaseB-ts != phaseC-ts"; fail=1; fi; \
+	 if cmp -s $$B  $$BT; then echo "PASS  cross (headline)    phaseB    == phaseB-ts"; else echo "FAIL  cross (headline)    phaseB    != phaseB-ts"; fail=1; fi; \
+	 echo "---"; \
+	 if [ $$fail -eq 0 ]; then echo "CONVERGED: all four standalones are byte-identical"; \
+	 else echo "NOT CONVERGED: see FAILs above (diff the named .jarr files to diagnose)"; fi; \
+	 exit $$fail
+
 # ============================================================
 # Pause schedules: run the main2 suite with varied initial GAS/RUNGAS
 # (see tests/pause-schedules/). Each scheduled run's output must match
@@ -749,19 +765,3 @@ pause-schedule-clean:
 	$(call RM,tests/pyret/main2-ps-alternate.jarr)
 	$(call RM,tests/pyret/main2-ps-sawtooth.jarr)
 	$(call RM,tests/pyret/main2-ps-ts-rand-small.jarr)
-
-.PHONY : bootstrap-converge
-bootstrap-converge: phaseB phaseC phaseB-ts phaseC-ts
-	@B=$(PHASEB)/pyret.jarr; C=$(PHASEC)/pyret.jarr; \
-	 BT=$(PHASEBTS)/pyret.jarr; CT=$(PHASECTS)/pyret.jarr; \
-	 echo "=== bootstrap convergence ==="; \
-	 sha256sum $$B $$C $$BT $$CT; \
-	 echo "---"; \
-	 fail=0; \
-	 if cmp -s $$B  $$C;  then echo "PASS  .arr fixpoint       phaseB    == phaseC";    else echo "FAIL  .arr fixpoint       phaseB    != phaseC";    fail=1; fi; \
-	 if cmp -s $$BT $$CT; then echo "PASS  ts   fixpoint       phaseB-ts == phaseC-ts"; else echo "FAIL  ts   fixpoint       phaseB-ts != phaseC-ts"; fail=1; fi; \
-	 if cmp -s $$B  $$BT; then echo "PASS  cross (headline)    phaseB    == phaseB-ts"; else echo "FAIL  cross (headline)    phaseB    != phaseB-ts"; fail=1; fi; \
-	 echo "---"; \
-	 if [ $$fail -eq 0 ]; then echo "CONVERGED: all four standalones are byte-identical"; \
-	 else echo "NOT CONVERGED: see FAILs above (diff the named .jarr files to diagnose)"; fi; \
-	 exit $$fail

--- a/lang/src/arr/compiler/compile-lib.arr
+++ b/lang/src/arr/compiler/compile-lib.arr
@@ -582,10 +582,7 @@ fun make-standalone(wl, compiled, options):
       J.j-field("pauseSchedule",
         cases(Option) options.pause-schedule:
           | none => j-false
-          | some(code) =>
-            J.j-raw-code("(function(module) { var exports = module.exports;\n"
-              + code
-              + "\nreturn module.exports; })({ exports: {} })")
+          | some(code) => j-str(code)
         end)
     ])
 

--- a/lang/src/arr/compiler/compile-lib.arr
+++ b/lang/src/arr/compiler/compile-lib.arr
@@ -549,7 +549,7 @@ end
 fun make-standalone(wl, compiled, options):
   natives = for fold(natives from empty, w from wl):
     w.locator.get-native-modules().map(_.path) + natives
-  end
+  end.sort()
   
   var all-compile-problems = empty
   static-modules = j-obj(for C.map_list(w from wl):
@@ -578,6 +578,14 @@ fun make-standalone(wl, compiled, options):
           j-false
         else:
           j-true
+        end),
+      J.j-field("pauseSchedule",
+        cases(Option) options.pause-schedule:
+          | none => j-false
+          | some(code) =>
+            J.j-raw-code("(function(module) { var exports = module.exports;\n"
+              + code
+              + "\nreturn module.exports; })({ exports: {} })")
         end)
     ])
 

--- a/lang/src/arr/compiler/compile-structs.arr
+++ b/lang/src/arr/compiler/compile-structs.arr
@@ -2980,7 +2980,8 @@ default-compile-options = {
   html-file: none,
   deps-file: "build/bundled-node-deps.js",
   standalone-file: "src/js/base/handalone.js",
-  url-file-mode: all-remote
+  url-file-mode: all-remote,
+  pause-schedule: none
 }
 
 fun make-default-compile-options(this-pyret-dir):

--- a/lang/src/arr/compiler/pyret.arr
+++ b/lang/src/arr/compiler/pyret.arr
@@ -91,6 +91,8 @@ fun main(args :: List<String>) -> Number block:
     C.flag(C.once, "Ignore all annotations in the runtime, treating them as if they were blank."),
     "url-file-mode",
     C.next-val-default(C.Str, "all-remote", none, C.once, "How to handle url-file imports (all-remote, all-local, or local-if-present)"),
+    "pause-schedule",
+    C.next-val(C.Str, C.once, "JS file computing initial GAS/RUNGAS for the runtime; its code is baked into the standalone"),
   ]
 
   params-parsed = C.parse-args(options, args)
@@ -127,6 +129,7 @@ fun main(args :: List<String>) -> Number block:
       module-eval = not(r.has-key("no-module-eval"))
       user-annotations = not(r.has-key("no-user-annotations"))
       runtime-annotations = not(r.has-key("no-runtime-annotations"))
+      pause-schedule = r.get("pause-schedule").and-then(F.file-to-string)
       when r.has-key("builtin-js-dir"):
         B.set-builtin-js-dirs(r.get-value("builtin-js-dir"))
       end
@@ -197,7 +200,8 @@ fun main(args :: List<String>) -> Number block:
             module-eval: module-eval,
             user-annotations: user-annotations,
             runtime-annotations: runtime-annotations,
-            url-file-mode: url-file-mode
+            url-file-mode: url-file-mode,
+            pause-schedule: pause-schedule
           })
         success-code
       else if r.has-key("serve"):

--- a/lang/src/js/base/handalone.js
+++ b/lang/src/js/base/handalone.js
@@ -44,7 +44,14 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/post-load-hooks", "pyret-base
   }
 
   if(checkFlag("pauseSchedule")) {
-    runtime.setPauseSchedule(program.runtimeOptions.pauseSchedule);
+    var scheduleModule = { exports: {} };
+    try {
+      (new Function("module", "exports", program.runtimeOptions.pauseSchedule))(
+        scheduleModule, scheduleModule.exports);
+    } catch(e) {
+      throw new Error("Could not evaluate the pause schedule baked in by --pause-schedule: " + e.message);
+    }
+    runtime.setPauseSchedule(scheduleModule.exports);
   }
 
   if(checkFlag("disableAnnotationChecks")) {

--- a/lang/src/js/base/handalone.js
+++ b/lang/src/js/base/handalone.js
@@ -43,6 +43,10 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/post-load-hooks", "pyret-base
     return program.runtimeOptions && program.runtimeOptions[name];
   }
 
+  if(checkFlag("pauseSchedule")) {
+    runtime.setPauseSchedule(program.runtimeOptions.pauseSchedule);
+  }
+
   if(checkFlag("disableAnnotationChecks")) {
     runtime.checkArgsInternal1 = function() {};
     runtime.checkArgsInternal2 = function() {};

--- a/lang/src/js/base/runtime.js
+++ b/lang/src/js/base/runtime.js
@@ -3583,8 +3583,20 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
       var TOS = 0;
 
       var sync = options.sync || false;
-      var initialGas = options.initialGas || thisRuntime.INITIAL_GAS;
-      var initialRunGas = options.initialRunGas || initialGas * 10;
+      var defaultInitialGas = options.initialGas || thisRuntime.INITIAL_GAS;
+      var defaultInitialRunGas = options.initialRunGas || defaultInitialGas * 10;
+      function nextInitialGas() {
+        var schedule = thisRuntime.pauseSchedule;
+        if(schedule && schedule.initialGas) { return schedule.initialGas(); }
+        return defaultInitialGas;
+      }
+      function nextInitialRunGas() {
+        var schedule = thisRuntime.pauseSchedule;
+        if(schedule && schedule.initialRunGas) { return schedule.initialRunGas(); }
+        return defaultInitialRunGas;
+      }
+      var initialGas = nextInitialGas();
+      var initialRunGas = nextInitialRunGas();
       thisRuntime.GAS = initialGas;
       thisRuntime.RUNGAS = sync ? Infinity : initialRunGas;
 
@@ -3617,6 +3629,10 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
             val = restartVal;
             TOS++;
             RUN_ACTIVE = true;
+            // Must refill: a nested run during the pause may leave GAS <= 1,
+            // and an entry-check capture on the resumed frame drops its ans.
+            thisRuntime.GAS = nextInitialGas();
+            thisRuntime.RUNGAS = nextInitialRunGas();
             util.suspend(iter);
           },
           break: breakFun,
@@ -3668,11 +3684,20 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
             }
             while(theOneTrueStackHeight > 0) {
               if(!sync && thisRuntime.RUNGAS <= 1) {
-                thisRuntime.RUNGAS = initialRunGas;
+                thisRuntime.RUNGAS = nextInitialRunGas();
                 TOS++;
                 // CONSOLE.log("Setting timeout to resume iter");
                 util.suspend(iter);
                 return;
+              }
+              // A frame popped with GAS <= 1 (or RUNGAS <= 1) trips its entry
+              // check, which re-captures and replaces a delivered-but-unconsumed
+              // ans with UNINITIALIZED_ANSWER; keep both >= 2 at every pop.
+              if(thisRuntime.GAS <= 1) {
+                thisRuntime.GAS = nextInitialGas();
+              }
+              if(sync && thisRuntime.RUNGAS <= 1) {
+                thisRuntime.RUNGAS = nextInitialRunGas();
               }
               var next = theOneTrueStack[--theOneTrueStackHeight];
               // CONSOLE.log("ActivationRecord[" + theOneTrueStackHeight + "] = " + JSON.stringify(next, null, "  "));
@@ -3698,8 +3723,8 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
               if(next.fun instanceof Function && thisRuntime.isContinuation(val)) {
                 // console.log("BOUNCING");
                 BOUNCES++;
-                thisRuntime.GAS = initialGas;
-                thisRuntime.RUNGAS = initialRunGas;
+                thisRuntime.GAS = nextInitialGas();
+                thisRuntime.RUNGAS = nextInitialRunGas();
                 for(var i = val.stack.length - 1; i >= 0; i--) {
     //              console.error(e.stack[i].vars.length + " width;" + e.stack[i].vars + "; from " + e.stack[i].from + "; frame " + theOneTrueStackHeight);
                   theOneTrueStack[theOneTrueStackHeight++] = val.stack[i];
@@ -3736,7 +3761,7 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
             if(thisRuntime.isCont(e)) {
               // CONSOLE.log("BOUNCING");
               BOUNCES++;
-              thisRuntime.GAS = initialGas;
+              thisRuntime.GAS = nextInitialGas();
               for(var i = e.stack.length - 1; i >= 0; i--) {
               // CONSOLE.error(e.stack[i].vars.length + " width;" + e.stack[i].vars + "; from " + e.stack[i].from + "; frame " + theOneTrueStackHeight);
                 theOneTrueStack[theOneTrueStackHeight++] = e.stack[i];
@@ -4026,6 +4051,11 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
     }
 
     var INITIAL_GAS = theOutsideWorld.initialGas || 500;
+
+    // schedule :: { initialGas: () -> Number, initialRunGas: () -> Number }
+    function setPauseSchedule(schedule) {
+      thisRuntime.pauseSchedule = schedule;
+    }
 
     var DEBUGLOG = true;
     /**
@@ -4475,6 +4505,9 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
           return good;
         }
         function foldFun($ar) {
+          if (thisRuntime.isInitializedActivationRecord($ar)) {
+            if ($ar.ans === bad) { return $ar.ans; }
+          }
           var res = foldHelp();
           if(isContinuation(res)) {
             res.stack[thisRuntime.EXN_STACKHEIGHT++] = thisRuntime.makeActivationRecord(
@@ -6119,6 +6152,8 @@ function (Namespace, jsnumslib, codePoint, util, exnStackParser, loader, seedran
 
       'GAS': INITIAL_GAS,
       'INITIAL_GAS': INITIAL_GAS,
+      'pauseSchedule': theOutsideWorld.pauseSchedule || null,
+      'setPauseSchedule': setPauseSchedule,
 
       'jsnums': jsnums,
       'NumberErrbacks': NumberErrbacks,

--- a/lang/src/ts-compiler/src/compile-lib.ts
+++ b/lang/src/ts-compiler/src/compile-lib.ts
@@ -614,6 +614,7 @@ export function makeStandalone(
   for (const w of wl) {
     natives = [...w.locator.getNativeModules().map((n) => n.path), ...natives];
   }
+  natives.sort();
 
   let allCompileProblems: CS.CompileError[] = [];
   const staticModules = new J.JObj(CL.map_list<ToCompile, J.JFieldT>((w) => {
@@ -635,7 +636,13 @@ export function makeStandalone(
     new J.JField("disableAnnotationChecks",
       options.runtimeAnnotations
         ? new J.JFalse()
-        : new J.JTrue())
+        : new J.JTrue()),
+    new J.JField("pauseSchedule",
+      options.pauseSchedule === undefined
+        ? new J.JFalse()
+        : new J.JRawCode("(function(module) { var exports = module.exports;\n"
+            + options.pauseSchedule
+            + "\nreturn module.exports; })({ exports: {} })"))
   ));
 
   if (allCompileProblems.length > 0) {

--- a/lang/src/ts-compiler/src/compile-lib.ts
+++ b/lang/src/ts-compiler/src/compile-lib.ts
@@ -640,9 +640,7 @@ export function makeStandalone(
     new J.JField("pauseSchedule",
       options.pauseSchedule === undefined
         ? new J.JFalse()
-        : new J.JRawCode("(function(module) { var exports = module.exports;\n"
-            + options.pauseSchedule
-            + "\nreturn module.exports; })({ exports: {} })"))
+        : new J.JStr(options.pauseSchedule))
   ));
 
   if (allCompileProblems.length > 0) {

--- a/lang/src/ts-compiler/src/compile-structs.ts
+++ b/lang/src/ts-compiler/src/compile-structs.ts
@@ -1013,6 +1013,7 @@ export interface CompileOptions {
   depsFile: string;
   standaloneFile: string;
   urlFileMode: UrlFileMode;
+  pauseSchedule: string | undefined;
   // Set by some front ends (CLI/webworker); not part of the defaults.
   pipeline?: string;
   compileModule?: boolean;
@@ -1060,7 +1061,8 @@ export const defaultCompileOptions: CompileOptions = {
   htmlFile: undefined,
   depsFile: "build/bundled-node-deps.js",
   standaloneFile: "src/js/base/handalone.js",
-  urlFileMode: allRemote
+  urlFileMode: allRemote,
+  pauseSchedule: undefined
 };
 
 export function makeDefaultCompileOptions(thisPyretDir: string): CompileOptions {

--- a/lang/src/ts-compiler/src/pyret.ts
+++ b/lang/src/ts-compiler/src/pyret.ts
@@ -2,6 +2,7 @@
 // Invoked as `node build/ts-compiler/pyret.js <options>`.
 
 import * as P from 'path';
+import * as fs from 'fs';
 import * as C from './cmdline';
 import * as CLI from './cli-module-loader';
 import * as CS from './compile-structs';
@@ -98,6 +99,8 @@ export async function main(args: string[]): Promise<number> {
       C.flag(C.once, 'Ignore all annotations in the runtime, treating them as if they were blank.')],
     ['url-file-mode',
       C.nextValDefault(C.Str, 'all-remote', undefined, C.once, 'How to handle url-file imports (all-remote, all-local, or local-if-present)')],
+    ['pause-schedule',
+      C.nextVal(C.Str, C.once, 'JS file computing initial GAS/RUNGAS for the runtime; its code is baked into the standalone')],
   ]);
 
   const paramsParsed = C.parseArgs(options, args);
@@ -129,6 +132,8 @@ export async function main(args: string[]): Promise<number> {
     const moduleEval = !r.has('no-module-eval');
     const userAnnotations = !r.has('no-user-annotations');
     const runtimeAnnotations = !r.has('no-runtime-annotations');
+    const pauseSchedule: string | undefined =
+      r.has('pause-schedule') ? fs.readFileSync(r.get('pause-schedule'), { encoding: 'utf8' }) : undefined;
     if (r.has('builtin-js-dir')) {
       B.setBuiltinJsDirs(r.get('builtin-js-dir'));
     }
@@ -195,7 +200,8 @@ export async function main(args: string[]): Promise<number> {
           moduleEval: moduleEval,
           userAnnotations: userAnnotations,
           runtimeAnnotations: runtimeAnnotations,
-          urlFileMode: urlFileMode
+          urlFileMode: urlFileMode,
+          pauseSchedule: pauseSchedule
         });
       return successCode;
     } else if (r.has('serve')) {

--- a/lang/src/ts-compiler/tests/parity-test.sh
+++ b/lang/src/ts-compiler/tests/parity-test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Parity test: compile each test program with BOTH the Pyret-hosted
 # compiler (build/phaseA/pyret.jarr) and the TypeScript compiler
-# (build/ts-compiler/pyret.js), using the same options, run both
-# standalones, and compare stdout + exit codes.
+# (build/ts-compiler/pyret.js), using the same options, require the
+# standalones to be byte-identical, run both, and compare stdout +
+# exit codes.
 #
 # Run from the pyret-lang root (lang/): bash src/ts-compiler/tests/parity-test.sh
 
@@ -72,6 +73,11 @@ run_one() {
       echo "FAIL $base: compile error output differs (see $WORK/$base.compile.diff)"
       return 1
     fi
+  fi
+
+  if ! cmp -s "$dir_a/$base.jarr" "$dir_t/$base.jarr"; then
+    echo "FAIL $base: standalone bytes differ (cmp $dir_a/$base.jarr $dir_t/$base.jarr)"
+    return 1
   fi
 
   $NODE "$dir_a/$base.jarr" > "$dir_a/run.out" 2>&1

--- a/lang/src/ts-compiler/tests/programs/pause-schedule.arr
+++ b/lang/src/ts-compiler/tests/programs/pause-schedule.arr
@@ -1,0 +1,29 @@
+fun sum-to(n):
+  if n == 0: 0
+  else: n + sum-to(n - 1)
+  end
+end
+
+fun flip(n):
+  if n == 0: true
+  else: flop(n - 1)
+  end
+end
+
+fun flop(n):
+  if n == 0: false
+  else: flip(n - 1)
+  end
+end
+
+print(sum-to(4000))
+print("\n")
+print(flip(50000))
+print("\n")
+print(torepr(map(lam(x): x * x end, range(0, 20))))
+print("\n")
+
+check:
+  sum-to(1000) is 500500
+  flip(10001) is false
+end

--- a/lang/src/ts-compiler/tests/programs/pause-schedule.options
+++ b/lang/src/ts-compiler/tests/programs/pause-schedule.options
@@ -1,0 +1,1 @@
+--pause-schedule tests/pause-schedules/rand-small.js

--- a/lang/tests/pause-schedules/alternate.js
+++ b/lang/tests/pause-schedules/alternate.js
@@ -1,0 +1,11 @@
+var phase = 0;
+
+module.exports = {
+  initialGas: function() {
+    phase = phase + 1;
+    return (phase % 2) === 1 ? 5 : 100000;
+  },
+  initialRunGas: function() {
+    return (phase % 2) === 1 ? 100000 : 60;
+  }
+};

--- a/lang/tests/pause-schedules/const-medium.js
+++ b/lang/tests/pause-schedules/const-medium.js
@@ -1,0 +1,4 @@
+module.exports = {
+  initialGas: function() { return 100; },
+  initialRunGas: function() { return 1000; }
+};

--- a/lang/tests/pause-schedules/const-small.js
+++ b/lang/tests/pause-schedules/const-small.js
@@ -1,0 +1,4 @@
+module.exports = {
+  initialGas: function() { return 40; },
+  initialRunGas: function() { return 400; }
+};

--- a/lang/tests/pause-schedules/rand-small.js
+++ b/lang/tests/pause-schedules/rand-small.js
@@ -1,0 +1,18 @@
+function mulberry32(seed) {
+  var a = seed >>> 0;
+  return function() {
+    a = (a + 0x6D2B79F5) >>> 0;
+    var t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t = (t + Math.imul(t ^ (t >>> 7), t | 61)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+var gasRng = mulberry32(0x9E3779B9);
+var runGasRng = mulberry32(0x85EBCA6B);
+
+module.exports = {
+  initialGas: function() { return 2 + Math.floor(gasRng() * 63); },
+  initialRunGas: function() { return 8 + Math.floor(runGasRng() * 505); }
+};

--- a/lang/tests/pause-schedules/rand-wide.js
+++ b/lang/tests/pause-schedules/rand-wide.js
@@ -1,0 +1,18 @@
+function mulberry32(seed) {
+  var a = seed >>> 0;
+  return function() {
+    a = (a + 0x6D2B79F5) >>> 0;
+    var t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t = (t + Math.imul(t ^ (t >>> 7), t | 61)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+var gasRng = mulberry32(12345);
+var runGasRng = mulberry32(67890);
+
+module.exports = {
+  initialGas: function() { return 2 + Math.floor(gasRng() * 2000); },
+  initialRunGas: function() { return 10 + Math.floor(runGasRng() * 20000); }
+};

--- a/lang/tests/pause-schedules/sawtooth.js
+++ b/lang/tests/pause-schedules/sawtooth.js
@@ -1,0 +1,11 @@
+var gas = 1024;
+
+module.exports = {
+  initialGas: function() {
+    gas = gas <= 2 ? 1024 : (gas / 2);
+    return gas;
+  },
+  initialRunGas: function() {
+    return gas * 8;
+  }
+};

--- a/lang/tests/pyret/main2.arr
+++ b/lang/tests/pyret/main2.arr
@@ -39,6 +39,7 @@ import file("./tests/test-constants.arr") as _
 import file("./tests/test-constants-scope.arr") as _
 import file("./tests/test-timing.arr") as _
 import file("./tests/test-csv-table.arr") as _
+import file("./tests/test-pause-schedule.arr") as _
 import file("./tests/modules/include-shadow-same.arr") as _
 import file("./tests/modules/import-re-provided.arr") as _
 import file("./tests/modules/test-import-re-provided-data.arr") as _

--- a/lang/tests/pyret/tests/test-pause-schedule.arr
+++ b/lang/tests/pyret/tests/test-pause-schedule.arr
@@ -1,0 +1,129 @@
+import either as E
+import equality as EQ
+import valueskeleton as VS
+
+fun sum-to(n):
+  if n == 0: 0
+  else: n + sum-to(n - 1)
+  end
+where:
+  sum-to(0) is 0
+  sum-to(1000) is 500500
+  sum-to(5000) is 12502500
+end
+
+fun mutual-even(n):
+  if n == 0: true
+  else: mutual-odd(n - 1)
+  end
+end
+
+fun mutual-odd(n):
+  if n == 0: false
+  else: mutual-even(n - 1)
+  end
+where:
+  mutual-even(100000) is true
+  mutual-odd(100000) is false
+  mutual-even(100001) is false
+end
+
+data Peano:
+  | zero
+  | succ(prev :: Peano)
+sharing:
+  method to-num(self):
+    cases(Peano) self:
+      | zero => 0
+      | succ(p) => 1 + p.to-num()
+    end
+  end,
+  method plus(self, other):
+    cases(Peano) self:
+      | zero => other
+      | succ(p) => succ(p.plus(other))
+    end
+  end
+end
+
+fun make-peano(n):
+  if n == 0: zero
+  else: succ(make-peano(n - 1))
+  end
+end
+
+check "method-chain recursion under pause schedules":
+  p500 = make-peano(500)
+  p500.to-num() is 500
+  p500.plus(p500).to-num() is 1000
+  make-peano(2000).to-num() is 2000
+end
+
+data ModEq:
+  | mod-eq(n :: Number, tag)
+sharing:
+  method _equals(self, other, eq):
+    if num-modulo(self.n, 7) == num-modulo(other.n, 7):
+      eq(self.tag, other.tag)
+    else:
+      EQ.NotEqual("mod-7 mismatch", self, other)
+    end
+  end,
+  method _output(self):
+    VS.vs-constr("mod-eq", [list: VS.vs-value(num-modulo(self.n, 7)), VS.vs-value(self.tag)])
+  end
+end
+
+fun nest-mod-eq(n, inner):
+  if n == 0: inner
+  else: nest-mod-eq(n - 1, mod-eq(n, inner))
+  end
+end
+
+check "equality callbacks under pause schedules":
+  mod-eq(3, "a") is mod-eq(10, "a")
+  mod-eq(3, "a") is-not mod-eq(4, "a")
+  nest-mod-eq(200, mod-eq(0, "base")) is nest-mod-eq(200, mod-eq(7, "base"))
+  nest-mod-eq(200, mod-eq(0, "base")) is-not nest-mod-eq(200, mod-eq(1, "base"))
+  equal-always(range(0, 3000), range(0, 3000)) is true
+  equal-always([list: range(0, 100), range(0, 100)], [list: range(0, 100), range(0, 100)]) is true
+end
+
+check "torepr callbacks under pause schedules":
+  torepr(mod-eq(10, "x")) is 'mod-eq(3, "x")'
+  torepr(nest-mod-eq(100, mod-eq(0, "deep"))) is torepr(nest-mod-eq(100, mod-eq(7, "deep")))
+  (string-length(torepr(range(0, 1000))) > 3000) is true
+end
+
+fun deep-raise(n):
+  if n == 0: raise("boom-at-depth")
+  else: deep-raise(n - 1) + 1
+  end
+end
+
+check "run-task nesting under pause schedules":
+  cases(E.Either) run-task(lam(): sum-to(2000) end):
+    | left(v) => v is 2001000
+    | right(_) => raise("run-task should succeed")
+  end
+  cases(E.Either) run-task(lam(): sum-to(2000) + deep-raise(100) end):
+    | left(_) => raise("run-task should propagate the failure")
+    | right(_) => nothing
+  end
+end
+
+check "exceptions through deep stacks under pause schedules":
+  deep-raise(1000) raises "boom-at-depth"
+  run-task(lam(): deep-raise(500) end) satisfies E.is-right
+end
+
+check "runtime loops under pause schedules":
+  var acc = 0
+  each(lam(x): acc := acc + x end, range(0, 2000))
+  acc is 1999000
+  fold(lam(a, b): a + b end, 0, range(0, 2000)) is 1999000
+  map(lam(x): x * 2 end, range(0, 1000)).length() is 1000
+  filter(lam(x): num-modulo(x, 2) == 0 end, range(0, 1000)).length() is 500
+  string-length(string-repeat("ab", 5000)) is 10000
+  raw-array-fold(lam(a, b, _): a + b end, 0, raw-array-of(1, 5000), 0) is 5000
+end


### PR DESCRIPTION
…sting

Adds a --pause-schedule <file.js> compiler option to both the Pyret-hosted and TypeScript compilers. The file's contents are baked into the standalone's runtimeOptions as a module computing initialGas/initialRunGas getters; the runtime consults them at every gas-refill point. In the browser, a runtime is configured directly via setPauseSchedule -- no environment variables.

Six deterministic schedule profiles in lang/tests/pause-schedules/ (constant small/medium, seeded random small/wide, alternating, sawtooth), plus a make pause-schedule-test rule that runs the main2 suite under each profile requiring byte-equal output against the unscheduled baseline, and a byte- identity check of an .arr-compiled vs TS-compiled scheduled build.

Includes three stack-capture fixes in the stock runtime that stress-running under schedules exposed: refill on pause-resume, GAS/RUNGAS floors at pop time, and the fold entry-check re-capture path.