### PR TITLE
TS compiler: name default where: blocks like the .arr compiler; run t…

### DIFF
--- a/.github/workflows/lang-test.yml
+++ b/.github/workflows/lang-test.yml
@@ -62,6 +62,11 @@ jobs:
     - name: compile-server test
       run: make ts-serve-test
 
+    # Same programs through both compilers: byte-identical standalones and
+    # identical run output.
+    - name: compiler parity test
+      run: make ts-parity-test
+
   bootstrap-converge:
     name: bootstrap convergence (.arr == TS, byte-identical)
 

--- a/lang/src/ts-compiler/src/desugar-check.ts
+++ b/lang/src/ts-compiler/src/desugar-check.ts
@@ -156,7 +156,7 @@ export function getChecks(stmts: A.Expr[]): CheckInfo[] {
       switch (stmt.$name) {
         case 's-fun': {
           if (stmt._check !== undefined) {
-            result.push(checkInfo(stmt.l, stmt.name, stmt._check.visit(checkStmtsVisitor), true));
+            result.push(checkInfo(stmt.l, "where: block for fun " + stmt.name + "(...)", stmt._check.visit(checkStmtsVisitor), true));
           }
           break;
         }


### PR DESCRIPTION
…s-parity-test in CI

Agent-written. Mirrors 9e4f8b1 ("Name default where: blocks 'where: block for fun f(...)'") in desugar-check.ts, which only changed the .arr side. `ts-parity-test` already caught the mismatch (`checks.arr`: standalone bytes differ) but no workflow ran it; the ts-suite job now does.