### PR TITLE
Add cookie/interface support for getting folks to beta-test TS mode

### DIFF
--- a/code.pyret.org/src/server.js
+++ b/code.pyret.org/src/server.js
@@ -628,13 +628,62 @@ function start(config, onServerReady) {
     });
   });
 
+  // Sticky ts opt-in for this browser: /settings/try-ts pins the ts flavor
+  // in a cookie so ordinary visits -- bookmarks, Drive opens, share links,
+  // none of which carry ?compiler= -- stay on it; /settings/clear-ts unpins.
+  // A cookie (not localStorage) because the flavor is resolved server-side
+  // at render time: the page's preload link and window.PYRET must point at
+  // the jarr that will actually load. 180 days: a class that opts in at the
+  // start of a term shouldn't silently revert mid-course; stale opt-ins are
+  // harmless because this resolution code remains the kill switch.
+  var COMPILER_COOKIE = "pyret-compiler";
+  var COMPILER_COOKIE_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000;
+  app.get("/settings/try-ts", function(req, res) {
+    res.cookie(COMPILER_COOKIE, "ts", {
+      maxAge: COMPILER_COOKIE_MAX_AGE_MS,
+      sameSite: "lax"
+    });
+    res.type("text/plain").send(
+      "You visited /settings/try-ts, so in this browser you'll use a new version\n" +
+      "of Pyret that is faster. This choice is remembered for around 6 months.\n" +
+      "\n" +
+      "You can visit /settings/clear-ts to clear this option.\n" +
+      "\n" +
+      "If anything seems off, turning it off and telling your teacher/instructor,\n" +
+      "or someone from the Pyret team, what you saw helps a lot.\n" +
+      "\n" +
+      "Thanks for testing it out!\n" +
+      "- The Pyret Team\n"
+    );
+  });
+  app.get("/settings/clear-ts", function(req, res) {
+    res.clearCookie(COMPILER_COOKIE);
+    res.type("text/plain").send(
+      "You visited /settings/clear-ts, so in this browser you'll use the regular\n" +
+      "Pyret version.\n" +
+      "\n" +
+      "You can visit /settings/try-ts to turn on the TypeScript mode (or back on,\n" +
+      "if you've used it before). It is an experimental faster version of the\n" +
+      "compiler.\n" +
+      "\n" +
+      "Thanks!\n" +
+      "- The Pyret Team\n"
+    );
+  });
+
   app.get("/editor", function(req, res) {
     // The compiler flavor can be chosen per request (?compiler=ts|pyret),
-    // falling back to the CPO_COMPILER env default. Resolving it here (in
-    // addition to the client-side check in editor.html) keeps the preload
-    // link and window.PYRET pointing at the jarr that will actually load,
-    // so the stock jarr isn't downloaded pointlessly in ts mode.
-    var compiler = req.query.compiler || defaultOpts.CPO_COMPILER;
+    // then by the sticky opt-in cookie (see /settings/try-ts above), then
+    // the CPO_COMPILER env default. Resolving it here (in addition to the
+    // client-side check in editor.html) keeps the preload link and
+    // window.PYRET pointing at the jarr that will actually load, so the
+    // stock jarr isn't downloaded pointlessly in ts mode. Only known
+    // flavor names are honored from the cookie; anything else falls
+    // through to the default. (No route sets "pyret" today, but honoring
+    // it gives a future ramp a per-user pin-to-stock for free.)
+    var cookieFlavor = req.cookies && req.cookies[COMPILER_COOKIE];
+    if (cookieFlavor !== "ts" && cookieFlavor !== "pyret") { cookieFlavor = ""; }
+    var compiler = req.query.compiler || cookieFlavor || defaultOpts.CPO_COMPILER;
     var compilerOpts = (compiler === "ts" && defaultOpts.PYRET_TS)
       ? { PYRET: defaultOpts.PYRET_TS, CPO_COMPILER: "ts" }
       : {};

--- a/code.pyret.org/src/web/css/editor.css
+++ b/code.pyret.org/src/web/css/editor.css
@@ -902,6 +902,27 @@ body.hideFooter .replContainer {
   padding-bottom: 0rem;
 }
 
+/* Unobtrusive compiler-flavor indicator, pinned to the REPL's corner just
+   above the footer padding. Hidden unless the page resolved to the ts
+   flavor (editor.html adds .ts-mode to <html> in the same branch that
+   swaps PYRET), so the stock editor shows nothing new. */
+#compilerFlavorBadge {
+  display: none;
+  position: absolute;
+  right: 8px;
+  bottom: calc(2.5rem + 4px);
+  font-size: 11px;
+  color: #999;
+  z-index: 1;
+  user-select: none;
+}
+html.ts-mode #compilerFlavorBadge {
+  display: block;
+}
+body.hideFooter #compilerFlavorBadge {
+  bottom: 4px;
+}
+
 body.hideHeader .replContainer {
   padding-top: 0px;
 }

--- a/code.pyret.org/src/web/editor.html
+++ b/code.pyret.org/src/web/editor.html
@@ -394,7 +394,7 @@
 </div>
 <div id="REPL" class="replContainer" role="region" aria-label="Interactions">
 <div id="handle" class="ui-resizable-handle ui-resizable-w"></div>
-<div id="compilerFlavorBadge" title="This session uses the TypeScript port of the Pyret compiler">(ts mode)</div>
+<div id="compilerFlavorBadge" title="This session uses the TypeScript version of Pyret. Visit /settings/clear-ts to turn it off.">(ts mode)</div>
 </div>
 <div id="help-keys">
   <p><b>Press <kbd>Esc</kbd> to close this help window</b></p>

--- a/code.pyret.org/src/web/editor.html
+++ b/code.pyret.org/src/web/editor.html
@@ -25,6 +25,9 @@
     if(m) { window.CPO_COMPILER = decodeURIComponent(m[1]); }
     if(window.CPO_COMPILER === "ts" && window.PYRET_TS) {
       window.PYRET = window.PYRET_TS;
+      // Lets pure CSS show ts-only chrome (the "(ts mode)" badge in the
+      // REPL corner) without another script running at DOM-ready.
+      document.documentElement.classList.add("ts-mode");
       // In gzipped mode the host may serve assets without an executable MIME
       // type (nosniff), which refuses a <script src> load outright --
       // beforePyret.js fetches the compiler bundle alongside the jarr instead.
@@ -391,6 +394,7 @@
 </div>
 <div id="REPL" class="replContainer" role="region" aria-label="Interactions">
 <div id="handle" class="ui-resizable-handle ui-resizable-w"></div>
+<div id="compilerFlavorBadge" title="This session uses the TypeScript port of the Pyret compiler">(ts mode)</div>
 </div>
 <div id="help-keys">
   <p><b>Press <kbd>Esc</kbd> to close this help window</b></p>

--- a/lang/src/arr/compiler/anf-loop-compiler.arr
+++ b/lang/src/arr/compiler/anf-loop-compiler.arr
@@ -923,7 +923,7 @@ end
 # fresh-id/js-id-of minting, get-loc interning, dispatch-table pushes --
 # therefore happens after all of its body's, which is what lets a
 # consumer of a flattened statement chain walk it as one backward loop.
-fun get-remaining-code(compiler, opt-dest, rest, ans) -> {J.JBlock;CList<J.JCase>}:
+fun get-remaining-code(compiler, opt-dest, rest :: DAG.CaseResults%(is-c-block), ans) -> {J.JBlock;CList<J.JCase>}:
   compiled-body = cases(Option) opt-dest:
     | some(dest) =>
       compile-annotated-let(compiler, dest, c-exp(j-id(ans), cl-empty), rest)
@@ -938,7 +938,7 @@ end
 # their block of code is done
 fun get-new-cases(compiler, opt-dest, opt-rest, ans) -> {CList<J.JBlock>; J.JExpr}:
   cases(Option) opt-rest:
-    | some(rest) =>
+    | some(rest :: DAG.CaseResults%(is-c-block)) =>
       pre-body-label = compiler.make-label()
       {next-block; next-cases} = get-remaining-code(compiler, opt-dest, rest, ans)
       remaining-cases = cl-cons(j-case(pre-body-label, next-block), next-cases)
@@ -1142,7 +1142,7 @@ fun compile-flat-app(l, compiler, opt-dest, f, args, opt-rest, app-info, is-defi
   # portions: 1) the code that can be in the same "block" (or case region)
   # and 2) the rest of the case statements
   {remaining-code; new-cases} = cases (Option) opt-rest:
-    | some(rest) =>
+    | some(rest :: DAG.CaseResults%(is-c-block)) =>
       get-remaining-code(compiler, opt-dest, rest, ans)
     | none =>
       # Special case: there is no more code after this so just jump to the
@@ -1423,7 +1423,7 @@ fun compile-flat-prim-app(l, compiler, opt-dest, f, args, opt-rest):
   # portions: 1) the code that can be in the same "block" (or case region)
   # and 2) the rest of the case statements
   {remaining-code; new-cases} = cases (Option) opt-rest:
-    | some(rest) =>
+    | some(rest :: DAG.CaseResults%(is-c-block)) =>
       get-remaining-code(compiler, opt-dest, rest, ans)
     | none =>
       # Special case: there is no more code after this so just jump to the

--- a/lang/src/arr/compiler/anf-loop-compiler.arr
+++ b/lang/src/arr/compiler/anf-loop-compiler.arr
@@ -917,26 +917,30 @@ fun compile-annotated-let(visitor, b :: BindType, compiled-e :: DAG.CaseResults%
   end
 end
 
-fun get-remaining-code(compiler, opt-dest, body, ans) -> {J.JBlock;CList<J.JCase>}:
-  compiled-body = body.visit(compiler)
-  shadow compiled-body = cases(Option) opt-dest:
+# The rest of the chain is compiled BEFORE the head that precedes it (see
+# the compiler-visitor's a-let/a-seq), so these take an already-compiled
+# `rest` rather than an AExpr to visit. Every effect a head performs --
+# fresh-id/js-id-of minting, get-loc interning, dispatch-table pushes --
+# therefore happens after all of its body's, which is what lets a
+# consumer of a flattened statement chain walk it as one backward loop.
+fun get-remaining-code(compiler, opt-dest, rest, ans) -> {J.JBlock;CList<J.JCase>}:
+  compiled-body = cases(Option) opt-dest:
     | some(dest) =>
-      compiled-binding = compile-annotated-let(compiler, dest, c-exp(j-id(ans), cl-empty), compiled-body)
-      compiled-binding
+      compile-annotated-let(compiler, dest, c-exp(j-id(ans), cl-empty), rest)
     | none =>
-      compiled-body
+      rest
   end
 
   {compiled-body.block; compiled-body.new-cases}
 end
 
-# Return code for opt-body and the label the caller should jump to after
+# Return code for opt-rest and the label the caller should jump to after
 # their block of code is done
-fun get-new-cases(compiler, opt-dest, opt-body, ans) -> {CList<J.JBlock>; J.JExpr}:
-  cases(Option) opt-body:
-    | some(compiled-body) =>
+fun get-new-cases(compiler, opt-dest, opt-rest, ans) -> {CList<J.JBlock>; J.JExpr}:
+  cases(Option) opt-rest:
+    | some(rest) =>
       pre-body-label = compiler.make-label()
-      {next-block; next-cases} = get-remaining-code(compiler, opt-dest, compiled-body, ans)
+      {next-block; next-cases} = get-remaining-code(compiler, opt-dest, rest, ans)
       remaining-cases = cl-cons(j-case(pre-body-label, next-block), next-cases)
 
       {remaining-cases; pre-body-label}
@@ -944,7 +948,7 @@ fun get-new-cases(compiler, opt-dest, opt-body, ans) -> {CList<J.JBlock>; J.JExp
   end
 end
 
-fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-body):
+fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-rest):
   ans = compiler.cur-ans
   step = compiler.cur-step
   compiled-obj = obj.visit(compiler).exp
@@ -966,7 +970,7 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
             j-str(methname),
             compiler.get-loc(l)],
           compiled-args)))
