### PR TITLE
fix: use `bash` from PATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PHASEA           = build/phaseA
 PHASEB           = build/phaseB
 PHASEC           = build/phaseC
 BUNDLED_DEPS     = build/bundled-node-deps.js
-SHELL := /usr/bin/env bash
+SHELL := bash
 
 # CUSTOMIZE THESE IF NECESSARY
 PARSERS         := $(patsubst src/js/base/%-grammar.bnf,src/js/%-parser.js,$(wildcard src/$(JSBASE)/*-grammar.bnf))


### PR DESCRIPTION
`/usr/bin/env` is not present in all environments (ex. Nix sandbox);

follow up to #1835

While it is good practice to use `/usr/bin/env` in a shebang--as most tooling will respect it even if there is not a literal binary present at `/usr/bin/env` (for example nix uses a [patchShebangs](https://github.com/NixOS/nixpkgs/blob/5a80dc31c437b265da1046bdfacecb65bb41833d/pkgs/build-support/setup-hooks/patch-shebangs.sh#L1-L8) setup hook)--it is not recommended to be used as a Makefile `SHELL` since it is not portable.

This PR instead sets `SHELL` to simply be `bash` which gets resolved through the environment's `$PATH`.

----

I suppose it could be argued that this change doesn't need to be upstreamed, and that it should instead be the responsibility of less typical environments to patch the source themselves, but I thought I'd at least try to upstream this to prevent having too many custom [patch](https://github.com/ironm00n/pyret-lang/commit/33c0527e4a8444999a07462b99606fca070d07c2)es for the pyret-autograder.

----

This is trivial to port to the new mono-repo layout, so I'm not going to bother fixing the mergeability unless considered desirable.