### PR TITLE
Fewer CI tests outside of mainmast, enable static-ts testing

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -15,13 +15,6 @@ name: browser-test (embed + vscode webviews)
 # Shape: build code.pyret.org + the extension ONCE, then fan out the five
 # environments as a parallel matrix (each on its own runner, so chart rendering
 # doesn't contend for CPU).
-#
-# cpo/embed/vscode/vscode-ovsx each run twice: once per compiler flavor (the
-# stock Pyret-hosted compiler and the TypeScript port, run.js's --compiler
-# knob); vscode-ovsx x ts covers the pyret-parley.compiler=ts setting under
-# hostile (nosniff) serving, where the compiler bundle must load via
-# beforePyret's fetch path. embed-static drives the built editor.embed.html
-# artifact whose flavor is baked at build time, so it stays pyret-only.
 
 on:
   push:
@@ -35,7 +28,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
+      - name: Compute test matrix
+        id: matrix
+        env:
+          REF: ${{ github.ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          case "${BASE_REF:-$REF}" in
+            mainmast|refs/heads/mainmast)
+              envs='["cpo","embed","embed-static","vscode","vscode-ovsx"]' ;;
+            *)
+              envs='["cpo","vscode"]' ;;
+          esac
+          echo "matrix={\"env\":$envs,\"compiler\":[\"pyret\",\"ts\"]}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
@@ -80,13 +89,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      matrix:
-        env: [cpo, embed, embed-static, vscode, vscode-ovsx]
-        compiler: [pyret, ts]
-        exclude:
-          # editor.embed.html's flavor is baked at build time (pyret)
-          - env: embed-static
-            compiler: ts
+      matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -76,8 +76,13 @@ the environment boots — the stock Pyret-hosted compiler or the TypeScript port
 (code.pyret.org's `?compiler=ts` opt-in). Each env adapter maps it to its own
 flavor knob: cpo appends `?compiler=ts` to `/editor`, embed forwards it through
 the host page to the iframe URL (as the embed library's `compiler` config
-option does), and vscode opens the fixture workspace whose settings set
-`pyret-parley.compiler: "ts"`. The suites and assertions are identical in both
+option does), vscode opens the fixture workspace whose settings set
+`pyret-parley.compiler: "ts"`, and embed-static hands it to the **library** —
+the host page passes `compiler` to `makeEmbedConfig`, which appends
+`?compiler=ts` to the artifact URL, so it is the one env where the library
+rather than the harness selects the flavor. (The ts flavor reads
+`cpo-main-ts.jarr.gz.js` + `ts-compiler.gz.js` from the served root, next to
+the stock bundle: `make web-ts`.) The suites and assertions are identical in both
 configurations; `run-all.sh` runs the full env × compiler matrix.
 
 It is **strictly additive**: nothing under `code.pyret.org/` or `vscode/` is

--- a/browser-test/envs/embed-static.js
+++ b/browser-test/envs/embed-static.js
@@ -21,6 +21,14 @@
  * Env vars:
  *   EMBED_STATIC_ROOT  override the served build dir
  *                      (default code.pyret.org/build/web)
+ *   PYRET_COMPILER     pyret (default) | ts. Forwarded to the host page as a
+ *                      query parameter, which hands it to makeEmbedConfig's
+ *                      `compiler` option -- the library then appends
+ *                      ?compiler=ts to the artifact URL and editor.html swaps
+ *                      in the ts jarr. This is the only env where the LIBRARY
+ *                      selects the flavor (the others set the editor URL
+ *                      themselves), and it needs the ts artifacts next to the
+ *                      bundle in the served root (`make web-ts`).
  */
 const path = require("path");
 const fs = require("fs");
@@ -33,6 +41,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const BUILD_ROOT = process.env.EMBED_STATIC_ROOT || path.join(REPO_ROOT, "code.pyret.org", "build", "web");
 const EMBED_DIST = path.join(REPO_ROOT, "embed", "dist");
 const PAGES_ROOT = path.resolve(__dirname, "..", "pages");
+const COMPILER = process.env.PYRET_COMPILER || "pyret";
 
 async function setup() {
   const artifact = path.join(BUILD_ROOT, "editor.embed.html");
@@ -49,6 +58,17 @@ async function setup() {
         "(`npm ci --ignore-scripts && npx webpack` in embed/ produce it)"
     );
   }
+  if (COMPILER === "ts") {
+    const tsCompiler = path.join(BUILD_ROOT, "js", "ts-compiler.gz.js");
+    if (!fs.existsSync(tsCompiler)) {
+      throw new Error(
+        "embed-static: " + tsCompiler + " not found -- is the ts flavor built? " +
+          "(`make web-ts` in code.pyret.org puts cpo-main-ts.jarr.gz.js and " +
+          "ts-compiler.gz.js next to cpo-main.jarr.gz.js, where editor.html " +
+          "derives their URLs)"
+      );
+    }
+  }
 
   const scope = resourceScope();
   try {
@@ -63,7 +83,8 @@ async function setup() {
     wireBrowserLogs(page);
     page.setDefaultTimeout(60000);
 
-    await page.goto(server.origin + "/embed-static-host.html", {
+    const query = COMPILER === "pyret" ? "" : "?compiler=" + COMPILER;
+    await page.goto(server.origin + "/embed-static-host.html" + query, {
       waitUntil: "domcontentloaded",
       timeout: 120000,
     });
@@ -85,5 +106,5 @@ async function setup() {
 
 module.exports = {
   setup,
-  label: "pyret-embed library against the static editor.embed.html artifact (no CPO server)",
+  label: `pyret-embed library against the static editor.embed.html artifact (${COMPILER} compiler, no CPO server)`,
 };

--- a/browser-test/pages/embed-static-host.html
+++ b/browser-test/pages/embed-static-host.html
@@ -8,6 +8,11 @@
 
   Served by envs/embed-static.js alongside code.pyret.org/build/web (the
   artifact) and embed/dist (the library), all same-origin.
+
+  ?compiler=ts on THIS page selects the compiler flavor: it goes into
+  makeEmbedConfig's `compiler` option, and the library appends it to the
+  artifact URL. That is the flow an embedding host uses, so it is the flow
+  worth testing -- the editor page is never given the flag directly here.
 -->
 <html>
 <head>
@@ -23,6 +28,8 @@
   makeEmbedConfig({
     container: document.getElementById("container"),
     src: "/editor.embed.html",
+    // 'pyret' is the library's default and adds no query parameter.
+    compiler: new URLSearchParams(location.search).get("compiler") || "pyret",
     // Same initial state the embed env resets to (envs/embed.js).
     state: {
       definitionsAtLastRun: false,


### PR DESCRIPTION
Add a new env to build static-embed under typescript. Also change CI rules:

- mainmast runs everything
- all other targets just run the cpo and vscode configs, to save action minutes