-    {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+    {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
     c-block(j-block([clist:
       j-expr(j-assign(step, after-app-label)),
       j-expr(j-assign(ans, call)),
@@ -977,7 +981,7 @@ fun compile-split-method-app(l, compiler, opt-dest, obj, methname, args, opt-bod
     colon-field = rt-method("getColonFieldLoc", [clist: obj-id, j-str(methname), compiler.get-loc(l)])
     colon-field-id = j-id(fresh-id(compiler-name("field")))
     check-method = rt-method("isMethod", [clist: colon-field-id])
-    {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+    {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
     c-block(
       j-block([clist:
           # Update step before the call, so that if it runs out of gas, the resumer goes to the right step
@@ -1062,12 +1066,12 @@ fun get-assignments(lst :: List<J.JExpr>, limit :: Number) -> {List<J.JStmt>; Li
   end
 end
 
-fun compile-split-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-definitely-fn):
+fun compile-split-app(l, compiler, opt-dest, f, args, opt-rest, app-info, is-definitely-fn):
   ans = compiler.cur-ans
   step = compiler.cur-step
   compiled-f = f.visit(compiler).exp
   compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
-  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
   if app-info.is-recursive and
      app-info.is-tail and
      compiler.allow-tco and
@@ -1123,7 +1127,7 @@ fun j-block-to-stmt-list(b :: J.JBlock) -> CL.ConcatList<J.JStmt>:
   end
 end
 
-fun compile-flat-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-definitely-fn) block:
+fun compile-flat-app(l, compiler, opt-dest, f, args, opt-rest, app-info, is-definitely-fn) block:
   ans = compiler.cur-ans
   compiled-f = f.visit(compiler).exp
   compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
@@ -1134,12 +1138,12 @@ fun compile-flat-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-defi
     j-expr(wrap-with-srcnode(l, j-assign(ans, app(l, compiled-f, compiled-args))))
   ]
 
-  # Compile the body of the let. We split it into two portions:
-  # 1) the code that can be in the same "block" (or case region) and
-  # 2) the rest of the case statements
-  {remaining-code; new-cases} = cases (Option) opt-body:
-    | some(body) =>
-      get-remaining-code(compiler, opt-dest, body, ans)
+  # Splice in the already-compiled rest of the let. We split it into two
+  # portions: 1) the code that can be in the same "block" (or case region)
+  # and 2) the rest of the case statements
+  {remaining-code; new-cases} = cases (Option) opt-rest:
+    | some(rest) =>
+      get-remaining-code(compiler, opt-dest, rest, ans)
     | none =>
       # Special case: there is no more code after this so just jump to the
       # special last block in the function
@@ -1158,11 +1162,11 @@ fun compile-flat-app(l, compiler, opt-dest, f, args, opt-body, app-info, is-defi
     new-cases)
 end
 
-fun compile-split-if(compiler, opt-dest, cond, consq, alt, opt-body):
+fun compile-split-if(compiler, opt-dest, cond, consq, alt, opt-rest):
   consq-label = compiler.make-label()
   alt-label = compiler.make-label()
   ans = compiler.cur-ans
-  {after-if-cases; after-if-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+  {after-if-cases; after-if-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
   compiler-after-if = compiler.{cur-target: after-if-label}
   compiled-consq = consq.visit(compiler-after-if)
   compiled-alt = alt.visit(compiler-after-if)
@@ -1281,9 +1285,9 @@ fun compile-inline-cases-branch(compiler, compiled-val, branch, compiled-body, c
     c-block(j-block(cl-append(preamble, compiled-body.block.stmts)), compiled-body.new-cases)
   end
 end
-fun compile-split-cases(compiler, cases-loc, opt-dest, typ, val :: N.AVal, branches :: List<N.ACasesBranch>, _else :: N.AExpr, opt-body :: Option<N.AExpr>) block:
+fun compile-split-cases(compiler, cases-loc, opt-dest, typ, val :: N.AVal, branches :: List<N.ACasesBranch>, _else :: N.AExpr, opt-rest :: Option<DAG.CaseResults%(is-c-block)>) block:
   compiled-val = val.visit(compiler).exp
-  {after-cases-cases; after-cases-label} = get-new-cases(compiler, opt-dest, opt-body, compiler.cur-ans)
+  {after-cases-cases; after-cases-label} = get-new-cases(compiler, opt-dest, opt-rest, compiler.cur-ans)
   compiler-after-cases = compiler.{cur-target: after-cases-label}
   compiled-branches = branches.map(compile-cases-branch(compiler-after-cases, compiled-val, _, cases-loc))
   compiled-else = _else.visit(compiler-after-cases)
@@ -1318,14 +1322,14 @@ fun compile-split-cases(compiler, cases-loc, opt-dest, typ, val :: N.AVal, branc
     new-cases)
 end
 
-fun compile-split-update(compiler, loc, opt-dest, obj :: N.AVal, fields :: List<N.AField>, opt-body :: Option<N.AExpr>):
+fun compile-split-update(compiler, loc, opt-dest, obj :: N.AVal, fields :: List<N.AField>, opt-rest :: Option<DAG.CaseResults%(is-c-block)>):
   ans = compiler.cur-ans
   step = compiler.cur-step
   compiled-obj = obj.visit(compiler).exp
   compiled-field-vals = CL.map_list(lam(a): a.value.visit(compiler).exp end, fields)
   field-names = CL.map_list(lam(f): j-str(f.name) end, fields)
   field-locs = CL.map_list(lam(f): compiler.get-loc(f.l) end, fields)
-  {new-cases; after-update-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+  {new-cases; after-update-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
   c-block(
     j-block([clist:
         # Update step before the call, so that if it runs out of gas, the resumer goes to the right step
@@ -1350,7 +1354,7 @@ end
 fun compile-a-app(l :: N.Loc, f :: N.AVal, args :: List<N.AVal>,
     compiler,
     b :: Option<BindType>,
-    opt-body :: Option<N.AExpr>,
+    opt-rest :: Option<DAG.CaseResults%(is-c-block)>,
     app-info :: A.AppInfo):
 
   is-safe-id = N.is-a-id(f) or N.is-a-id-safe-letrec(f)
@@ -1361,7 +1365,7 @@ fun compile-a-app(l :: N.Loc, f :: N.AVal, args :: List<N.AVal>,
   end
 
   is-fn = is-safe-id and is-id-fn-name(compiler.flatness-env, f.id.key())
-  app-compiler(l, compiler, b, f, args, opt-body, app-info, is-fn)
+  app-compiler(l, compiler, b, f, args, opt-rest, app-info, is-fn)
 end
 
 fun compile-a-lam(compiler, l :: Loc, name :: String, args :: List<N.ABind>, ret :: A.Ann, body :: N.AExpr, bind-opt :: Option<BindType>) block:
@@ -1389,11 +1393,11 @@ fun compile-a-lam(compiler, l :: Loc, name :: String, args :: List<N.ABind>, ret
 end
 
 
-fun compile-split-prim-app(l, compiler, opt-dest, f, args, opt-body):
+fun compile-split-prim-app(l, compiler, opt-dest, f, args, opt-rest):
   ans = compiler.cur-ans
   step = compiler.cur-step
   compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
-  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-body, ans)
+  {new-cases; after-app-label} = get-new-cases(compiler, opt-dest, opt-rest, ans)
   c-block(
     j-block(
       # Update step before the call, so that if it runs out of gas,
@@ -1408,19 +1412,19 @@ fun compile-split-prim-app(l, compiler, opt-dest, f, args, opt-body):
 end
 
 
-fun compile-flat-prim-app(l, compiler, opt-dest, f, args, opt-body):
+fun compile-flat-prim-app(l, compiler, opt-dest, f, args, opt-rest):
   ans = compiler.cur-ans
   compiled-args = CL.map_list(lam(a): a.visit(compiler).exp end, args)
 
   # Generate the code for calling the function
   call-code = j-expr(wrap-with-srcnode(l, j-assign(ans, rt-method(f, compiled-args))))
 
-  # Compile the body of the let. We split it into two portions:
-  # 1) the code that can be in the same "block" (or case region) and
-  # 2) the rest of the case statements
-  {remaining-code; new-cases} = cases (Option) opt-body:
-    | some(body) =>
-      get-remaining-code(compiler, opt-dest, body, ans)
+  # Splice in the already-compiled rest of the let. We split it into two
+  # portions: 1) the code that can be in the same "block" (or case region)
+  # and 2) the rest of the case statements
+  {remaining-code; new-cases} = cases (Option) opt-rest:
+    | some(rest) =>
+      get-remaining-code(compiler, opt-dest, rest, ans)
     | none =>
       # Special case: there is no more code after this so just jump to the
       # special last block in the function
@@ -1442,7 +1446,7 @@ end
 fun compile-a-prim-app(l :: N.Loc, f :: String, args :: List<N.AVal>,
     compiler,
     b :: Option<BindType>,
-    opt-body :: Option<N.AExpr>,
+    opt-rest :: Option<DAG.CaseResults%(is-c-block)>,
     app-info :: A.PrimAppInfo):
 
   app-compiler = if app-info.needs-step:
@@ -1450,23 +1454,23 @@ fun compile-a-prim-app(l :: N.Loc, f :: String, args :: List<N.AVal>,
   else:
     compile-flat-prim-app
   end
-  app-compiler(l, compiler, b, f, args, opt-body)
+  app-compiler(l, compiler, b, f, args, opt-rest)
 end
 
-fun compile-lettable(compiler, b :: Option<BindType>, e :: N.ALettable, opt-body :: Option<N.AExpr>, else-case :: (DAG.CaseResults -> DAG.CaseResults)):
+fun compile-lettable(compiler, b :: Option<BindType>, e :: N.ALettable, opt-rest :: Option<DAG.CaseResults%(is-c-block)>, else-case :: (DAG.CaseResults -> DAG.CaseResults)):
   cases(N.ALettable) e:
     | a-prim-app(l2, f, args, app-info) =>
-      compile-a-prim-app(l2, f, args, compiler, b, opt-body, app-info)
+      compile-a-prim-app(l2, f, args, compiler, b, opt-rest, app-info)
     | a-app(l2, f, args, app-info) =>
-      compile-a-app(l2, f, args, compiler, b, opt-body, app-info)
+      compile-a-app(l2, f, args, compiler, b, opt-rest, app-info)
     | a-method-app(l2, obj, m, args) =>
-      compile-split-method-app(l2, compiler, b, obj, m, args, opt-body)
+      compile-split-method-app(l2, compiler, b, obj, m, args, opt-rest)
     | a-if(l2, cond, then, els) =>
-      compile-split-if(compiler, b, cond, then, els, opt-body)
+      compile-split-if(compiler, b, cond, then, els, opt-rest)
     | a-cases(l2, typ, val, branches, _else) =>
-      compile-split-cases(compiler, l2, b, typ, val, branches, _else, opt-body)
+      compile-split-cases(compiler, l2, b, typ, val, branches, _else, opt-rest)
     | a-update(l2, obj, fields) =>
-      compile-split-update(compiler, l2, b, obj, fields, opt-body)
+      compile-split-update(compiler, l2, b, obj, fields, opt-rest)
     | a-lam(l2, name, args, ret, body) =>
       compiled-e = compile-a-lam(compiler, l2, name, args, ret, body, b)
       else-case(compiled-e)
@@ -1590,8 +1594,8 @@ compiler-visitor = {
             cl-append(_, visited-body.block.stmts)),
           visited-body.new-cases)
       | a-newtype-bind(l2, name, nameb) =>
-        brander-id = js-id-of(nameb)
         visited-body = body.visit(self)
+        brander-id = js-id-of(nameb)
         c-block(
           j-block(
             [clist:
@@ -1603,14 +1607,14 @@ compiler-visitor = {
     end
   end,
   method a-let(self, _, b :: N.ABind, e :: N.ALettable, body :: N.AExpr):
-    compile-lettable(self, some(b-let(b)), e, some(body), lam(compiled-e):
-      compiled-body = body.visit(self)
+    compiled-body = body.visit(self)
+    compile-lettable(self, some(b-let(b)), e, some(compiled-body), lam(compiled-e):
       compile-annotated-let(self, b-let(b), compiled-e, compiled-body)
     end)
   end,
   method a-arr-let(self, _, b :: N.ABind, idx :: Number, e :: N.ALettable, body :: N.AExpr):
-    compile-lettable(self, some(b-array(b, idx)), e, some(body), lam(compiled-e):
-      compiled-body = body.visit(self)
+    compiled-body = body.visit(self)
+    compile-lettable(self, some(b-array(b, idx)), e, some(compiled-body), lam(compiled-e):
       compile-annotated-let(self, b-array(b, idx), compiled-e, compiled-body)
     end)
   end,
@@ -1629,8 +1633,8 @@ compiler-visitor = {
       compiled-body.new-cases)
   end,
   method a-seq(self, _, e1, e2):
-    compile-lettable(self, none, e1, some(e2), lam(e1-visit):
-      e2-visit = e2.visit(self)
+    e2-visit = e2.visit(self)
+    compile-lettable(self, none, e1, some(e2-visit), lam(e1-visit):
       first-stmt = if J.is-JStmt(e1-visit.exp): e1-visit.exp else: j-expr(e1-visit.exp) end
       c-block(
         j-block(cl-append(e1-visit.other-stmts, cl-cons(first-stmt, e2-visit.block.stmts))),

--- a/lang/src/ts-compiler/README.md
+++ b/lang/src/ts-compiler/README.md
@@ -153,7 +153,7 @@ generates the browserify entry; `make web-ts` there builds
 Because browsers have fixed ~1MB stacks (no `--stack-size` escape
 hatch), every per-statement recursion in the pipeline is implemented
 iteratively: the ANF spine (`anfLinear` in `anf.ts`), the splitting
-code generator (generators + the `runChain` driver in
+code generator (`compileAExpr`'s backward walk over a chain's heads in
 `anf-loop-compiler.ts`), scope resolution (`desugarScopeBlock`'s step
 driver), the flatness environment passes, and DAG liveness
 (`computeLiveVars`). All of these preserve the exact statement/effect

--- a/lang/src/ts-compiler/src/anf-loop-compiler.ts
+++ b/lang/src/ts-compiler/src/anf-loop-compiler.ts
@@ -1097,208 +1097,122 @@ export function compileAnnotatedLet(
 }
 
 /*
-  The original recursive implementation compiled each head by doing some
-  work, compiling the entire rest of the chain, and then wrapping the
-  compiled rest -- one stack frame per statement. Here each head's
-  compilation is split at exactly that point: a "pre" phase (the work
-  done before the rest -- visiting operand values, minting labels and
-  fresh ids) run in a forward loop, and a "post" phase (the work done
-  after -- wrapping the destination binding, assembling the block and
-  case list) folded backward from the compiled tail. The effect order
-  (jsIdOf/freshId minting, makeLabel, getLoc interning, dispatch-table
-  pushes) is kept exactly the same, so the generated code is identical.
+  A statement chain is compiled from the tail outward: the tail lettable
+  first, then each head wrapped around the already-compiled rest. That is
+  also the order the Pyret compiler works in -- its a-let/a-seq visit the
+  body before handing the compiled result to compile-lettable (see the
+  comment on get-remaining-code in anf-loop-compiler.arr) -- so every
+  head's effects (freshId/jsIdOf minting, getLoc interning, dispatch-table
+  pushes) happen after all of its body's, and the generated code matches.
+  Chains are flat, so the backward walk costs no stack per statement.
 */
-type HeadPost = (rest: DAG.CBlock) => DAG.CBlock;
-
 export function compileAExpr(compiler: CompilerVisitor, ae: N.AExpr): DAG.CBlock {
-  const posts: HeadPost[] = [];
-  for (const head of ae.heads) {
-    posts.push(preHead(compiler, head));
+  let rest = compileLettable(compiler, undefined, ae.e, undefined,
+    (compiledE) => tailLettable(compiler, compiledE));
+  for (let i = ae.heads.length - 1; i >= 0; i--) {
+    rest = compileHead(compiler, ae.heads[i], rest);
   }
-  let cur = compileTailLettable(compiler, ae.e);
-  for (let i = posts.length - 1; i >= 0; i--) {
-    cur = posts[i](cur);
-  }
-  return cur;
+  return rest;
 }
 
-function preHead(compiler: CompilerVisitor, head: N.AExprHead): HeadPost {
+function compileHead(compiler: CompilerVisitor, head: N.AExprHead, rest: DAG.CBlock): DAG.CBlock {
   switch (head.$name) {
-    case 'a-let':
-      return preLettable(compiler, new BLet(head.bind), head.e);
-    case 'a-arr-let':
-      return preLettable(compiler, new BArray(head.bind, head.idx), head.e);
+    case 'a-let': {
+      const b = new BLet(head.bind);
+      return compileLettable(compiler, b, head.e, rest,
+        (compiledE) => compileAnnotatedLet(compiler, b, compiledE, rest));
+    }
+    case 'a-arr-let': {
+      const b = new BArray(head.bind, head.idx);
+      return compileLettable(compiler, b, head.e, rest,
+        (compiledE) => compileAnnotatedLet(compiler, b, compiledE, rest));
+    }
     case 'a-seq':
-      return preLettable(compiler, undefined, head.e1);
-    case 'a-var': {
-      const node = head;
-      // The value is visited after the rest of the chain is compiled,
-      // as in the recursive formulation.
-      return (compiledBody) => {
-        const compiledE: DAG.CExp = node.e.visit(compiler);
-        // TODO: annotations here?
+      return compileLettable(compiler, undefined, head.e1, rest, (e1Visit) => {
+        const firstStmt: J.JStmt = (e1Visit.exp as any) instanceof J.JStmtBase
+          ? (e1Visit.exp as any as J.JStmt)
+          : jExpr(e1Visit.exp);
         return cBlock(
-          jBlock(
-            clCons(
-              jVar(jsIdOf(node.bind.id),
-                jObj(clist<J.JFieldT>(jField('$var', compiledE.exp)
-                  // NOTE(joe): This can be useful to turn on for debugging
-                  //                     , j-field("$name", j-str(b.id.toname()))
-                ))) as J.JStmt,
-              DAG.stmtsOf(compiledBody.block))),
-          compiledBody.newCases);
-      };
+          jBlock(clAppend(e1Visit.otherStmts, clCons(firstStmt, DAG.stmtsOf(rest.block)))),
+          rest.newCases);
+      });
+    case 'a-var': {
+      const compiledE: DAG.CExp = head.e.visit(compiler);
+      // TODO: annotations here?
+      return cBlock(
+        jBlock(
+          clCons(
+            jVar(jsIdOf(head.bind.id),
+              jObj(clist<J.JFieldT>(jField('$var', compiledE.exp)
+                // NOTE(joe): This can be useful to turn on for debugging
+                //                     , j-field("$name", j-str(b.id.toname()))
+              ))) as J.JStmt,
+            DAG.stmtsOf(rest.block))),
+        rest.newCases);
     }
     case 'a-type-let': {
       const bind = head.bind;
       switch (bind.$name) {
-        case 'a-type-bind':
-          return (visitedBody) => {
-            const compiledAnn = compileAnn(bind.ann, bind.name.toname(), compiler);
-            return cBlock(
-              jBlock(
-                clAppend(
-                  clSnoc(compiledAnn.otherStmts, jVar(jsIdOf(bind.name), compiledAnn.exp) as J.JStmt),
-                  DAG.stmtsOf(visitedBody.block))),
-              visitedBody.newCases);
-          };
+        case 'a-type-bind': {
+          const compiledAnn = compileAnn(bind.ann, bind.name.toname(), compiler);
+          return cBlock(
+            jBlock(
+              clAppend(
+                clSnoc(compiledAnn.otherStmts, jVar(jsIdOf(bind.name), compiledAnn.exp) as J.JStmt),
+                DAG.stmtsOf(rest.block))),
+            rest.newCases);
+        }
         case 'a-newtype-bind': {
           const branderId = jsIdOf(bind.namet);
-          return (visitedBody) => cBlock(
+          return cBlock(
             jBlock(
               clAppend(
                 clist<J.JStmt>(
                   jVar(branderId, rtMethod('namedBrander', clist<J.JExprT>(jStr(bind.name.toname()), compiler.getLoc(bind.l)))),
                   jVar(jsIdOf(bind.name), rtMethod('makeBranderAnn', clist<J.JExprT>(jId(branderId), jStr(bind.name.toname()))))
                 ),
-                DAG.stmtsOf(visitedBody.block))),
-            visitedBody.newCases);
+                DAG.stmtsOf(rest.block))),
+            rest.newCases);
         }
         default:
           throw new InternalCompilerError('Unknown ATypeBind in a-type-let');
       }
     }
     default:
-      throw new InternalCompilerError('Unknown AExprHead in preHead: ' + (head as any).$name);
+      throw new InternalCompilerError('Unknown AExprHead in compileHead: ' + (head as any).$name);
   }
 }
 
-// The "rest of the chain follows this head" bookkeeping the recursive
-// formulation did in getNewCases/getRemainingCode: the pre-body label is
-// minted in the head's pre phase; once the rest is compiled, the
-// destination binding (if any) is wrapped around it and it becomes the
-// case the head's code jumps to.
-function finishRest(
+function compileLettable(
   compiler: CompilerVisitor,
-  optDest: BindType | undefined,
-  preBodyLabel: J.JExprT,
-  rest: DAG.CBlock
-): [CList<J.JCaseT>, J.JExprT] {
-  let compiledBody = rest;
-  if (optDest !== undefined) {
-    compiledBody = compileAnnotatedLet(compiler, optDest, cExp(jId(compiler.curAns), clEmpty), compiledBody);
-  }
-  return [clCons(jCase(preBodyLabel, compiledBody.block) as J.JCaseT, compiledBody.newCases), preBodyLabel];
-}
-
-function plainPost(compiler: CompilerVisitor, b: BindType | undefined, compiledE: DAG.CExp): HeadPost {
-  if (b !== undefined) {
-    return (rest) => compileAnnotatedLet(compiler, b, compiledE, rest);
-  }
-  return (rest) => {
-    const firstStmt: J.JStmt = (compiledE.exp as any) instanceof J.JStmtBase ? (compiledE.exp as any as J.JStmt) : jExpr(compiledE.exp);
-    return cBlock(
-      jBlock(clAppend(compiledE.otherStmts, clCons(firstStmt, DAG.stmtsOf(rest.block)))),
-      rest.newCases);
-  };
-}
-
-function preLettable(compiler: CompilerVisitor, b: BindType | undefined, e: N.ALettable): HeadPost {
+  b: BindType | undefined,
+  e: N.ALettable,
+  optRest: DAG.CBlock | undefined,
+  elseCase: (compiledE: DAG.CExp) => DAG.CBlock
+): DAG.CBlock {
   switch (e.$name) {
     case 'a-prim-app':
-      return e.appInfo.needsStep
-        ? preSplitPrimApp(e.l, compiler, b, e.f, e.args)
-        : preFlatPrimApp(e.l, compiler, b, e.f, e.args);
-    case 'a-app': {
-      const f = e._fun;
-      const isSafeId = N.isAId(f) || N.isAIdSafeLetrec(f);
-      if (isSafeId && isFunctionFlat(compiler.flatnessEnv, (f as any).id.key())) {
-        return preFlatApp(e.l, compiler, b, f, e.args);
-      }
-      const isFn = isSafeId && isIdFnName(compiler.flatnessEnv, (f as any).id.key());
-      return preSplitApp(e.l, compiler, b, f, e.args, e.appInfo, isFn);
-    }
+      return compileAPrimApp(e.l, e.f, e.args, compiler, b, optRest, e.appInfo);
+    case 'a-app':
+      return compileAApp(e.l, e._fun, e.args, compiler, b, optRest, e.appInfo);
     case 'a-method-app':
-      return preSplitMethodApp(e.l, compiler, b, e.obj, e.meth, e.args);
+      return compileSplitMethodApp(e.l, compiler, b, e.obj, e.meth, e.args, optRest);
     case 'a-if':
-      return preSplitIf(compiler, b, e);
+      return compileSplitIf(compiler, b, e, optRest);
     case 'a-cases':
-      return preSplitCases(compiler, e.l, b, e.val, e.branches, e._else);
+      return compileSplitCases(compiler, e.l, b, e.val, e.branches, e._else, optRest);
     case 'a-update':
-      return preSplitUpdate(compiler, e.l, b, e.supe, e.fields);
-    case 'a-lam': {
-      const compiledE = compileALam(compiler, e.l, e.name, e.args, e.ret, e.body, b);
-      return plainPost(compiler, b, compiledE);
-    }
-    default: {
-      const compiledE: DAG.CExp = e.visit(compiler);
-      return plainPost(compiler, b, compiledE);
-    }
+      return compileSplitUpdate(compiler, e.l, b, e.supe, e.fields, optRest);
+    case 'a-lam':
+      return elseCase(compileALam(compiler, e.l, e.name, e.args, e.ret, e.body, b));
+    default:
+      return elseCase(e.visit(compiler));
   }
 }
 
-function compileTailLettable(compiler: CompilerVisitor, e: N.ALettable): DAG.CBlock {
-  switch (e.$name) {
-    case 'a-prim-app': {
-      if (e.appInfo.needsStep) {
-        const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), e.args);
-        return buildSplitPrimApp(e.l, compiler, e.f, compiledArgs, clEmpty, compiler.curTarget);
-      }
-      const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), e.args);
-      return buildFlatPrimApp(e.l, compiler, e.f, compiledArgs, tailRemainingBlock(compiler), clEmpty);
-    }
-    case 'a-app': {
-      const f = e._fun;
-      const isSafeId = N.isAId(f) || N.isAIdSafeLetrec(f);
-      if (isSafeId && isFunctionFlat(compiler.flatnessEnv, (f as any).id.key())) {
-        const compiledF = field(f.visit(compiler), 'exp');
-        const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), e.args);
-        return buildFlatApp(e.l, compiler, compiledF, compiledArgs, tailRemainingBlock(compiler), clEmpty);
-      }
-      const isFn = isSafeId && isIdFnName(compiler.flatnessEnv, (f as any).id.key());
-      const compiledF = field(f.visit(compiler), 'exp');
-      const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), e.args);
-      return buildSplitApp(e.l, compiler, compiledF, compiledArgs, e.appInfo, isFn, clEmpty, compiler.curTarget);
-    }
-    case 'a-method-app': {
-      const state = methodAppState(e.l, compiler, e.obj, e.meth, e.args);
-      return buildMethodApp(e.l, compiler, state, clEmpty, compiler.curTarget);
-    }
-    case 'a-if': {
-      const consqLabel = compiler.makeLabel();
-      const altLabel = compiler.makeLabel();
-      return buildNaryIf(compiler, e, consqLabel, altLabel, clEmpty, compiler.curTarget);
-    }
-    case 'a-cases': {
-      const compiledVal = field(e.val.visit(compiler), 'exp');
-      return buildSplitCases(compiler, e.l, compiledVal, e.branches, e._else, clEmpty, compiler.curTarget);
-    }
-    case 'a-update': {
-      const state = updateState(compiler, e.supe, e.fields);
-      return buildSplitUpdate(compiler, e.l, state, clEmpty, compiler.curTarget);
-    }
-    case 'a-lam': {
-      const compiledE = compileALam(compiler, e.l, e.name, e.args, e.ret, e.body, undefined);
-      return tailPlain(compiler, compiledE);
-    }
-    default: {
-      const compiledE: DAG.CExp = e.visit(compiler);
-      return tailPlain(compiler, compiledE);
-    }
-  }
-}
-
-function tailPlain(compiler: CompilerVisitor, visitE: DAG.CExp): DAG.CBlock {
+// The last lettable in a chain has nothing to bind its answer to: stash it
+// in curAns and jump to the block the enclosing construct nominated.
+function tailLettable(compiler: CompilerVisitor, visitE: DAG.CExp): DAG.CBlock {
   return cBlock(
     jBlock(
       clAppend(
@@ -1318,38 +1232,73 @@ function tailRemainingBlock(compiler: CompilerVisitor): J.JBlockT {
   ));
 }
 
+/*
+  The rest of the chain is already compiled by the time a head asks for it
+  (see compileAExpr), so these take a `rest` CBlock rather than an AExpr to
+  visit -- as get-remaining-code/get-new-cases do in anf-loop-compiler.arr.
+*/
+function getRemainingCode(
+  compiler: CompilerVisitor,
+  optDest: BindType | undefined,
+  rest: DAG.CBlock,
+  ans: A.Name
+): [J.JBlockT, CList<J.JCaseT>] {
+  const compiledBody = optDest !== undefined
+    ? compileAnnotatedLet(compiler, optDest, cExp(jId(ans), clEmpty), rest)
+    : rest;
+  return [compiledBody.block, compiledBody.newCases];
+}
+
+// Return code for optRest and the label the caller should jump to after
+// their block of code is done
+function getNewCases(
+  compiler: CompilerVisitor,
+  optDest: BindType | undefined,
+  optRest: DAG.CBlock | undefined,
+  ans: A.Name
+): [CList<J.JCaseT>, J.JExprT] {
+  if (optRest === undefined) {
+    return [clEmpty, compiler.curTarget];
+  }
+  const preBodyLabel = compiler.makeLabel();
+  const [nextBlock, nextCases] = getRemainingCode(compiler, optDest, optRest, ans);
+  return [clCons(jCase(preBodyLabel, nextBlock) as J.JCaseT, nextCases), preBodyLabel];
+}
+
 // ---------- a-app ----------
 
-function preSplitApp(
+function compileAApp(
+  l: Loc,
+  f: N.AVal,
+  args: N.AVal[],
+  compiler: CompilerVisitor,
+  b: BindType | undefined,
+  optRest: DAG.CBlock | undefined,
+  appInfo: A.AppInfo
+): DAG.CBlock {
+  const isSafeId = N.isAId(f) || N.isAIdSafeLetrec(f);
+  if (isSafeId && isFunctionFlat(compiler.flatnessEnv, (f as any).id.key())) {
+    return compileFlatApp(l, compiler, b, f, args, optRest);
+  }
+  const isFn = isSafeId && isIdFnName(compiler.flatnessEnv, (f as any).id.key());
+  return compileSplitApp(l, compiler, b, f, args, optRest, appInfo, isFn);
+}
+
+function compileSplitApp(
   l: Loc,
   compiler: CompilerVisitor,
   optDest: BindType | undefined,
   f: N.AVal,
   args: N.AVal[],
+  optRest: DAG.CBlock | undefined,
   appInfo: A.AppInfo,
   isDefinitelyFn: boolean
-): HeadPost {
-  const compiledF = field(f.visit(compiler), 'exp');
-  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [newCases, afterAppLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildSplitApp(l, compiler, compiledF, compiledArgs, appInfo, isDefinitelyFn, newCases, afterAppLabel);
-  };
-}
-
-function buildSplitApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  compiledF: J.JExprT,
-  compiledArgs: CList<J.JExprT>,
-  appInfo: A.AppInfo,
-  isDefinitelyFn: boolean,
-  newCases: CList<J.JCaseT>,
-  afterAppLabel: J.JExprT
 ): DAG.CBlock {
   const ans = compiler.curAns;
   const step = compiler.curStep;
+  const compiledF = field(f.visit(compiler), 'exp');
+  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
+  const [newCases, afterAppLabel] = getNewCases(compiler, optDest, optRest, ans);
   if (appInfo.isRecursive &&
     appInfo.isTail &&
     compiler.allowTco &&
@@ -1399,39 +1348,33 @@ export function jBlockToStmtList(b: J.JBlockT): CList<J.JStmt> {
   }
 }
 
-function preFlatApp(
+function compileFlatApp(
   l: Loc,
   compiler: CompilerVisitor,
   optDest: BindType | undefined,
   f: N.AVal,
-  args: N.AVal[]
-): HeadPost {
-  const compiledF = field(f.visit(compiler), 'exp');
-  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
-  return (rest) => {
-    let compiledBody = rest;
-    if (optDest !== undefined) {
-      compiledBody = compileAnnotatedLet(compiler, optDest, cExp(jId(compiler.curAns), clEmpty), compiledBody);
-    }
-    return buildFlatApp(l, compiler, compiledF, compiledArgs, compiledBody.block, compiledBody.newCases);
-  };
-}
-
-function buildFlatApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  compiledF: J.JExprT,
-  compiledArgs: CList<J.JExprT>,
-  remainingCode: J.JBlockT,
-  newCases: CList<J.JCaseT>
+  args: N.AVal[],
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
   const ans = compiler.curAns;
+  const compiledF = field(f.visit(compiler), 'exp');
+  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
+
   // Generate the code for calling the function
   const callCode = clist<J.JStmt>(
     jExpr(jRawCode('// caller optimization')),
     jExpr(wrapWithSrcnode(l, jAssign(ans, app(l, compiledF, compiledArgs))))
   );
-  // Merge the code for calling the function with the next block
+
+  // Splice in the already-compiled rest of the let. We split it into two
+  // portions: 1) the code that can be in the same "block" (or case region)
+  // and 2) the rest of the case statements. With no rest there is no more
+  // code after this, so just jump to the function's special last block.
+  const [remainingCode, newCases]: [J.JBlockT, CList<J.JCaseT>] = optRest !== undefined
+    ? getRemainingCode(compiler, optDest, optRest, ans)
+    : [tailRemainingBlock(compiler), clEmpty];
+
+  // Now merge the code for calling the function with the next block
   // (this is basically our optimization, since we're not starting a new case
   // for the next block)
   return cBlock(
@@ -1441,31 +1384,32 @@ function buildFlatApp(
 
 // ---------- a-prim-app ----------
 
-function preSplitPrimApp(
+function compileAPrimApp(
+  l: Loc,
+  f: string,
+  args: N.AVal[],
+  compiler: CompilerVisitor,
+  b: BindType | undefined,
+  optRest: DAG.CBlock | undefined,
+  appInfo: A.PrimAppInfo
+): DAG.CBlock {
+  return appInfo.needsStep
+    ? compileSplitPrimApp(l, compiler, b, f, args, optRest)
+    : compileFlatPrimApp(l, compiler, b, f, args, optRest);
+}
+
+function compileSplitPrimApp(
   l: Loc,
   compiler: CompilerVisitor,
   optDest: BindType | undefined,
   f: string,
-  args: N.AVal[]
-): HeadPost {
-  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [newCases, afterAppLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildSplitPrimApp(l, compiler, f, compiledArgs, newCases, afterAppLabel);
-  };
-}
-
-function buildSplitPrimApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  f: string,
-  compiledArgs: CList<J.JExprT>,
-  newCases: CList<J.JCaseT>,
-  afterAppLabel: J.JExprT
+  args: N.AVal[],
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
   const ans = compiler.curAns;
   const step = compiler.curStep;
+  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
+  const [newCases, afterAppLabel] = getNewCases(compiler, optDest, optRest, ans);
   return cBlock(
     jBlock(
       // Update step before the call, so that if it runs out of gas,
@@ -1479,34 +1423,24 @@ function buildSplitPrimApp(
     newCases);
 }
 
-function preFlatPrimApp(
+function compileFlatPrimApp(
   l: Loc,
   compiler: CompilerVisitor,
   optDest: BindType | undefined,
   f: string,
-  args: N.AVal[]
-): HeadPost {
-  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
-  return (rest) => {
-    let compiledBody = rest;
-    if (optDest !== undefined) {
-      compiledBody = compileAnnotatedLet(compiler, optDest, cExp(jId(compiler.curAns), clEmpty), compiledBody);
-    }
-    return buildFlatPrimApp(l, compiler, f, compiledArgs, compiledBody.block, compiledBody.newCases);
-  };
-}
-
-function buildFlatPrimApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  f: string,
-  compiledArgs: CList<J.JExprT>,
-  remainingCode: J.JBlockT,
-  newCases: CList<J.JCaseT>
+  args: N.AVal[],
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
   const ans = compiler.curAns;
+  const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
+
   // Generate the code for calling the function
   const callCode = jExpr(wrapWithSrcnode(l, jAssign(ans, rtMethod(f, compiledArgs))));
+
+  const [remainingCode, newCases]: [J.JBlockT, CList<J.JCaseT>] = optRest !== undefined
+    ? getRemainingCode(compiler, optDest, optRest, ans)
+    : [tailRemainingBlock(compiler), clEmpty];
+
   // Merge the code for calling the function with the next block
   return cBlock(
     jBlock(clCons(callCode as J.JStmt, jBlockToStmtList(remainingCode))),
@@ -1515,30 +1449,23 @@ function buildFlatPrimApp(
 
 // ---------- a-method-app ----------
 
-interface MethodAppState {
-  compiledObj: J.JExprT;
-  compiledArgs: CList<J.JExprT>;
-  // isJId(compiledObj) path: the whole call is built (interning its loc)
-  // before the rest of the chain is compiled, as in the recursive
-  // formulation.
-  call: J.JExprT | undefined;
-  objId: J.JId | undefined;
-  colonField: J.JExprT | undefined;
-  colonFieldId: J.JId | undefined;
-  checkMethod: J.JExprT | undefined;
-}
-
-function methodAppState(
+function compileSplitMethodApp(
   l: Loc,
   compiler: CompilerVisitor,
+  optDest: BindType | undefined,
   obj: N.AVal,
   methname: string,
-  args: N.AVal[]
-): MethodAppState {
+  args: N.AVal[],
+  optRest: DAG.CBlock | undefined
+): DAG.CBlock {
+  const ans = compiler.curAns;
+  const step = compiler.curStep;
   const compiledObj = field(obj.visit(compiler), 'exp');
   const compiledArgs = CL.map_list((a: N.AVal) => field(a.visit(compiler), 'exp'), args);
+
   const argcount = compiledArgs.length();
   const helperName = argcount <= 7 ? 'maybeMethodCall' + String(argcount) : 'maybeMethodCall';
+
   if (J.isJId(compiledObj)) {
     const call = wrapWithSrcnode(l,
       rtMethod(helperName,
@@ -1546,64 +1473,32 @@ function methodAppState(
           jStr(methname),
           compiler.getLoc(l)),
         compiledArgs)));
-    return { compiledObj, compiledArgs, call, objId: undefined, colonField: undefined, colonFieldId: undefined, checkMethod: undefined };
+    const [newCases, afterAppLabel] = getNewCases(compiler, optDest, optRest, ans);
+    return cBlock(jBlock(clist<J.JStmt>(
+      jExpr(jAssign(step, afterAppLabel)),
+      jExpr(jAssign(ans, call)),
+      jBreak
+    )), newCases);
   } else {
     const objId = jId(freshId(compilerName('obj')));
     const colonField = rtMethod('getColonFieldLoc', clist(objId, jStr(methname), compiler.getLoc(l)));
     const colonFieldId = jId(freshId(compilerName('field')));
     const checkMethod = rtMethod('isMethod', clist<J.JExprT>(colonFieldId));
-    return { compiledObj, compiledArgs, call: undefined, objId, colonField, colonFieldId, checkMethod };
-  }
-}
-
-function preSplitMethodApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  optDest: BindType | undefined,
-  obj: N.AVal,
-  methname: string,
-  args: N.AVal[]
-): HeadPost {
-  const state = methodAppState(l, compiler, obj, methname, args);
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [newCases, afterAppLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildMethodApp(l, compiler, state, newCases, afterAppLabel);
-  };
-}
-
-function buildMethodApp(
-  l: Loc,
-  compiler: CompilerVisitor,
-  state: MethodAppState,
-  newCases: CList<J.JCaseT>,
-  afterAppLabel: J.JExprT
-): DAG.CBlock {
-  const ans = compiler.curAns;
-  const step = compiler.curStep;
-  if (state.objId === undefined) {
-    return cBlock(jBlock(clist<J.JStmt>(
-      jExpr(jAssign(step, afterAppLabel)),
-      jExpr(jAssign(ans, state.call!)),
-      jBreak
-    )), newCases);
-  } else {
-    const objId = state.objId;
-    const colonFieldId = state.colonFieldId!;
+    const [newCases, afterAppLabel] = getNewCases(compiler, optDest, optRest, ans);
     return cBlock(
       jBlock(clist<J.JStmt>(
         // Update step before the call, so that if it runs out of gas, the resumer goes to the right step
         jExpr(jAssign(step, afterAppLabel)),
         jExpr(jAssign(compiler.curApploc, compiler.getLoc(l))),
-        jVar(objId.id, state.compiledObj),
-        jVar(colonFieldId.id, state.colonField!),
-        jIf(state.checkMethod!, jBlock(clist<J.JStmt>(
+        jVar(objId.id, compiledObj),
+        jVar(colonFieldId.id, colonField),
+        jIf(checkMethod, jBlock(clist<J.JStmt>(
           jExpr(jAssign(ans, jApp(jDot(colonFieldId, 'full_meth'),
-            clCons<J.JExprT>(objId, state.compiledArgs))))
+            clCons<J.JExprT>(objId, compiledArgs))))
         )),
         jBlock(clist<J.JStmt>(
           checkFun(l, compiler.getLoc(l), colonFieldId),
-          jExpr(wrapWithSrcnode(l, jAssign(ans, app(l, colonFieldId, state.compiledArgs))))
+          jExpr(wrapWithSrcnode(l, jAssign(ans, app(l, colonFieldId, compiledArgs))))
         ))),
         // If the answer is a cont, jump to the end of the current function
         // rather than continuing normally
@@ -1675,87 +1570,56 @@ export function getAssignments(lst: J.JExprT[], limit: number): [J.JStmt[], J.JS
 
 // ---------- a-if ----------
 
-function preSplitIf(
-  compiler: CompilerVisitor,
-  optDest: BindType | undefined,
-  node: N.AIf
-): HeadPost {
-  const consqLabel = compiler.makeLabel();
-  const altLabel = compiler.makeLabel();
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [afterIfCases, afterIfLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildNaryIf(compiler, node, consqLabel, altLabel, afterIfCases, afterIfLabel);
-  };
-}
-
 /*
   The flattened n-ary a-if, compiled exactly as the nested binary chain
-  was: arm 1's dispatch block tests c1 and jumps to its body's case or to
-  the alt case holding arm 2's test-computation heads followed by arm 2's
-  dispatch, and so on; the else is the innermost alt. Forward over the
-  arms: each arm's test-head pre phases, its two labels, then its
-  compiled body. Backward: each arm's condition value is visited (the
-  recursive formulation visited it after compiling the whole alt chain --
-  this is where anf_if temporaries get their JS names, so the reverse-arm
-  minting order is preserved), the dispatch block is assembled, and the
-  arm's test-head posts wrap it to become the next-outer arm's alt.
+  was. Arm 1's dispatch block tests c1 and jumps either to its body's case
+  or to the alt case, which holds arm 2's test-computation heads followed
+  by arm 2's dispatch, and so on; the else is the innermost alt. So the
+  bodies are compiled outermost-first, then the arms are assembled inward
+  out: each arm's condition is visited only once its whole alt chain is
+  compiled (this is where anf_if temporaries get their JS names), and its
+  test-computation heads wrap the result to become the next-outer arm's alt.
 */
-function buildNaryIf(
+function compileSplitIf(
   compiler: CompilerVisitor,
+  optDest: BindType | undefined,
   node: N.AIf,
-  consqLabel1: J.JExprT,
-  altLabel1: J.JExprT,
-  afterIfCases: CList<J.JCaseT>,
-  afterIfLabel: J.JExprT
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
+  const [afterIfCases, afterIfLabel] = getNewCases(compiler, optDest, optRest, compiler.curAns);
   const compilerAfterIf = ext(compiler, { curTarget: afterIfLabel });
   const branches = node.branches;
-  const n = branches.length;
-  const consqLabels: J.JExprT[] = [consqLabel1];
-  const altLabels: J.JExprT[] = [altLabel1];
-  const compiledBodies: DAG.CBlock[] = [];
-  const headPosts: HeadPost[][] = [];
-  for (let i = 0; i < n; i++) {
-    const b = branches[i];
-    const posts: HeadPost[] = [];
-    for (const h of b.heads) {
-      posts.push(preHead(compilerAfterIf, h));
-    }
-    headPosts.push(posts);
-    if (i > 0) {
-      consqLabels.push(compiler.makeLabel());
-      altLabels.push(compiler.makeLabel());
-    }
-    compiledBodies.push(compileAExpr(compilerAfterIf, b.body));
-  }
-  let cur = compileAExpr(compilerAfterIf, node.elseBody);
-  for (let i = n - 1; i >= 0; i--) {
+  const compiledConsqs = branches.map((b) => compileAExpr(compilerAfterIf, b.body));
+  let compiledAlt = compileAExpr(compilerAfterIf, node.elseBody);
+  for (let i = branches.length - 1; i >= 0; i--) {
     // The nested chain visited arm 1's condition with the enclosing
     // compiler and inner arms' with the after-if one; they only differ
     // in curTarget, which value visits never read -- match it anyway.
     const condCompiler = i === 0 ? compiler : compilerAfterIf;
-    const condExp = field(branches[i].test.visit(condCompiler), 'exp');
+    const compiledCond = field(branches[i].test.visit(condCompiler), 'exp');
+    const consqLabel = compiler.makeLabel();
+    const altLabel = compiler.makeLabel();
     const newCases =
       clAppend(
         clAppend(
-          clCons(jCase(consqLabels[i], compiledBodies[i].block) as J.JCaseT, compiledBodies[i].newCases),
-          clCons(jCase(altLabels[i], cur.block) as J.JCaseT, cur.newCases)),
+          clCons(jCase(consqLabel, compiledConsqs[i].block) as J.JCaseT, compiledConsqs[i].newCases),
+          clCons(jCase(altLabel, compiledAlt.block) as J.JCaseT, compiledAlt.newCases)),
         i === 0 ? afterIfCases : clEmpty);
-    cur = cBlock(
+    compiledAlt = cBlock(
       jBlock(clist<J.JStmt>(
         jExpr(jAssign(compiler.curStep,
-          jTernary(rtMethod('checkPyretTrue', clist(condExp)),
-            consqLabels[i], altLabels[i]))),
+          jTernary(rtMethod('checkPyretTrue', clist(compiledCond)),
+            consqLabel, altLabel))),
         jBreak
       )),
       newCases);
-    const posts = headPosts[i];
-    for (let j = posts.length - 1; j >= 0; j--) {
-      cur = posts[j](cur);
+    // Arm 1's heads belong to the enclosing chain, so it has none here.
+    const heads = branches[i].heads;
+    for (let j = heads.length - 1; j >= 0; j--) {
+      compiledAlt = compileHead(compilerAfterIf, heads[j], compiledAlt);
     }
   }
-  return cur;
+  return compiledAlt;
 }
 
 // ---------- a-cases ----------
@@ -1884,31 +1748,17 @@ export function compileInlineCasesBranch(
   }
 }
 
-function preSplitCases(
+function compileSplitCases(
   compiler: CompilerVisitor,
   casesLoc: Loc,
   optDest: BindType | undefined,
   val: N.AVal,
   branches: N.ACasesBranch[],
-  _else: N.AExpr
-): HeadPost {
-  const compiledVal = field(val.visit(compiler), 'exp');
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [afterCasesCases, afterCasesLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildSplitCases(compiler, casesLoc, compiledVal, branches, _else, afterCasesCases, afterCasesLabel);
-  };
-}
-
-function buildSplitCases(
-  compiler: CompilerVisitor,
-  casesLoc: Loc,
-  compiledVal: J.JExprT,
-  branches: N.ACasesBranch[],
   _else: N.AExpr,
-  afterCasesCases: CList<J.JCaseT>,
-  afterCasesLabel: J.JExprT
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
+  const compiledVal = field(val.visit(compiler), 'exp');
+  const [afterCasesCases, afterCasesLabel] = getNewCases(compiler, optDest, optRest, compiler.curAns);
   const compilerAfterCases = ext(compiler, { curTarget: afterCasesLabel });
   const compiledBranches: DAG.CBlock[] = [];
   for (const branch of branches) {
@@ -1943,58 +1793,33 @@ function buildSplitCases(
 
 // ---------- a-update ----------
 
-interface UpdateState {
-  compiledObj: J.JExprT;
-  compiledFieldVals: CList<J.JExprT>;
-  fieldNames: CList<J.JExprT>;
-  fieldLocs: CList<J.JExprT>;
-  objLoc: Loc;
-}
-
-function updateState(compiler: CompilerVisitor, obj: N.AVal, fields: N.AField[]): UpdateState {
-  const compiledObj = field(obj.visit(compiler), 'exp');
-  const compiledFieldVals = CL.map_list((a: N.AField) => field(a.value.visit(compiler), 'exp'), fields);
-  const fieldNames = CL.map_list((f: N.AField) => jStr(f.name) as J.JExprT, fields);
-  const fieldLocs = CL.map_list((f: N.AField) => compiler.getLoc(f.l), fields);
-  return { compiledObj, compiledFieldVals, fieldNames, fieldLocs, objLoc: obj.l };
-}
-
-function preSplitUpdate(
+function compileSplitUpdate(
   compiler: CompilerVisitor,
   loc: Loc,
   optDest: BindType | undefined,
   obj: N.AVal,
-  fields: N.AField[]
-): HeadPost {
-  const state = updateState(compiler, obj, fields);
-  const preBodyLabel = compiler.makeLabel();
-  return (rest) => {
-    const [newCases, afterUpdateLabel] = finishRest(compiler, optDest, preBodyLabel, rest);
-    return buildSplitUpdate(compiler, loc, state, newCases, afterUpdateLabel);
-  };
-}
-
-function buildSplitUpdate(
-  compiler: CompilerVisitor,
-  loc: Loc,
-  state: UpdateState,
-  newCases: CList<J.JCaseT>,
-  afterUpdateLabel: J.JExprT
+  fields: N.AField[],
+  optRest: DAG.CBlock | undefined
 ): DAG.CBlock {
   const ans = compiler.curAns;
   const step = compiler.curStep;
+  const compiledObj = field(obj.visit(compiler), 'exp');
+  const compiledFieldVals = CL.map_list((a: N.AField) => field(a.value.visit(compiler), 'exp'), fields);
+  const fieldNames = CL.map_list((f: N.AField) => jStr(f.name) as J.JExprT, fields);
+  const fieldLocs = CL.map_list((f: N.AField) => compiler.getLoc(f.l), fields);
+  const [newCases, afterUpdateLabel] = getNewCases(compiler, optDest, optRest, ans);
   return cBlock(
     jBlock(clist<J.JStmt>(
       // Update step before the call, so that if it runs out of gas, the resumer goes to the right step
       jExpr(jAssign(step, afterUpdateLabel)),
       jExpr(jAssign(ans, rtMethod('checkRefAnns',
         clist(
-          state.compiledObj,
-          jList(false, state.fieldNames),
-          jList(false, state.compiledFieldVals),
-          jList(false, state.fieldLocs),
+          compiledObj,
+          jList(false, fieldNames),
+          jList(false, compiledFieldVals),
+          jList(false, fieldLocs),
           compiler.getLoc(loc),
-          compiler.getLoc(state.objLoc))))),
+          compiler.getLoc(obj.l))))),
       jBreak)),
     newCases);
 }
@@ -2180,8 +2005,8 @@ export class CompilerVisitor {
         compiledChecks.otherStmts));
   }
 
-  // AExpr chains are not visited: compileAExpr drives them directly
-  // (see the pre/post machinery above).
+  // AExpr chains are not visited: compileAExpr walks them directly, and
+  // these lettables always sit in a chain (see compileLettable).
   aIf(_node: N.AIf): never {
     return raise('Impossible: a-if directly in compiler-visitor should never happen');
   }

--- a/lang/src/ts-compiler/src/flatness.ts
+++ b/lang/src/ts-compiler/src/flatness.ts
@@ -303,30 +303,26 @@ export function makeLettableDataEnv(
 }
 
 /*
-  Per-head flatness: the forward part (run in statement order; includes
-  all sd/ad mutations and the value-side flatness) returns the backward
-  part, a frame combining the flatness of everything after the head —
-  work the recursive formulation on the nested representation did after
-  its body call (a-let's annFlatness and the flatnessMax combinations),
-  applied in the original unwind order (deepest first).
+  A head's own contribution to the chain's flatness: its env mutations and
+  its value-side flatness, computed in statement order. An a-let's binding
+  annotation is deliberately NOT included -- the nested representation
+  resolved it after compiling the body, so it must see the env the body
+  leaves behind; foldHeadsAfterBody adds it on the way back out.
 */
-type FlatnessFrame = (bodyFlatness: Flatness) => Flatness;
-
-export function headFlatnessForward(
+export function headFlatness(
   head: AA.AExprHead,
   sd: FEnv,
   ad: FEnv,
   mb: Map<string, C.ModuleBind>,
   env: C.CompileEnvironment
-): FlatnessFrame {
+): Flatness {
   switch (head.$name) {
     case 'a-type-let':
-      return (bodyFlatness) => bodyFlatness;
+      return 0;
     case 'a-let': {
       const bind = head.bind;
       const val = head.e;
 
-      let valFlatness: Flatness;
       if (AA.isALam(val)) {
         const retFlatness = annFlatness(val.ret, sd, ad, mb, env);
         let argsFlatness = retFlatness;
@@ -340,7 +336,7 @@ export function headFlatnessForward(
         sd.set(bind.id.key(), lamFlatness);
         // flatness of defining this lambda is 0, since we're not actually
         // doing anything with it
-        valFlatness = 0;
+        return 0;
       } else if (AA.isAIdSafeLetrec(val)) {
         // If we're binding this name to something that's already been defined
         // just copy over the definition
@@ -352,40 +348,54 @@ export function headFlatnessForward(
         }
         // flatness of the binding part of the let is 0 since we don't
         // call anything
-        valFlatness = 0;
+        return 0;
       } else if (AA.isAVal(val) && AA.isAIdModref(val.v)) {
         const funFlatness = getFlatnessForModuleFun(val.v.id, val.v.name, mb, env);
         sd.set(bind.id.key(), funFlatness);
-        valFlatness = 0;
+        return 0;
       } else {
-        valFlatness = makeLettableFlatnessEnv(val, sd, ad, mb, env);
+        return makeLettableFlatnessEnv(val, sd, ad, mb, env);
       }
-
-      return (bodyFlatness) => {
-        const annF = annFlatness(bind.ann, sd, ad, mb, env);
-        return flatnessMax(flatnessMax(valFlatness, bodyFlatness), annF);
-      };
     }
     case 'a-arr-let': {
       // Could maybe try to add some string like "bind.name + idx" to the
       // sd to let us keep track of the flatness if e is an a-lam, but for
       // now we don't since I'm not sure it'd work right.
       const annF = annFlatness(head.bind.ann, sd, ad, mb, env);
-      const lettF = makeLettableFlatnessEnv(head.e, sd, ad, mb, env);
-      return (bodyFlatness) => flatnessMax(annF, flatnessMax(lettF, bodyFlatness));
+      return flatnessMax(annF, makeLettableFlatnessEnv(head.e, sd, ad, mb, env));
     }
-    case 'a-var': {
+    case 'a-var':
       // Do same thing with a-var as with a-let for now
-      const annF = annFlatness(head.bind.ann, sd, ad, mb, env);
-      return (bodyFlatness) => flatnessMax(annF, bodyFlatness);
-    }
-    case 'a-seq': {
-      const aFlatness = makeLettableFlatnessEnv(head.e1, sd, ad, mb, env);
-      return (bodyFlatness) => flatnessMax(aFlatness, bodyFlatness);
-    }
+      return annFlatness(head.bind.ann, sd, ad, mb, env);
+    case 'a-seq':
+      return makeLettableFlatnessEnv(head.e1, sd, ad, mb, env);
     default:
-      throw new InternalCompilerError('headFlatnessForward: unknown head ' + (head as any).$name);
+      throw new InternalCompilerError('headFlatness: unknown head ' + (head as any).$name);
   }
+}
+
+// Combine a chain's heads with the flatness of everything that follows
+// them, innermost head first -- the order the nested representation
+// unwound in, and the point at which an a-let's binding annotation is
+// resolved (see headFlatness).
+function foldHeadsAfterBody(
+  heads: AA.AExprHead[],
+  headFlats: Flatness[],
+  bodyFlatness: Flatness,
+  sd: FEnv,
+  ad: FEnv,
+  mb: Map<string, C.ModuleBind>,
+  env: C.CompileEnvironment
+): Flatness {
+  let result = bodyFlatness;
+  for (let i = heads.length - 1; i >= 0; i--) {
+    const head = heads[i];
+    result = flatnessMax(headFlats[i], result);
+    if (head.$name === 'a-let') {
+      result = flatnessMax(result, annFlatness(head.bind.ann, sd, ad, mb, env));
+    }
+  }
+  return result;
 }
 
 // Calculate the flatness of aexpr, and along the way mutably update sd to
@@ -397,15 +407,9 @@ export function makeExprFlatnessEnv(
   mb: Map<string, C.ModuleBind>,
   env: C.CompileEnvironment
 ): Flatness {
-  const frames: FlatnessFrame[] = [];
-  for (const head of aexpr.heads) {
-    frames.push(headFlatnessForward(head, sd, ad, mb, env));
-  }
-  let result = makeLettableFlatnessEnv(aexpr.e, sd, ad, mb, env);
-  for (let i = frames.length - 1; i >= 0; i--) {
-    result = frames[i](result);
-  }
-  return result;
+  const headFlats = aexpr.heads.map((head) => headFlatness(head, sd, ad, mb, env));
+  const tailFlatness = makeLettableFlatnessEnv(aexpr.e, sd, ad, mb, env);
+  return foldHeadsAfterBody(aexpr.heads, headFlats, tailFlatness, sd, ad, mb, env);
 }
 
 export function incrementFlatness(f: Flatness): Flatness {
@@ -466,28 +470,19 @@ export function makeLettableFlatnessEnv(
     case 'a-if': {
       // The nested chain computed
       //   max(t1, wrap2(max(t2, wrap3(... max(tn, else) ...))))
-      // where wrap_i applies arm i's test-computation head frames.
-      // Forward pass (arm bodies and head pre-work, in arm order), then
-      // a backward fold — the same value and the same sd/ad effect order
-      // as the recursion, without stack growth in the arm count.
+      // where wrap_i folds in arm i's test-computation heads. Forward over
+      // the arms (their heads and bodies, in arm order), then back out.
       const branches = lettable.branches;
-      const branchFrames: FlatnessFrame[][] = [];
+      const branchHeadFlats: Flatness[][] = [];
       const branchFlats: Flatness[] = [];
       for (const b of branches) {
-        const frames: FlatnessFrame[] = [];
-        for (const h of b.heads) {
-          frames.push(headFlatnessForward(h, sd, ad, mb, env));
-        }
-        branchFrames.push(frames);
+        branchHeadFlats.push(b.heads.map((h) => headFlatness(h, sd, ad, mb, env)));
         branchFlats.push(makeExprFlatnessEnv(b.body, sd, ad, mb, env));
       }
       let result = makeExprFlatnessEnv(lettable.elseBody, sd, ad, mb, env);
       for (let i = branches.length - 1; i >= 0; i--) {
         result = flatnessMax(branchFlats[i], result);
-        const frames = branchFrames[i];
-        for (let j = frames.length - 1; j >= 0; j--) {
-          result = frames[j](result);
-        }
+        result = foldHeadsAfterBody(branches[i].heads, branchHeadFlats[i], result, sd, ad, mb, env);
       }
       return result;
     }


### PR DESCRIPTION
This adds:

- A cookie that can force the editor to choose TS mode
- `/settings/try-ts` and `/settings/clear-ts` to set it/forget it
- A UI indicator in the bottom right of the REPL that says if you're in TS mode

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ad63ea8f-edf1-4815-a4ab-0fa0d9416d92" />
<img width="480" height="235" alt="image" src="https://github.com/user-attachments/assets/6a9d953d-52d7-4ba2-a82f-c5cba70c1ce7" />
<img width="420" height="160" alt="image" src="https://github.com/user-attachments/assets/172b82d5-435d-4a9b-a298-0b2c213a6672" />


---

This PR *also* includes a small compiler ordering rewrite on the .arr side to improve the TS code. By moving recursive calls on the .arr side, the gensym order works out to run in a natural (backwards) loop on the TS side, saving ~280 LOC and a complicated worklist structure.