### PR TITLE
Follow v-alias when binding an included var, so `:=` works through re…

### DIFF
--- a/lang/src/arr/compiler/resolve-scope.arr
+++ b/lang/src/arr/compiler/resolve-scope.arr
@@ -887,10 +887,17 @@ fun resolve-names(p :: A.Program, thismodule-uri :: String, initial-env :: C.Com
       | some(value-export) =>
         # A re-exported name (`provide from M: x end`) arrives here as a
         # v-alias; follow it to the defining module so a `var` stays
-        # assignable through any number of re-exports.
+        # assignable through any number of re-exports. If the target isn't
+        # in the environment (e.g. builtin://global in CPO, whose values
+        # aren't listed as provides), keep the alias and bind it as a let,
+        # which is what happened before aliases were followed at all.
         resolved-export = cases(C.ValueExport) value-export:
           | v-alias(origin, original-name) =>
-            initial-env.value-by-uri-value(origin.uri-of-definition, original-name)
+            if initial-env.all-modules.has-key-now(origin.uri-of-definition):
+              initial-env.value-by-uri(origin.uri-of-definition, original-name).or-else(value-export)
+            else:
+              value-export
+            end
           | else => value-export
         end
         vbinder = cases(C.ValueExport) resolved-export block:

--- a/lang/src/arr/compiler/resolve-scope.arr
+++ b/lang/src/arr/compiler/resolve-scope.arr
@@ -885,7 +885,15 @@ fun resolve-names(p :: A.Program, thismodule-uri :: String, initial-env :: C.Com
         name-errors := link(C.name-not-provided(l, imp-loc, vname, "value"), name-errors)
         env
       | some(value-export) =>
-        vbinder = cases(C.ValueExport) value-export block:
+        # A re-exported name (`provide from M: x end`) arrives here as a
+        # v-alias; follow it to the defining module so a `var` stays
+        # assignable through any number of re-exports.
+        resolved-export = cases(C.ValueExport) value-export:
+          | v-alias(origin, original-name) =>
+            initial-env.value-by-uri-value(origin.uri-of-definition, original-name)
+          | else => value-export
+        end
+        vbinder = cases(C.ValueExport) resolved-export block:
           | v-var(_, t) => C.vb-var
           | else => C.vb-let
         end

--- a/lang/src/ts-compiler/src/resolve-scope.ts
+++ b/lang/src/ts-compiler/src/resolve-scope.ts
@@ -991,7 +991,13 @@ export function resolveNames(p: A.Program, thismoduleUri: string, initialEnv: C.
       return env;
     } else {
       const valueExport = maybeValueExport;
-      const vbinder = C.isVVar(valueExport) ? C.vbVar : C.vbLet;
+      // A re-exported name (`provide from M: x end`) arrives here as a
+      // v-alias; follow it to the defining module so a `var` stays
+      // assignable through any number of re-exports.
+      const resolvedExport = C.isVAlias(valueExport)
+        ? initialEnv.valueByUriValue(valueExport.origin.uriOfDefinition, valueExport.originalName)
+        : valueExport;
+      const vbinder = C.isVVar(resolvedExport) ? C.vbVar : C.vbLet;
       const atomEnv = makeImportAtomFor(asName, valueExport.origin.uriOfDefinition, env, bindings,
         (atom) => new C.ValueBind(
           C.boModule(field(asName, 'l'), valueExport.origin.definitionBindSite, valueExport.origin.uriOfDefinition, valueExport.origin.originalName),

--- a/lang/src/ts-compiler/src/resolve-scope.ts
+++ b/lang/src/ts-compiler/src/resolve-scope.ts
@@ -993,9 +993,12 @@ export function resolveNames(p: A.Program, thismoduleUri: string, initialEnv: C.
       const valueExport = maybeValueExport;
       // A re-exported name (`provide from M: x end`) arrives here as a
       // v-alias; follow it to the defining module so a `var` stays
-      // assignable through any number of re-exports.
-      const resolvedExport = C.isVAlias(valueExport)
-        ? initialEnv.valueByUriValue(valueExport.origin.uriOfDefinition, valueExport.originalName)
+      // assignable through any number of re-exports. If the target isn't
+      // in the environment (e.g. builtin://global in CPO, whose values
+      // aren't listed as provides), keep the alias and bind it as a let,
+      // which is what happened before aliases were followed at all.
+      const resolvedExport = (C.isVAlias(valueExport) && initialEnv.allModules.has(valueExport.origin.uriOfDefinition))
+        ? (initialEnv.valueByUri(valueExport.origin.uriOfDefinition, valueExport.originalName) ?? valueExport)
         : valueExport;
       const vbinder = C.isVVar(resolvedExport) ? C.vbVar : C.vbLet;
       const atomEnv = makeImportAtomFor(asName, valueExport.origin.uriOfDefinition, env, bindings,

--- a/lang/tests/pyret/main2.arr
+++ b/lang/tests/pyret/main2.arr
@@ -35,6 +35,7 @@ import file("./tests/test-parse.arr") as _
 import file("./tests/test-pprint.arr") as _
 import file("./tests/test-module-syntax.arr") as _
 import file("./tests/test-import-variable.arr") as _
+import file("./tests/test-import-variable-reexport.arr") as _
 import file("./tests/test-constants.arr") as _
 import file("./tests/test-constants-scope.arr") as _
 import file("./tests/test-timing.arr") as _

--- a/lang/tests/pyret/tests/reexports-vars.arr
+++ b/lang/tests/pyret/tests/reexports-vars.arr
@@ -1,0 +1,4 @@
+import file("defines-vars.arr") as D
+
+# Re-exports defines-vars.arr's vars, so importers see them as aliases
+provide from D: *, y as y2 end

--- a/lang/tests/pyret/tests/test-import-variable-reexport.arr
+++ b/lang/tests/pyret/tests/test-import-variable-reexport.arr
@@ -1,0 +1,23 @@
+import file("defines-vars.arr") as D
+import file("reexports-vars.arr") as R
+include from R: x, y2, g end
+
+# The values below are chosen not to collide with test-import-variable.arr,
+# which mutates the same module-level vars earlier in the same run.
+
+check "assign to a var included through a provide-from re-export":
+  x := 42
+  x is 42
+  D.x is 42
+  R.x is 42
+  g(43) # assigns x inside the defining module
+  x is 43
+  R.x is 43
+end
+
+check "assign to a var re-exported under a different name":
+  y2 := 44
+  y2 is 44
+  D.y is 44
+  R.y2 is 44
+end


### PR DESCRIPTION
…-exports

This is a clear bug, because it works at one level of import but fails when chained (because of a mistake handling `v-alias`).

Fix is just to resolve better and not fall through to “don't know, must be `vb-let`”.

Note that this *has* to work for one level for the REPL to work at all with variables, so it makes sense for it to work in general.

The dynamic semantics is fine with it – the variable is boxed.

@schanzer ran into this in a Bootstrap starter file (in production) when he refactored a variable to be one more import hop away from an assigning module.

Most PLs would use a getter/setter pair to do this, but in Pyret it's allowed, so we should support it correctly.


Claude said:

`include from M: x end` (and `use context M`, which desugars to an include) chose the binder kind straight off M's own export. When M re-exports x with `provide from D: ... end`, that export is a v-alias, which fell into the vb-let arm -- so a `var` defined in D became unassignable once reached through any re-export, and the error blamed the `var` line for being an "identifier definition".

Resolve the alias to the defining module first (value-by-uri-value already follows alias chains; `s-dot` on a module already did this). Same one-line change in the TS compiler.

Test: reexports-vars.arr re-exports defines-vars.arr's vars (via `*` and a rename); test-import-variable-reexport.arr assigns through both and checks the value from the importer, the definer, and the re-exporter. 8/8 pass with the fix; the existing one-hop test-import-variable.arr still passes 5/5. Without the fix the new test fails at name resolution.
