### PR TITLE
Make same-line well-formedness check source-aware

### DIFF
--- a/lang/src/arr/compiler/well-formed.arr
+++ b/lang/src/arr/compiler/well-formed.arr
@@ -233,11 +233,11 @@ fun ensure-distinct-lines(loc :: Loc, prev-is-template :: Boolean, stmts :: List
     | link(first, rest) =>
       cases(Loc) loc:
         | builtin(_) => ensure-distinct-lines(first.l, A.is-s-template(first), rest)
-        | srcloc(_, _, _, _, end-line1, _, _) =>
+        | srcloc(source1, _, _, _, end-line1, _, _) =>
           cases(Loc) first.l block:
             | builtin(_) => ensure-distinct-lines(loc, prev-is-template, rest) # No need to preserve builtin() locs
-            | srcloc(_, start-line2, _, _, _, _, _) =>
-              when (end-line1 == start-line2):
+            | srcloc(source2, start-line2, _, _, _, _, _) =>
+              when (end-line1 == start-line2) and (source1 == source2):
                 if A.is-s-template(first) and prev-is-template:
                   add-error(C.template-same-line(loc, first.l))
                 else if not(A.is-s-template(first)) and not(prev-is-template):


### PR DESCRIPTION
Joe says:

Mechanical post-monorepo cleanup. Asked claude to retarget #1834 on pyret-lang to drydock rather than horizon.

Ben and I signed off on the changes (which are from the comments in the original PR)

Claude said:

Retarget of brownplt/pyret-lang#1834 (originally 9801d32a4c against horizon) at drydock, with the path moved under lang/ for the monorepo layout.

ensure-distinct-lines only compared line numbers when deciding whether two consecutive statements share a line. When a program's statements carry srclocs from more than one source (the autograder splices instructor code around student code), unrelated statements from different files could collide on a line number and be rejected as same-line. The check now also requires the two srclocs to have the same source.

Differences from the PR as opened: the bindings are named source1 and source2 instead of end-source1 and start-source2. The filtered-call-site alternative raised in review was considered and not taken; a student/instructor/student interleaving that skips a same-line error is acceptable for the intended use.