### PR TITLE
Name default where: blocks "where: block for fun f(...)"

### DIFF
--- a/lang/src/arr/compiler/desugar-check.arr
+++ b/lang/src/arr/compiler/desugar-check.arr
@@ -165,7 +165,7 @@ fun get-checks(stmts):
         cases(A.Expr) stmt:
           | s-fun(l, name, _, _, _, _, _, _, _check, _) =>
             cases(Option) _check:
-              | some(v) => link(check-info(l, name, v.visit(check-stmts-visitor), true), add-check(rest))
+              | some(v) => link(check-info(l, "where: block for fun " + name + "(...)", v.visit(check-stmts-visitor), true), add-check(rest))
               | none => add-check(rest)
             end
           | s-data(l, name, _, _, _, _, _, _check) =>


### PR DESCRIPTION
Joe says:

Mechanical + decision blending Ben's answer and Daniel's from the original

Claude said:

Retarget of brownplt/pyret-lang#1773 (originally 16aaf6435e against horizon) at drydock, with the path moved under lang/ for the monorepo layout.

The default name of a function's where: block was just the function name. With --checks "only:<pat>" doing substring matching on check block names, a richer default lets a filter say "the where: block for f" rather than matching any check whose name happens to contain "f".

The name is now the literal string "where: block for fun " + name + "(...)". The "(...)" is verbatim, per review: it signals a function header without claiming to be its signature, and it avoids baking parameter names, which may not be stable across student submissions, into the test name. The "where:" keeps the colon, matching how the block is written in source.

CLI output for a failing where: block on `fun f(x)` changes from

    test.arr:1:0-5:3: f (0/1)

to

    test.arr:1:0-5:3: where: block for fun f(...) (0/1)

Only s-fun where: blocks are renamed, as in the original PR; data where: blocks and explicitly named check/examples blocks are unchanged. No tests or CPO rendering depend on the old default name.