### PR TITLE
Fix #1928 (error rendering issue in TS mode)

### DIFF
--- a/code.pyret.org/src/web/js/ts-compiler-lib.js
+++ b/code.pyret.org/src/web/js/ts-compiler-lib.js
@@ -27,11 +27,12 @@
   requires: [
     { "import-type": "builtin", name: "load-lib" },
     { "import-type": "builtin", name: "either" },
-    { "import-type": "builtin", name: "error-display" }
+    { "import-type": "builtin", name: "error-display" },
+    { "import-type": "builtin", name: "ast" }
   ],
   nativeRequires: [],
   provides: {},
-  theModule: function(runtime, namespace, uri, loadLib, eitherLib, errorDisplayLib) {
+  theModule: function(runtime, namespace, uri, loadLib, eitherLib, errorDisplayLib, astLib) {
     var gf = runtime.getField;
     var gmf = function(m, f) { return gf(gf(m, "values"), f); };
     // NOTE: runtime.ffi is not fully populated until the ffi builtin
@@ -183,6 +184,13 @@
       return e && e.name === "PyretParseError" && typeof e.kind === "string";
     }
 
+    function tsCheckOpToPyret(op) {
+      var mkOp = gmf(astLib, op.$name);
+      var l = tsLocToPyret(op.l);
+      if(typeof op.op === "string") { return mkOp.app(l, op.op); }
+      return mkOp.app(l);
+    }
+
     function throwPyretParseError(e) {
       var loc = tsLocToPyret(e.loc);
       switch(e.kind) {
@@ -197,7 +205,7 @@
         case "parse-error-bad-operator":
           return runtime.ffi.throwParseErrorBadOper(loc);
         case "parse-error-bad-check-operator":
-          return runtime.ffi.throwParseErrorBadCheckOper(tsLocToPyret(e.op && e.op.l ? e.op.l : e.loc));
+          return runtime.ffi.throwParseErrorBadCheckOper(tsCheckOpToPyret(e.op));
         case "parse-error-colon-colon":
           return runtime.ffi.throwParseErrorColonColon(loc, e.nextToken);
         case "parse-error-bad-app":

--- a/code.pyret.org/test/errors.js
+++ b/code.pyret.org/test/errors.js
@@ -253,6 +253,43 @@ describe("Rendering errors", function() {
      "check:\n  f(g\n    is\n    h)\nend",
      "must be used inside a"],
 
+    // well-formedness
+    ["single-branch-if", "if true: 5 end", "if-expression"],
+    ["non-example", "examples: 2 + 2 end", "testing statement"],
+    ["block-needed", "fun f():\n  print(1)\n  2\nend\nv = f()", "multiple expressions"],
+    ["unwelcome-test-refinement", "check: raise('x') raises%(tostring) 'x' end", "may not be used with"],
+    ["no-arguments", "x = method(): 5 end", "should accept at least one argument"],
+    ["tuple-get-bad-index", "x = {1;2}\ny = x.{1001}", "There are no tuples that big"],
+    ["table-row-wrong-size", "t = table: a, b row: 1 end", "but the table header"],
+    ["table-duplicate-column-name", "t = table: a, a row: 1, 1 end", "have the same name"],
+    ["table-reducer-bad-column",
+     "t = table: a row: 1 end\nu = extend t using a:\n  c: running-sum of b\nend",
+     "is used with the reducer"],
+    ["table-sanitizer-bad-column",
+     "load-table: a\n  source: 5\n  sanitize b using c\nend",
+     "is used with the sanitizer"],
+    ["load-table-no-body", "load-table: a end", "has no information about how to load the table"],
+    ["load-table-bad-number-srcs",
+     "load-table: a\n  source: 5\n  source: 6\nend",
+     "but it should only specify one"],
+
+    // scope resolution
+    ["unbound-id", "y = zzz", "is unbound"],
+    ["unbound-type-id", "y :: NotAType = 5", "is used to indicate a type"],
+    ["bad-assignment", "x = 5\nx := 6", "to refer to a variable definition"],
+    ["name-not-provided", "import lists as L\ninclude from L: zzz end", "is not provided as a value"],
+
+    // type checker
+    ["toplevel-unann", "fun f(x): x end\nv = f(1)", "needs a type annotation", {typeCheck: true}],
+    ["incorrect-number-of-args",
+     "fun f(x :: Number) -> Number: x end\nv = f(1, 2)",
+     "the same number of arguments", {typeCheck: true}],
+    ["apply-non-function", "x = 5\ny = x(1)", "to evaluate to a function value", {typeCheck: true}],
+    ["incorrect-type-expression", "o = {x: 5}\ny = o!x", "The type checker rejected the expression", {typeCheck: true}],
+    ["unnecessary-branch",
+     "v = cases(Option) none:\n  | none => 1\n  | empty => 2\nend",
+     "have a variant of the same name", {typeCheck: true}],
+
     ["incorrect-number-of-bindings",
      "data D:\n  | d(a :: Number, b :: Number)\nend\nfun f(x :: D) -> Number:\n  cases(D) x:\n    | d(a) => 1\n  end\nend",
      "same number of field bindings",

--- a/code.pyret.org/test/errors.js
+++ b/code.pyret.org/test/errors.js
@@ -249,6 +249,10 @@ describe("Rendering errors", function() {
      "load-table: h1, h2\n  source: src1\n  sanitize h1 using s1\n  sanitize h2 using s2\n  sanitize h1 using s1\nend",
      "is already sanitized by the sanitizer sanitize h1 using s1"],
 
+    ["bad-check-operator-outside-test",
+     "check:\n  f(g\n    is\n    h)\nend",
+     "must be used inside a"],
+
     ["incorrect-number-of-bindings",
      "data D:\n  | d(a :: Number, b :: Number)\nend\nfun f(x :: D) -> Number:\n  cases(D) x:\n    | d(a) => 1\n  end\nend",
      "same number of field bindings",

--- a/lang/src/js/trove/ffi.js
+++ b/lang/src/js/trove/ffi.js
@@ -499,8 +499,10 @@
     function throwParseErrorBadOper(loc) {
       raise(err("parse-error-bad-operator")(loc));
     }
-    function throwParseErrorBadCheckOper(loc) {
-      raise(err("parse-error-bad-check-operator")(loc));
+    // NOTE(joe Sep 2026): unique among these parse-level errors, this takes an
+    // AST node, not a loc
+    function throwParseErrorBadCheckOper(opNode) {
+      raise(err("parse-error-bad-check-operator")(opNode));
     }
     function throwParseErrorColonColon(loc, nextToken) {
       raise(err("parse-error-colon-colon")(loc));


### PR DESCRIPTION
A TS-internal error representation made it to the renderer. Fix it to reconstruct the right AST node at the cpo conversion layer, and add tests for related cases (errors that embed an AST node for rendering)